### PR TITLE
Follow PEP 518 when installing (pyproject.toml) 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ graft proto
 graft tests
 graft pyrobuf
 
-include .travis.yml .appveyor.yml
+include .travis.yml .appveyor.yml pyproject.toml
 global-exclude __pycache__/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "cykhash", "pyrobuf"]

--- a/setup.py
+++ b/setup.py
@@ -3,36 +3,13 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import io
-import re
 from os.path import dirname
 from os.path import join
 from os import path
 from setuptools import find_packages
 from setuptools import setup
 import os
-
-# TODO: The installation of Cython, Cykhash and Pyrobuf this way is a hack.
-#  Integrate cykhash function directly to pyrosm to avoid these and publish in conda-forge.
-
-# Cython needs to be installed before running setup
-# https://luminousmen.com/post/resolve-cython-and-numpy-dependencies
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    os.system('pip install Cython')
-    from Cython.Build import cythonize
-
-# Cykhash needs to be installed before running setup
-try:
-    import cykhash
-except ImportError:
-    os.system('pip install https://github.com/HTenkanen/cykhash/archive/master.zip')
-
-# Pyrobuf needs to be installed before running setup
-try:
-    import pyrobuf_list
-except ImportError:
-    os.system('pip install pyrobuf')
+from Cython.Build import cythonize
 
 
 def read(*names, **kwargs):
@@ -51,10 +28,12 @@ def read_long_description():
 
 
 requirements = [
-    'python-rapidjson',
-    'setuptools>=18.0',
-    'geopandas',
-    'pygeos',
+    "python-rapidjson",
+    "setuptools>=18.0",
+    "geopandas",
+    "pygeos",
+    "cykhash",
+    "pyrobuf",
 ]
 
 setup(


### PR DESCRIPTION
Follow PEP 518 when installing (pyproject.toml) which handles build dependencies (cython, pyrobuf, cykhash).