### PR TITLE
Fix linear ring creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+v0.5.3
+------
+
+Changes:
+
+ - Ensures that geometry construction works with new Pygeos release v0.8.0 (#46)
+
+v0.5.2
+------
+
+Changes:
+
+ - Fix data source for New York City
+ - Fix multi-level filtering
+ - Add support for using "exclude" also with nodes and relations
+
 v0.5.0
 ------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+v0.5.3 (Sep 13, 2020)
+---------------------
+
+Changes:
+
+ - Ensures that geometry construction works with new Pygeos release v0.8.0 (#46)
+
+v0.5.2 (May 11, 2020)
+---------------------
+
+Changes:
+
+ - Fix data source for New York City
+ - Fix multi-level filtering
+ - Add support for using "exclude" also with nodes and relations
+
 v0.5.0 (May 7, 2020)
 --------------------
 

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -93,19 +93,19 @@ cdef get_way_coordinates_for_polygon(node_coordinate_lookup, way_elements):
     return features
 
 cdef create_linear_ring(coordinates):
-    # At least 3 different coordinates are needed for valid linearring
-    if len(coordinates) < 3:
-        return None
-    if len(coordinates) < 4 and coordinates[0] == coordinates[-1]:
-        return None
     try:
         return linearrings(coordinates)
+    # pygeos 0.7.1 throws GEOSException
     except GEOSException as e:
         if "Invalid number of points" in str(e):
             return None
         elif "point array must contain" in str(e):
             return None
         raise e
+    # pygeos 0.8.0 throws ValueError
+    except ValueError as e:
+        if "Provide at least 4 coordinates" in str(e):
+            return None
     except Exception as e:
         raise e
 
@@ -119,6 +119,8 @@ cdef create_linestring(coordinates):
             return None
         raise e
     except ValueError as e:
+        if "Provide at least 2 coordinates" in str(e):
+            return None
         if "not have enough dimensions" in str(e):
             raise e
     except Exception as e:

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -96,6 +96,8 @@ cdef create_linear_ring(coordinates):
     # At least 3 different coordinates are needed for valid linearring
     if len(coordinates) < 3:
         return None
+    if len(coordinates) < 4 and coordinates[0] == coordinates[-1]:
+        return None
     try:
         return linearrings(coordinates)
     except GEOSException as e:

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -93,6 +93,9 @@ cdef get_way_coordinates_for_polygon(node_coordinate_lookup, way_elements):
     return features
 
 cdef create_linear_ring(coordinates):
+    # At least 3 different coordinates are needed for valid linearring
+    if len(coordinates) < 3:
+        return None
     try:
         return linearrings(coordinates)
     except GEOSException as e:

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -321,6 +321,10 @@ cdef create_polygon_geometry(nodes, node_coordinates):
                 return None
             else:
                 raise e
+        # pygeos 0.8.0 throws ValueError
+        except ValueError as e:
+            if "Provide at least 4 coordinates" in str(e):
+                return None
         except Exception as e:
             raise e
     else:


### PR DESCRIPTION
Fixes #46.

Pygeos v0.8.0 throws ValueError instead of GEOSException when constructing linearrings. This fix now catches the error in both ways.   