### PR TITLE
Use cykhash2.0.0 functionality

### DIFF
--- a/ci/36-conda.yaml
+++ b/ci/36-conda.yaml
@@ -10,7 +10,7 @@ dependencies:
   - pygeos
   - cython
   - pyrobuf
-  - cykhash
+  - cykhash=2.0.0
   - python-rapidjson
   # optional
   - python-igraph

--- a/ci/37-conda.yaml
+++ b/ci/37-conda.yaml
@@ -9,7 +9,7 @@ dependencies:
   - geopandas
   - pygeos
   - cython
-  - cykhash
+  - cykhash=2.0.0
   - pyrobuf
   - python-rapidjson
   # optional

--- a/ci/38-conda.yaml
+++ b/ci/38-conda.yaml
@@ -9,7 +9,7 @@ dependencies:
   - geopandas
   - pygeos
   - cython
-  - cykhash
+  - cykhash=2.0.0
   - pyrobuf
   - python-rapidjson
   # optional

--- a/ci/39-conda.yaml
+++ b/ci/39-conda.yaml
@@ -9,7 +9,7 @@ dependencies:
   - geopandas
   - pygeos
   - cython
-  - cykhash
+  - cykhash=2.0.0
   - pyrobuf
   - python-rapidjson
   # optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "cykhash", "pyrobuf"]
+requires = ["setuptools", "wheel", "Cython", "cykhash==2.0.0", "pyrobuf"]

--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -1,6 +1,5 @@
 import numpy as np
-from cykhash.khashsets cimport Int64Set_from_buffer
-from cykhash import isin_int64
+from cykhash.khashsets cimport any_int64_from_iter, isin_int64, Int64Set_from_buffer
 from cpython cimport array
 
 
@@ -203,14 +202,7 @@ cdef get_nodeid_lookup_khash(nodes):
 
 
 cdef nodes_for_way_exist_khash(nodes, node_lookup):
-    v = array.array('q', nodes)
-    cdef int n = len(v)
-
-    result = array.array('B', [False] * n)
-    isin_int64(v, node_lookup, result)
-    if True in result:
-        return True
-    return False
+    return any_int64_from_iter(nodes, node_lookup)
 
 
 cpdef get_mask_by_osmid(src_array, osm_ids):


### PR DESCRIPTION
Using `any_int64_from_iter` rather than building temporary array: it is faster as it will short-cut for the first True and doesn't need additional memory.

`any_int64_from_iter` was introduced in cykhash v2.0.0 thus pinning the version of cykhash.

It is probably safer to pin to the exact version 2.0.0 than to >=2.0.0 as having built against one version and run with another might lead to problems when C-functionality is used (i.e. cimported rather than imported)