### PR TITLE
static `to_graph`

### DIFF
--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -708,8 +708,8 @@ class OSM:
                 gdf = gdf.drop("nodes", axis=1)
         return gdf
 
+    @staticmethod
     def to_graph(
-        self,
         nodes,
         edges,
         graph_type="igraph",


### PR DESCRIPTION
See discussion in issue #134 

This changes `pyrosm.OSM.to_graph()` into a static method to better indicate that it does not use the network internal to the respective `pyrosm.OSM` instance.


(wooohooo! 1 line contributed!)