### PR TITLE
ENH: Calculate network distance and export to igraph

### DIFF
--- a/ci/36-conda.yaml
+++ b/ci/36-conda.yaml
@@ -12,8 +12,11 @@ dependencies:
   - pyrobuf
   - cykhash
   - python-rapidjson
+  # optional
+  - python-igraph
   # testing
   - pytest
   - pytest-cov
   - codecov
   - requests
+

--- a/ci/37-conda.yaml
+++ b/ci/37-conda.yaml
@@ -12,6 +12,8 @@ dependencies:
   - cykhash
   - pyrobuf
   - python-rapidjson
+  # optional
+  - python-igraph
   # testing
   - pytest
   - pytest-cov

--- a/ci/38-conda.yaml
+++ b/ci/38-conda.yaml
@@ -12,6 +12,8 @@ dependencies:
   - cykhash
   - pyrobuf
   - python-rapidjson
+  # optional
+  - python-igraph
   # testing
   - pytest
   - pytest-cov

--- a/pyrosm/config/__init__.py
+++ b/pyrosm/config/__init__.py
@@ -48,3 +48,5 @@ class Tags:
 class Conf:
     network_filters = NetworkFilter()
     tags = Tags()
+    _possible_network_filters = [a for a in network_filters.__dir__() if "__" not in a]
+    _possible_network_filters += ["all", "driving+service"]

--- a/pyrosm/config/__init__.py
+++ b/pyrosm/config/__init__.py
@@ -50,3 +50,6 @@ class Conf:
     tags = Tags()
     _possible_network_filters = [a for a in network_filters.__dir__() if "__" not in a]
     _possible_network_filters += ["all", "driving+service"]
+
+    # One way tags
+    oneway_values = ['yes', 'true', '1', '-1', 'T', 'F']

--- a/pyrosm/data_filter.pxd
+++ b/pyrosm/data_filter.pxd
@@ -5,6 +5,7 @@ cdef get_nodeid_lookup_khash(nodes)
 cdef nodes_for_way_exist_khash(nodes, node_lookup)
 cdef filter_relation_indices(relations, osm_keys, data_filter, filter_type)
 cdef filter_node_indices(node_arrays, osm_keys, data_filter, filter_type)
+cpdef get_mask_by_osmid(src_array, osm_ids)
 
 # For debuggin purposes
 cpdef _filter_array_dict_by_indices_or_mask(array_dict, indices)

--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -205,6 +205,18 @@ cdef nodes_for_way_exist_khash(nodes, node_lookup):
         return True
     return False
 
+cpdef get_mask_by_osmid(src_array, osm_ids):
+    """
+    Creates a (boolean) mask for the given source array flagging True
+    all items that exist in the 'osm_ids' array. Can be used to filter items
+    e.g. from OSM node data arrays.
+    """
+    n = len(src_array)
+    lookup = Int64Set_from_buffer(osm_ids)
+    result = np.empty(src_array.size, dtype=np.bool)
+    isin_int64(src_array, lookup, result)
+    return result
+
 cdef record_should_be_kept(tag, osm_keys, data_filter, filter_type):
     if tag is None:
         return False

--- a/pyrosm/distance.py
+++ b/pyrosm/distance.py
@@ -1,0 +1,71 @@
+from enum import Enum
+import numpy as np
+
+
+class Unit(Enum):
+    """
+    Enumeration of supported units.
+    The full list can be checked by iterating over the class; e.g.
+    the expression `tuple(Unit)`.
+
+    Inspired by: https://github.com/mapado/haversine
+
+    """
+
+    KILOMETERS = 'km'
+    METERS = 'm'
+    MILES = 'mi'
+    NAUTICAL_MILES = 'nmi'
+    FEET = 'ft'
+    INCHES = 'in'
+
+
+# mean earth radius - https://en.wikipedia.org/wiki/Earth_radius#Mean_radius
+_AVG_EARTH_RADIUS_KM = 6371.0088
+
+# Unit values taken from http://www.unitconversion.org/unit_converter/length.html
+_CONVERSIONS = {Unit.KILOMETERS: 1.0,
+                Unit.METERS: 1000.0,
+                Unit.MILES: 0.621371192,
+                Unit.NAUTICAL_MILES: 0.539956803,
+                Unit.FEET: 3280.839895013,
+                Unit.INCHES: 39370.078740158}
+
+
+def haversine(lat1, lng1, lat2, lng2, unit=Unit.KILOMETERS):
+    """
+    Calculate the great-circle distance between two points on the Earth surface.
+    Takes two 2-tuples, containing the latitude and longitude of each point in decimal degrees,
+    and, optionally, a unit of length.
+
+    Inspired by: https://github.com/mapado/haversine
+
+    Parameters
+    ==========
+    lat1 : np.array
+        Latitude in decimal degrees
+    lng1 : np.array
+        Longitude in decimal degrees
+    lat2 : np.array
+        Latitude in decimal degrees
+    lng2 : np.arrays
+        Longitude in decimal degrees
+    unit : pyrosm.distance.Unit
+        A member of pyrosm.distance.Unit, or, equivalently, a string containing the
+        initials of its corresponding unit of measurement (i.e. miles = mi)
+        default 'km' (kilometers).
+    """
+
+    # get earth radius in required units
+    unit = Unit(unit)
+    avg_earth_radius = _AVG_EARTH_RADIUS_KM * _CONVERSIONS[unit]
+
+    # convert all latitudes/longitudes from decimal degrees to radians
+    lat1, lng1, lat2, lng2 = map(np.deg2rad, (lat1, lng1, lat2, lng2))
+
+    # calculate haversine
+    lat = lat2 - lat1
+    lng = lng2 - lng1
+    d = np.sin(lat * 0.5) ** 2 + np.cos(lat1) * np.cos(lat2) * np.sin(lng * 0.5) ** 2
+
+    return 2 * avg_earth_radius * np.arcsin(np.sqrt(d))

--- a/pyrosm/frames.pxd
+++ b/pyrosm/frames.pxd
@@ -1,7 +1,12 @@
 cpdef create_nodes_gdf(node_dict_list)
 cpdef create_gdf(data_records, geometry_array)
-cpdef prepare_way_gdf(node_coordinates, ways)
+cpdef prepare_way_gdf(node_coordinates, ways, keep_edge_ids)
 cpdef prepare_node_gdf(nodes)
-cpdef prepare_geodataframe(nodes, node_coordinates, ways,
-                           relations, relation_ways, tags_as_columns,
-                           bounding_box)
+cpdef prepare_geodataframe(nodes,
+                           node_coordinates,
+                           ways,
+                           relations,
+                           relation_ways,
+                           tags_as_columns,
+                           bounding_box,
+                           keep_edge_ids=*)

--- a/pyrosm/frames.pxd
+++ b/pyrosm/frames.pxd
@@ -1,6 +1,6 @@
 cpdef create_nodes_gdf(node_dict_list)
 cpdef create_gdf(data_records, geometry_array)
-cpdef prepare_way_gdf(node_coordinates, ways, keep_edge_ids)
+cpdef prepare_way_gdf(node_coordinates, ways, keep_vertex_ids)
 cpdef prepare_node_gdf(nodes)
 cpdef prepare_geodataframe(nodes,
                            node_coordinates,
@@ -9,4 +9,4 @@ cpdef prepare_geodataframe(nodes,
                            relation_ways,
                            tags_as_columns,
                            bounding_box,
-                           keep_edge_ids=*)
+                           keep_vertex_ids=*)

--- a/pyrosm/frames.pxd
+++ b/pyrosm/frames.pxd
@@ -1,6 +1,6 @@
 cpdef create_nodes_gdf(node_dict_list)
 cpdef create_gdf(data_records, geometry_array)
-cpdef prepare_way_gdf(node_coordinates, ways, keep_vertex_ids)
+cpdef prepare_way_gdf(node_coordinates, ways, parse_network)
 cpdef prepare_node_gdf(nodes)
 cpdef prepare_geodataframe(nodes,
                            node_coordinates,
@@ -9,4 +9,4 @@ cpdef prepare_geodataframe(nodes,
                            relation_ways,
                            tags_as_columns,
                            bounding_box,
-                           keep_vertex_ids=*)
+                           parse_network=*)

--- a/pyrosm/frames.pyx
+++ b/pyrosm/frames.pyx
@@ -43,7 +43,7 @@ cpdef create_gdf(data_arrays, geometry_array):
     df['geometry'] = geometry_array
     return gpd.GeoDataFrame(df, crs='epsg:4326')
 
-cpdef prepare_way_gdf(node_coordinates, ways, keep_edge_ids):
+cpdef prepare_way_gdf(node_coordinates, ways, keep_vertex_ids):
     if ways is not None:
         geometries, us, vs = create_way_geometries(node_coordinates,
                                                    ways)
@@ -51,7 +51,7 @@ cpdef prepare_way_gdf(node_coordinates, ways, keep_edge_ids):
         way_gdf = create_gdf(ways, geometries)
         way_gdf['osm_type'] = "way"
 
-        if keep_edge_ids:
+        if keep_vertex_ids:
             way_gdf["u"] = us
             way_gdf["v"] = vs
     else:
@@ -83,12 +83,12 @@ cpdef prepare_relation_gdf(node_coordinates, relations, relation_ways, tags_as_c
 cpdef prepare_geodataframe(nodes, node_coordinates, ways,
                            relations, relation_ways,
                            tags_as_columns, bounding_box,
-                           keep_edge_ids=False):
+                           keep_vertex_ids=False):
     # Prepare nodes
     node_gdf = prepare_node_gdf(nodes)
 
     # Prepare ways
-    way_gdf = prepare_way_gdf(node_coordinates, ways, keep_edge_ids)
+    way_gdf = prepare_way_gdf(node_coordinates, ways, keep_vertex_ids)
 
     # Prepare relation data
     relation_gdf = prepare_relation_gdf(node_coordinates, relations, relation_ways, tags_as_columns)

--- a/pyrosm/frames.pyx
+++ b/pyrosm/frames.pyx
@@ -43,17 +43,20 @@ cpdef create_gdf(data_arrays, geometry_array):
     df['geometry'] = geometry_array
     return gpd.GeoDataFrame(df, crs='epsg:4326')
 
-cpdef prepare_way_gdf(node_coordinates, ways, keep_vertex_ids):
+cpdef prepare_way_gdf(node_coordinates, ways, parse_network):
     if ways is not None:
-        geometries, us, vs = create_way_geometries(node_coordinates,
-                                                   ways)
+        geometries, geom_lengths, us, vs = create_way_geometries(node_coordinates,
+                                                                 ways,
+                                                                 parse_network)
         # Convert to GeoDataFrame
         way_gdf = create_gdf(ways, geometries)
         way_gdf['osm_type'] = "way"
 
-        if keep_vertex_ids:
+        if parse_network:
             way_gdf["u"] = us
             way_gdf["v"] = vs
+            way_gdf["length"] = geom_lengths
+
     else:
         way_gdf = gpd.GeoDataFrame()
     return way_gdf
@@ -83,12 +86,12 @@ cpdef prepare_relation_gdf(node_coordinates, relations, relation_ways, tags_as_c
 cpdef prepare_geodataframe(nodes, node_coordinates, ways,
                            relations, relation_ways,
                            tags_as_columns, bounding_box,
-                           keep_vertex_ids=False):
+                           parse_network=False):
     # Prepare nodes
     node_gdf = prepare_node_gdf(nodes)
 
     # Prepare ways
-    way_gdf = prepare_way_gdf(node_coordinates, ways, keep_vertex_ids)
+    way_gdf = prepare_way_gdf(node_coordinates, ways, parse_network)
 
     # Prepare relation data
     relation_gdf = prepare_relation_gdf(node_coordinates, relations, relation_ways, tags_as_columns)

--- a/pyrosm/geometry.pxd
+++ b/pyrosm/geometry.pxd
@@ -1,7 +1,7 @@
 cpdef create_point_geometries(xarray, yarray)
 cdef _create_point_geometries(xarray, yarray)
-cdef _create_way_geometries(node_coordinates, way_elements)
-cpdef create_way_geometries(node_coordinates, way_elements)
+cdef _create_way_geometries(node_coordinates, way_elements, parse_network)
+cpdef create_way_geometries(node_coordinates, way_elements, parse_network)
 cdef create_relation_geometry(node_coordinates, ways,
                              member_roles, force_linestring,
                              make_multipolygon)

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -346,12 +346,17 @@ cdef _create_way_geometries(node_coordinates, way_elements):
 
     geometries = []
 
+    # Highway specific containers
+    us, vs = [], []
+
     for i in range(0, n):
         nodes = way_elements['nodes'][i]
         coords = []
+        u = nodes[0]
+        v = nodes[-1]
 
         # If first and last node are the same, it's a closed way
-        if nodes[0] == nodes[-1]:
+        if  u == v:
             tag_keys = way_elements.keys()
             # Create Polygon by default unless way is of type 'highway', 'barrier' or 'route'
             if "highway" in tag_keys or "barrier" in tag_keys or "route" in tag_keys:
@@ -362,10 +367,11 @@ cdef _create_way_geometries(node_coordinates, way_elements):
         # Otherwise create LineString
         else:
             geom = create_linestring_geometry(nodes, node_coordinates)
-
         geometries.append(geom)
+        us.append(u)
+        vs.append(v)
 
-    return to_shapely(geometries)
+    return to_shapely(geometries), us, vs
 
 cpdef create_way_geometries(node_coordinates, way_elements):
     return _create_way_geometries(node_coordinates, way_elements)

--- a/pyrosm/graph_export.pxd
+++ b/pyrosm/graph_export.pxd
@@ -1,0 +1,2 @@
+cpdef _create_igraph(nodes, edges, direction, from_id_col, to_id_col, force_bidirectional)
+

--- a/pyrosm/graph_export.pyx
+++ b/pyrosm/graph_export.pyx
@@ -1,0 +1,125 @@
+from pyrosm.utils._compat import HAS_IGRAPH
+
+cpdef _create_igraph(nodes,
+                     edges,
+                     direction,
+                     from_id_col,
+                     to_id_col,
+                     force_bidirectional):
+
+    if not HAS_IGRAPH:
+        raise ImportError("'python-igraph' needs to be installed "
+                  "in order to export the network for igraph.")
+    import igraph
+
+    cdef long long i
+
+    nodes = nodes.copy()
+    edges = edges.copy()
+
+    from_id_int = from_id_col + "_seq"
+    to_id_int = to_id_col + "_seq"
+    oneway_values = ['yes', 'true', '1', '-1', 'T', 'F']
+
+    edge_list = []
+
+    edge_columns = edges.columns.to_list()
+    n_edges = len(edges)
+    n_nodes = len(nodes)
+    n_cols = len(edge_columns)
+
+    # Convert edges to dict
+    edges = edges.to_dict(orient="list")
+
+    # Add columns for sequential ids
+    edges[from_id_int] = [None for x in range(n_edges)]
+    edges[to_id_int] = [None for x in range(n_edges)]
+
+    # Node-ids needs to be sequential for igraph
+    nodes = nodes.reset_index(drop=True)
+    nodes["node_id"] = nodes.index
+
+    # Prepare dictionary for fast lookups
+    node_dict = {k: v for k, v in zip(nodes["id"].to_list(), nodes["node_id"].to_list())}
+
+    # Node attributes
+    node_attributes = nodes[["node_id", "id", "x", "y"]].to_dict(orient='list')
+
+    # Generate edge dictionary
+    for i in range(0, n_edges):
+
+        # Get nodeids for the edge
+        # ------------------------
+        # Note: In some cases the node for from/to_id might not exist
+        # on the "edge" of the network (e.g. if data has been cropped manually).
+        try:
+            from_node_id = edges[from_id_col][i]
+            from_seq_id = node_dict[from_node_id]
+        except KeyError:
+            continue
+        except Exception as e:
+            raise e
+
+        try:
+            to_node_id = edges[to_id_col][i]
+            to_seq_id = node_dict[to_node_id]
+        except KeyError:
+            continue
+        except Exception as e:
+            raise e
+
+        # Oneway streets
+        if edges[direction][i] in oneway_values and not force_bidirectional:
+            # When travelling is allowed only against digitization direction
+            # flip the order of link nodes
+            if edges[direction][i] in ['-1', 'T']:
+
+                edge_list.append([to_seq_id, from_seq_id])
+                edges[from_id_int][i] = to_seq_id
+                edges[to_id_int][i] = from_seq_id
+
+            # In other cases add edge along the digitization direction
+            else:
+                edge_list.append([from_seq_id, to_seq_id])
+                edges[from_id_int][i] = from_seq_id
+                edges[to_id_int][i] = to_seq_id
+
+        # Roundabouts are oneways
+        elif 'junction' in edge_columns \
+            and edges['junction'][i] == 'roundabout' \
+                and not force_bidirectional:
+
+            edge_list.append([from_seq_id, to_seq_id])
+            edges[from_id_int][i] = from_seq_id
+            edges[to_id_int][i] = to_seq_id
+
+        else:
+            # If road is bi-directional add it in both ways
+            # ---------------------------------------------
+            # Along
+            edge_list.append([from_seq_id, to_seq_id])
+            edges[from_id_int][i] = from_seq_id
+            edges[to_id_int][i] = to_seq_id
+
+            # Against - Flip the link nodes
+            edge_list.append([to_seq_id, from_seq_id])
+
+            # Append the opposite direction link nodes and attributes
+            edges[from_id_int].append(to_seq_id)
+            edges[to_id_int].append(from_seq_id)
+            edges[from_id_col].append(to_node_id)
+            edges[to_id_col].append(from_node_id)
+
+            for key in edge_columns:
+                # Skip edge nodes which were added separately (in opposite direction)
+                if key == from_id_col or key == to_id_col:
+                    continue
+                edges[key].append(edges[key][i])
+
+    del node_dict
+
+    # Create directed graph
+    graph = igraph.Graph(n=n_nodes, directed=True, edges=edge_list,
+                         vertex_attrs=node_attributes,
+                         edge_attrs=edges)
+    return graph

--- a/pyrosm/graph_export.pyx
+++ b/pyrosm/graph_export.pyx
@@ -1,4 +1,8 @@
 from pyrosm.utils._compat import HAS_IGRAPH
+from pyrosm.config import Conf
+
+# The values used to determine oneway road in OSM
+oneway_values = Conf.oneway_values
 
 cpdef _create_igraph(nodes,
                      edges,
@@ -19,7 +23,6 @@ cpdef _create_igraph(nodes,
 
     from_id_int = from_id_col + "_seq"
     to_id_int = to_id_col + "_seq"
-    oneway_values = ['yes', 'true', '1', '-1', 'T', 'F']
 
     edge_list = []
 
@@ -43,7 +46,7 @@ cpdef _create_igraph(nodes,
     node_dict = {k: v for k, v in zip(nodes["id"].to_list(), nodes["node_id"].to_list())}
 
     # Node attributes
-    node_attributes = nodes[["node_id", "id", "x", "y"]].to_dict(orient='list')
+    node_attributes = nodes.to_dict(orient='list')
 
     # Generate edge dictionary
     for i in range(0, n_edges):

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -1,0 +1,89 @@
+from pyrosm.graph_export import _create_igraph
+from pyrosm.config import Conf
+
+def to_networkx(nodes, edges, network_type=None):
+    pass
+
+
+def to_pandana(nodes, edges, network_type=None):
+    pass
+
+
+def to_igraph(nodes,
+              edges,
+              direction='oneway',
+              from_id_col='u',
+              to_id_col='v',
+              force_bidirectional=False,
+              network_type=None):
+    """
+    Creates a Graph from given OSM GeoDataFrame.
+
+    Parameters
+    ----------
+    edges : GeoDataFrame
+        GeoDataFrame containing road network data.
+
+    network_type : str
+        The type of the network. Possible values:
+              - `'walking'`
+              - `'cycling'`
+              - `'driving'`
+              - `'driving+service'`
+              - `'all'`.
+
+    direction : str
+        Name for the column containing information about the allowed driving directions
+
+    from_id_col : str
+        Name for the column having the from-node-ids of edges.
+
+    to_id_col : str
+        Name for the column having the to-node-ids of edges.
+
+    force_bidirectional : bool
+        If True, all edges will be created as bidirectional (allow travel to both directions).
+
+    network_type : str
+        Network type for the given data. Determines how the graph will be constructed.
+        By default, bidirectional graph is created for walking, cycling and all,
+        and directed graph for driving (i.e. oneway streets are taken into account).
+        Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.
+    """
+    allowed_network_types = Conf._possible_network_filters
+
+    for col in [direction, from_id_col, to_id_col]:
+        if col not in edges.columns:
+            raise ValueError(
+                "Required column '{col}' does not exist in edges.".format(
+                    col=col)
+            )
+
+    # Check if user wants to force bidirectional graph
+    if force_bidirectional:
+        return _create_igraph(nodes, edges, direction, from_id_col, to_id_col, force_bidirectional)
+
+    # Check the network_type
+    if network_type is not None:
+        net_type = network_type
+    else:
+        net_type = edges._metadata[-1]
+
+    # Check if network type is stored with edges or nodes
+    if net_type not in allowed_network_types:
+        net_type = nodes._metadata[-1]
+        if net_type not in allowed_network_types:
+            txt = ", ".join(allowed_network_types)
+            raise ValueError("Could not detect the network type from the edges. "
+                             "In order to save the graph, specify the type of your network"
+                             "with 'network_type' -parameter."
+                             "Possible network types are: " + txt)
+
+    # For cycling, walking and all create bidirectional graph
+    if net_type in ["walking", "cycling", "all"]:
+        return _create_igraph(nodes, edges, direction, from_id_col, to_id_col, True)
+
+    # Otherwise, create directed graph as specified in OSM
+    return _create_igraph(nodes, edges, direction, from_id_col, to_id_col, False)
+
+

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -2,6 +2,8 @@ from pyrosm.graph_export import _create_igraph
 from pyrosm.config import Conf
 
 def to_networkx(nodes, edges, network_type=None):
+    # For compatibility with OSMnx ensure gdf has "key" column
+    edges["key"] = 0
     pass
 
 

--- a/pyrosm/networks.py
+++ b/pyrosm/networks.py
@@ -32,6 +32,9 @@ def get_network_data(node_coordinates, way_records, tags_as_columns,
                                tags_as_columns, bounding_box,
                                keep_vertex_ids=True)
 
+    # For compatibility with OSMnx ensure gdf has "key" column
+    gdf["key"] = 0
+
     return gdf
 
 

--- a/pyrosm/networks.py
+++ b/pyrosm/networks.py
@@ -19,9 +19,9 @@ def get_network_data(node_coordinates, way_records, tags_as_columns,
                                                          osm_keys="highway",
                                                          )
 
-    # If there weren't any data, return empty GeoDataFrame
+    # If there weren't any data, return None
     if ways is None:
-        warnings.warn("Could not find any buildings for given area.",
+        warnings.warn("Could not find any edges for given area.",
                       UserWarning,
                       stacklevel=2)
         return None
@@ -29,7 +29,9 @@ def get_network_data(node_coordinates, way_records, tags_as_columns,
     # Prepare GeoDataFrame
     gdf = prepare_geodataframe(nodes, node_coordinates, ways,
                                relations, relation_ways,
-                               tags_as_columns, bounding_box)
+                               tags_as_columns, bounding_box,
+                               keep_vertex_ids=True)
+
     return gdf
 
 

--- a/pyrosm/networks.py
+++ b/pyrosm/networks.py
@@ -30,10 +30,7 @@ def get_network_data(node_coordinates, way_records, tags_as_columns,
     gdf = prepare_geodataframe(nodes, node_coordinates, ways,
                                relations, relation_ways,
                                tags_as_columns, bounding_box,
-                               keep_vertex_ids=True)
-
-    # For compatibility with OSMnx ensure gdf has "key" column
-    gdf["key"] = 0
+                               parse_network=True)
 
     return gdf
 

--- a/pyrosm/pbfreader.pyx
+++ b/pyrosm/pbfreader.pyx
@@ -110,11 +110,11 @@ cdef parse_dense(pblock, data, string_table, bounding_box):
     # Metadata might not be available, if so add empty
     # This can happen with BBBike data
     if versions.shape[0] == 0:
-        versions = np.empty(len(data.id), dtype=np.int8)
+        versions = np.zeros(len(data.id), dtype=np.int8)
     if changesets.shape[0] == 0:
-        changesets = np.empty(len(data.id), dtype=np.int8)
+        changesets = np.zeros(len(data.id), dtype=np.int8)
     if timestamps.shape[0] == 0:
-        timestamps = np.empty(len(data.id), dtype=np.int8)
+        timestamps = np.zeros(len(data.id), dtype=np.int8)
 
     if bounding_box is not None:
         # Filter

--- a/pyrosm/pbfreader.pyx
+++ b/pyrosm/pbfreader.pyx
@@ -109,11 +109,11 @@ cdef parse_dense(pblock, data, string_table, bounding_box):
 
     # Metadata might not be available, if so add empty
     # This can happen with BBBike data
-    if versions.shape[0] != 0:
+    if versions.shape[0] == 0:
         versions = np.empty(len(data.id), dtype=np.int8)
-    if changesets.shape[0] != 0:
+    if changesets.shape[0] == 0:
         changesets = np.empty(len(data.id), dtype=np.int8)
-    if timestamps.shape[0] != 0:
+    if timestamps.shape[0] == 0:
         timestamps = np.empty(len(data.id), dtype=np.int8)
 
     if bounding_box is not None:

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -1,3 +1,4 @@
+import numpy as np
 from pyrosm.config import Conf
 from pyrosm.pbfreader import parse_osm_data
 from pyrosm._arrays import concatenate_dicts_of_arrays
@@ -83,8 +84,8 @@ class OSM:
             bounding_box = self.bounding_box
 
         nodes, ways, relations, way_tags = parse_osm_data(self.filepath,
-                                             bounding_box,
-                                             exclude_relations=False)
+                                                          bounding_box,
+                                                          exclude_relations=False)
 
         self._nodes = nodes
         self._way_records = ways
@@ -120,7 +121,11 @@ class OSM:
         elif net_type == "all":
             return None
 
-    def get_network(self, network_type="walking", extra_attributes=None):
+    def get_network(self,
+                    network_type="walking",
+                    extra_attributes=None,
+                    nodes=False,
+                    ):
         """
         Parses street networks from OSM
         for walking, driving, and cycling.
@@ -140,12 +145,24 @@ class OSM:
         extra_attributes : list (optional)
             Additional OSM tag keys that will be converted into columns in the resulting GeoDataFrame.
 
+        nodes : bool (default: False)
+            If True, also the nodes associated with the network will be returned.
+
+        Returns
+        -------
+
+        gdf_edges or (gdf_nodes, gdf_edges)
+
+        Return type
+        -----------
+
+        geopandas.GeoDataFrame or tuple
+
         See Also
         --------
 
         Take a look at the OSM documentation for further details about the data:
         `https://wiki.openstreetmap.org/wiki/Key:highway <https://wiki.openstreetmap.org/wiki/Key:highway>`__
-
         """
         # Get filter
         network_filter = self._get_network_filter(network_type)
@@ -159,20 +176,35 @@ class OSM:
             self._read_pbf()
 
         # Filter network data with given filter
-        gdf = get_network_data(self._node_coordinates,
-                               self._way_records,
-                               tags_as_columns,
-                               network_filter,
-                               self.bounding_box
-                               )
+        edges = get_network_data(self._node_coordinates,
+                                 self._way_records,
+                                 tags_as_columns,
+                                 network_filter,
+                                 self.bounding_box,
+                                 )
+
+        # For compatibility with OSMnx ensure gdf has "key" column
+        # TODO: Contact Geoff and ask why this is used.
+        edges["key"] = 0
 
         # Do not keep node information unless specifically asked for
         # (they are in a list, and can cause issues when saving the files)
-        if not self.keep_node_info and gdf is not None:
-            if "nodes" in gdf.columns:
-                gdf = gdf.drop("nodes", axis=1)
+        if not self.keep_node_info and edges is not None:
+            if "nodes" in edges.columns:
+                edges = edges.drop("nodes", axis=1)
 
-        return gdf
+        # In case both edges and nodes are requested
+        if nodes:
+            # Get all ids that are part of the network
+            osmids = np.unique(np.concatenate([edges['u'].unique(), edges['v'].unique()]))
+            nodes_gdf = create_nodes_gdf(self._nodes, osmids_to_keep=osmids)
+            # Ensure the gdf follows osmnx structure
+            nodes_gdf = nodes_gdf.rename(columns={'id': 'osmid', 'lat': 'y', 'lon': 'x'})
+            nodes_gdf = nodes_gdf.set_index("osmid", drop=False)
+            nodes_gdf = nodes_gdf.rename_axis(index=None)
+            return (nodes_gdf, edges)
+
+        return edges
 
     def get_buildings(self, custom_filter=None, extra_attributes=None):
         """

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -181,8 +181,9 @@ class OSM:
                                  self.bounding_box,
                                  )
 
-        # Add metadata
-        edges._metadata.append(network_type)
+        if edges is not None:
+            # Add metadata
+            edges._metadata.append(network_type)
 
         # Do not keep node information unless specifically asked for
         # (they are in a list, and can cause issues when saving the files)

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -199,8 +199,8 @@ class OSM:
             osmids = np.unique(np.concatenate([edges['u'].unique(), edges['v'].unique()]))
             nodes_gdf = create_nodes_gdf(self._nodes, osmids_to_keep=osmids)
             # Ensure the gdf follows osmnx structure
-            nodes_gdf = nodes_gdf.rename(columns={'id': 'osmid', 'lat': 'y', 'lon': 'x'})
-            nodes_gdf = nodes_gdf.set_index("osmid", drop=False)
+            nodes_gdf = nodes_gdf.rename(columns={'lat': 'y', 'lon': 'x'})
+            nodes_gdf = nodes_gdf.set_index("id", drop=False)
             nodes_gdf = nodes_gdf.rename_axis(index=None)
             return (nodes_gdf, edges)
 

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -183,10 +183,6 @@ class OSM:
                                  self.bounding_box,
                                  )
 
-        # For compatibility with OSMnx ensure gdf has "key" column
-        # TODO: Contact Geoff and ask why this is used.
-        edges["key"] = 0
-
         # Do not keep node information unless specifically asked for
         # (they are in a list, and can cause issues when saving the files)
         if not self.keep_node_info and edges is not None:

--- a/pyrosm/utils/_compat.py
+++ b/pyrosm/utils/_compat.py
@@ -15,3 +15,11 @@ if not shapely_geos_version.startswith(geos_capi_version_string):
     PYGEOS_SHAPELY_COMPAT = False
 else:
     PYGEOS_SHAPELY_COMPAT = True
+
+# python-igraph is an optional dependency
+try:
+    import igraph
+    HAS_IGRAPH = True
+except ImportError:
+    HAS_IGRAPH = False
+

--- a/tests/test_building_parsing.py
+++ b/tests/test_building_parsing.py
@@ -61,8 +61,8 @@ def test_creating_building_geometries(test_pbf):
                                                          filter_type="keep")
     assert isinstance(ways, dict)
 
-    geometries = create_way_geometries(osm._node_coordinates,
-                                       ways)
+    geometries, us, vs = create_way_geometries(osm._node_coordinates,
+                                               ways)
     assert isinstance(geometries, ndarray)
     assert isinstance(geometries[0], Polygon)
     assert len(geometries) == len(ways["id"])
@@ -237,10 +237,9 @@ def test_adding_extra_attribute(helsinki_pbf):
     extra = osm.get_buildings(extra_attributes=[extra_col])
 
     # The extra should have one additional column compared to the original one
-    assert extra.shape[1] == gdf.shape[1]+1
+    assert extra.shape[1] == gdf.shape[1] + 1
     # Should have same number of rows
     assert extra.shape[0] == gdf.shape[0]
     assert extra_col in extra.columns
     assert len(extra[extra_col].dropna().unique()) > 0
     assert isinstance(gdf, GeoDataFrame)
-

--- a/tests/test_building_parsing.py
+++ b/tests/test_building_parsing.py
@@ -61,8 +61,9 @@ def test_creating_building_geometries(test_pbf):
                                                          filter_type="keep")
     assert isinstance(ways, dict)
 
-    geometries, us, vs = create_way_geometries(osm._node_coordinates,
-                                               ways)
+    geometries, lengths, us, vs = create_way_geometries(osm._node_coordinates,
+                                                        ways,
+                                                        parse_network=False)
     assert isinstance(geometries, ndarray)
     assert isinstance(geometries[0], Polygon)
     assert len(geometries) == len(ways["id"])

--- a/tests/test_distance_calculation.py
+++ b/tests/test_distance_calculation.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+def test_distance_calculations():
+    from pyrosm.distance import Unit, haversine
+
+    # Example line from Null Island to 10'10 --> should be ~1569 km
+    lon1, lat1 = np.array(0.0, dtype=np.float), np.array(0.0, dtype=np.float)
+    lon2, lat2 = np.array(10.0, dtype=np.float), np.array(10.0, dtype=np.float)
+    correct_distance_km = 1568.52272
+    correct_distance_miles = 974.634834
+    correct_distance_nautical_miles = 846.93452
+    correct_distance_feet = 5146072
+    correct_distance_inches = 61752863
+
+    # Test kilometers
+    l_km = haversine(lat1, lon1, lat2, lon2, unit=Unit.KILOMETERS)
+    assert round(l_km, 5) == correct_distance_km
+
+    # Meters
+    l_m = haversine(lat1, lon1, lat2, lon2, unit=Unit.METERS)
+    assert round(l_m, 2) == correct_distance_km*1000
+
+    # Miles
+    l_mi = haversine(lat1, lon1, lat2, lon2, unit=Unit.MILES)
+    assert round(l_mi, 6) == correct_distance_miles
+
+    # Nautical miles
+    l_nmi = haversine(lat1, lon1, lat2, lon2, unit=Unit.NAUTICAL_MILES)
+    assert round(l_nmi, 5) == correct_distance_nautical_miles
+
+    # Feet
+    l_f = haversine(lat1, lon1, lat2, lon2, unit=Unit.FEET)
+    assert round(l_f, 0) == correct_distance_feet
+
+    # Inches
+    l_f = haversine(lat1, lon1, lat2, lon2, unit=Unit.INCHES)
+    assert round(l_f, 0) == correct_distance_inches
+
+
+
+

--- a/tests/test_graph_exports.py
+++ b/tests/test_graph_exports.py
@@ -1,0 +1,172 @@
+import pytest
+from pyrosm import get_data
+from pyrosm.config import Conf
+
+# The values used to determine oneway road in OSM
+oneway_values = Conf.oneway_values
+oneway_col = "oneway"
+
+@pytest.fixture
+def test_pbf():
+    pbf_path = get_data("test_pbf")
+    return pbf_path
+
+@pytest.fixture
+def walk_nodes_and_edges():
+    from pyrosm import OSM
+    # UlanBator is good small dataset for testing
+    # (unmodified, i.e. not cropped)
+    pbf_path = get_data("ulanbator")
+    osm = OSM(pbf_path)
+    return osm.get_network(nodes=True)
+
+@pytest.fixture
+def bike_nodes_and_edges():
+    from pyrosm import OSM
+    # UlanBator is good small dataset for testing
+    # (unmodified, i.e. not cropped)
+    pbf_path = get_data("ulanbator")
+    osm = OSM(pbf_path)
+    return osm.get_network(nodes=True, network_type="cycling")
+
+@pytest.fixture
+def driving_nodes_and_edges():
+    from pyrosm import OSM
+    pbf_path = get_data("ulanbator")
+    osm = OSM(pbf_path)
+    return osm.get_network(network_type="driving", nodes=True)
+
+
+def test_igraph_export_by_walking(walk_nodes_and_edges):
+    from geopandas import GeoDataFrame
+    from pyrosm.graphs import to_igraph
+    import igraph
+
+    nodes, edges = walk_nodes_and_edges
+    g = to_igraph(nodes, edges)
+    n_edges = len(edges)
+    n_nodes = len(nodes)
+
+    assert isinstance(g, igraph.Graph)
+
+    # In case of walking/cycling there should be 2x the num of edges
+    # as in the orig gdf (one edge for each direction)
+    # --> assuming the data has not been cropped (which might drop nodes/edges)
+    assert g.ecount() == 2*n_edges
+
+    # The number of nodes should be the same
+    assert g.vcount() == n_nodes
+
+    # Ensure that all attributes were transfered to graph
+    ecolumns = edges.columns
+    ncolumns = nodes.columns
+    eattributes = g.edge_attributes()
+    nattributes = g.vertex_attributes()
+
+    for col in ecolumns:
+        assert col in eattributes
+
+    for col in ncolumns:
+        assert col in nattributes
+
+    # Check that all edge attributes have same length
+    for col in eattributes:
+        assert len(g.es[col]) == g.ecount()
+
+
+def test_igraph_export_by_cycling(bike_nodes_and_edges):
+    from geopandas import GeoDataFrame
+    from pyrosm.graphs import to_igraph
+    import igraph
+
+    nodes, edges = bike_nodes_and_edges
+    g = to_igraph(nodes, edges)
+    n_edges = len(edges)
+    n_nodes = len(nodes)
+
+    assert isinstance(g, igraph.Graph)
+
+    # In case of walking/cycling there should be 2x the num of edges
+    # as in the orig gdf (one edge for each direction)
+    # --> assuming the data has not been cropped (which might drop nodes/edges)
+    assert g.ecount() == 2*n_edges
+
+    # The number of nodes should be the same
+    assert g.vcount() == n_nodes
+
+    # Ensure that all attributes were transfered to graph
+    ecolumns = edges.columns
+    ncolumns = nodes.columns
+    eattributes = g.edge_attributes()
+    nattributes = g.vertex_attributes()
+
+    for col in ecolumns:
+        assert col in eattributes
+
+    for col in ncolumns:
+        assert col in nattributes
+
+    # Check that all edge attributes have same length
+    for col in eattributes:
+        assert len(g.es[col]) == g.ecount()
+
+
+def test_igraph_export_by_driving(driving_nodes_and_edges):
+    from geopandas import GeoDataFrame
+    from pyrosm.graphs import to_igraph
+    import igraph
+
+    nodes, edges = driving_nodes_and_edges
+    g = to_igraph(nodes, edges)
+    n_nodes = len(nodes)
+
+    assert isinstance(g, igraph.Graph)
+
+    # The number of nodes should be the same in the graph
+    assert g.vcount() == n_nodes
+
+    # Ensure that all attributes were transfered to graph
+    ecolumns = edges.columns
+    ncolumns = nodes.columns
+    eattributes = g.edge_attributes()
+    nattributes = g.vertex_attributes()
+
+    for col in ecolumns:
+        assert col in eattributes
+
+    for col in ncolumns:
+        assert col in nattributes
+
+    # Check that all edge attributes have same length
+    for col in eattributes:
+        assert len(g.es[col]) == g.ecount()
+
+    # Calculate the number of edges that should be oneway + bidirectional
+    mask = edges[oneway_col].isin(oneway_values)
+    oneway_edge_cnt = len(edges.loc[mask])
+    twoway_edge_cnt = len(edges.loc[~mask])
+
+    # Check that the edge count matches
+    assert g.ecount() == oneway_edge_cnt + twoway_edge_cnt*2
+
+
+def test_igraph_unmutable_counts(test_pbf):
+    """
+    A simple check to ensure that
+    the graph shape is always the
+    same with unmutable data.
+    """
+    from geopandas import GeoDataFrame
+    from pyrosm.graphs import to_igraph
+    import igraph
+    from pyrosm import OSM
+    osm = OSM(test_pbf)
+    nodes, edges = osm.get_network(nodes=True)
+    g = to_igraph(nodes, edges)
+    n_nodes = len(nodes)
+
+    assert isinstance(g, igraph.Graph)
+    # Check that the edge count matches
+    assert g.ecount() == 462
+    assert g.vcount() == n_nodes
+

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -31,7 +31,7 @@ def test_filter_network_by_walking(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (265, 20)
+    assert gdf.shape == (265, 23)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
@@ -54,7 +54,7 @@ def test_filter_network_by_driving(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 18)
+    assert gdf.shape == (207, 21)
 
     required_cols = ['access', 'bridge', 'highway', 'int_ref', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id', 'geometry', 'tags',
@@ -78,7 +78,7 @@ def test_filter_network_by_driving_with_service_roads(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 18)
+    assert gdf.shape == (207, 21)
 
     required_cols = ['access', 'bridge', 'highway', 'int_ref', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id', 'geometry', 'tags',
@@ -102,7 +102,7 @@ def test_filter_network_by_cycling(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (290, 20)
+    assert gdf.shape == (290, 23)
 
     required_cols = ['access', 'bicycle', 'bridge', 'foot', 'highway', 'lanes', 'lit',
                      'maxspeed', 'name', 'oneway', 'ref', 'service', 'surface', 'tunnel',
@@ -126,7 +126,7 @@ def test_filter_network_by_all(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (331, 21)
+    assert gdf.shape == (331, 24)
 
     required_cols = ['access', 'bicycle', 'bridge', 'foot', 'highway', 'lanes', 'lit',
                      'maxspeed', 'name', 'oneway', 'ref', 'service', 'surface', 'tunnel',
@@ -174,7 +174,7 @@ def test_parse_network_with_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 20)
+    assert gdf.shape == (74, 23)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
@@ -206,7 +206,7 @@ def test_parse_network_with_shapely_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 20)
+    assert gdf.shape == (74, 23)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -31,11 +31,11 @@ def test_filter_network_by_walking(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (265, 23)
+    assert gdf.shape == (265, 24)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
-                     'geometry', 'tags', 'osm_type']
+                     'geometry', 'tags', 'osm_type', 'length']
     for col in required_cols:
         assert col in gdf.columns
 
@@ -54,11 +54,11 @@ def test_filter_network_by_driving(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 21)
+    assert gdf.shape == (207, 22)
 
     required_cols = ['access', 'bridge', 'highway', 'int_ref', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id', 'geometry', 'tags',
-                     'osm_type']
+                     'osm_type', 'length']
     for col in required_cols:
         assert col in gdf.columns
 
@@ -78,11 +78,11 @@ def test_filter_network_by_driving_with_service_roads(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 21)
+    assert gdf.shape == (207, 22)
 
     required_cols = ['access', 'bridge', 'highway', 'int_ref', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id', 'geometry', 'tags',
-                     'osm_type']
+                     'osm_type', 'length']
     for col in required_cols:
         assert col in gdf.columns
 
@@ -102,11 +102,11 @@ def test_filter_network_by_cycling(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (290, 23)
+    assert gdf.shape == (290, 24)
 
     required_cols = ['access', 'bicycle', 'bridge', 'foot', 'highway', 'lanes', 'lit',
                      'maxspeed', 'name', 'oneway', 'ref', 'service', 'surface', 'tunnel',
-                     'id', 'geometry', 'tags', 'osm_type']
+                     'id', 'geometry', 'tags', 'osm_type', 'length']
     for col in required_cols:
         assert col in gdf.columns
 
@@ -126,11 +126,11 @@ def test_filter_network_by_all(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (331, 24)
+    assert gdf.shape == (331, 25)
 
     required_cols = ['access', 'bicycle', 'bridge', 'foot', 'highway', 'lanes', 'lit',
                      'maxspeed', 'name', 'oneway', 'ref', 'service', 'surface', 'tunnel',
-                     'id', 'geometry', 'tags', 'osm_type']
+                     'id', 'geometry', 'tags', 'osm_type', 'length']
     for col in required_cols:
         assert col in gdf.columns
 
@@ -174,11 +174,11 @@ def test_parse_network_with_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 23)
+    assert gdf.shape == (74, 24)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
-                     'geometry', 'tags', 'osm_type']
+                     'geometry', 'tags', 'osm_type', 'length']
     for col in required_cols:
         assert col in gdf.columns
 
@@ -206,11 +206,11 @@ def test_parse_network_with_shapely_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 23)
+    assert gdf.shape == (74, 24)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
-                     'geometry', 'tags', 'osm_type']
+                     'geometry', 'tags', 'osm_type', 'length']
     for col in required_cols:
         assert col in gdf.columns
 
@@ -324,7 +324,7 @@ def test_getting_nodes_and_edges(test_pbf):
     assert isinstance(nodes.loc[0, 'geometry'], Point)
 
     # Test shape
-    assert edges.shape == (265, 23)
+    assert edges.shape == (265, 24)
     assert nodes.shape == (382, 8)
 
     # Edges should have "u" and "v" columns
@@ -333,7 +333,7 @@ def test_getting_nodes_and_edges(test_pbf):
     for col in required:
         assert col in ecols
 
-    # Nodes should have "id", "x", and "y" columns
+    # Nodes should have (at least) "id", "x", and "y" columns
     required = ["id", "x", "y"]
     ncols = nodes.columns
     for col in required:

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -300,3 +300,42 @@ def test_adding_extra_attribute(helsinki_pbf):
     assert extra_col in extra.columns
     assert len(extra[extra_col].dropna().unique()) > 0
     assert isinstance(gdf, GeoDataFrame)
+
+
+def test_getting_nodes_and_edges(test_pbf):
+    from pyrosm import OSM
+    from geopandas import GeoDataFrame
+    from shapely.geometry import Point, LineString
+
+    osm = OSM(filepath=test_pbf)
+
+    nodes, edges = osm.get_network(nodes=True)
+    orig_edges = osm.get_network()
+
+    # Edges with nodes and without nodes should be the same
+    assert edges.shape == orig_edges.shape
+
+    nodes = nodes.reset_index(drop=True)
+
+    assert isinstance(edges, GeoDataFrame)
+    assert isinstance(edges.loc[0, 'geometry'], LineString)
+
+    assert isinstance(nodes, GeoDataFrame)
+    assert isinstance(nodes.loc[0, 'geometry'], Point)
+
+    # Test shape
+    assert edges.shape == (265, 23)
+    assert nodes.shape == (382, 8)
+
+    # Edges should have "u" and "v" columns
+    required = ["u", "v"]
+    ecols = edges.columns
+    for col in required:
+        assert col in ecols
+
+    # Nodes should have "id", "x", and "y" columns
+    required = ["id", "x", "y"]
+    ncols = nodes.columns
+    for col in required:
+        assert col in ncols
+

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -31,7 +31,7 @@ def test_filter_network_by_walking(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (265, 24)
+    assert gdf.shape == (265, 23)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
@@ -54,7 +54,7 @@ def test_filter_network_by_driving(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 22)
+    assert gdf.shape == (207, 21)
 
     required_cols = ['access', 'bridge', 'highway', 'int_ref', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id', 'geometry', 'tags',
@@ -78,7 +78,7 @@ def test_filter_network_by_driving_with_service_roads(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 22)
+    assert gdf.shape == (207, 21)
 
     required_cols = ['access', 'bridge', 'highway', 'int_ref', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id', 'geometry', 'tags',
@@ -102,7 +102,7 @@ def test_filter_network_by_cycling(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (290, 24)
+    assert gdf.shape == (290, 23)
 
     required_cols = ['access', 'bicycle', 'bridge', 'foot', 'highway', 'lanes', 'lit',
                      'maxspeed', 'name', 'oneway', 'ref', 'service', 'surface', 'tunnel',
@@ -126,7 +126,7 @@ def test_filter_network_by_all(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (331, 25)
+    assert gdf.shape == (331, 24)
 
     required_cols = ['access', 'bicycle', 'bridge', 'foot', 'highway', 'lanes', 'lit',
                      'maxspeed', 'name', 'oneway', 'ref', 'service', 'surface', 'tunnel',
@@ -174,7 +174,7 @@ def test_parse_network_with_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 24)
+    assert gdf.shape == (74, 23)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
@@ -206,7 +206,7 @@ def test_parse_network_with_shapely_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 24)
+    assert gdf.shape == (74, 23)
 
     required_cols = ['access', 'bridge', 'foot', 'highway', 'lanes', 'lit', 'maxspeed',
                      'name', 'oneway', 'ref', 'service', 'surface', 'id',
@@ -324,7 +324,7 @@ def test_getting_nodes_and_edges(test_pbf):
     assert isinstance(nodes.loc[0, 'geometry'], Point)
 
     # Test shape
-    assert edges.shape == (265, 24)
+    assert edges.shape == (265, 23)
     assert nodes.shape == (382, 8)
 
     # Edges should have "u" and "v" columns


### PR DESCRIPTION
Relates to #52. 

Adds functionality to:
 - calculate the length of network edges. Information is updated to column `length` (reported in meters with 3 decimals). 
 - (optionally) return the nodes when parsing networks (**notice**: handling one-way/two-way streets are handled only when exporting the graph)
 - export the network into igraph.Graph (support for networkx/pandana are added next)

Example:
```
from pyrosm import OSM, get_data
from pyrosm.graphs import to_igraph
osm = OSM(get_data("helsinki"))
# Parse nodes and edges using `nodes=True`
nodes, edges = osm.get_network(nodes=True)
# Export to igraph
g = to_igraph(nodes, edges)
```

   