### PR TITLE
Add pyrosm to conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ which is also used by OpenStreetMap contributors to distribute the OSM data in P
 
 ## Install
 
-Pyrosm is distributed via PyPi and it can be installed with pip:
+Pyrosm is distributed via PyPi and conda-forge. 
+
+The recommended way to install pyrosm is using `conda` package manager:
+
+`$ conda install -c conda-forge pyrosm`
+
+You can also install the package with pip:
 
 `$ pip install pyrosm`
 

--- a/docs/installation.ipynb
+++ b/docs/installation.ipynb
@@ -6,8 +6,11 @@
    "source": [
     "# Installation\n",
     "\n",
+    "The recommended way to install pyrosm is by using [conda](https://docs.conda.io/en/latest/) package manager:\n",
     "\n",
-    "Pyrosm is distributed via [PyPi](https://pypi.org/project/pyrosm) and it can be installed with pip:\n",
+    "`$ conda install -c conda-forge pyrosm`\n",
+    "\n",
+    "Pyrosm is also distributed via [PyPi](https://pypi.org/project/pyrosm) and it can be installed with pip:\n",
     "\n",
     "`$ pip install pyrosm`\n",
     "\n",
@@ -39,7 +42,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.1"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -51,15 +51,11 @@ def read_long_description():
 
 
 requirements = [
-    # These will be checked before setup
-    #'Cython>=0.15.1',
-    #'pyrobuf>=0.9.3',
     'python-rapidjson',
     'setuptools>=18.0',
     'geopandas',
     'pygeos',
 ]
-
 
 setup(
     name='pyrosm',


### PR DESCRIPTION
Closes #1. Relates to #37 and #38. 

Pyrosm can now be installed from `conda-forge` with:

`$ conda install -c conda-forge pyrosm`

Built for Python 3.6, 3.7 and 3.8 covering all major OS: Windows, Linux and OSX. 