### PR TITLE
make cycling directional

### DIFF
--- a/docs/basics.ipynb
+++ b/docs/basics.ipynb
@@ -2146,7 +2146,7 @@
     "\n",
     "- **Pyrosm will always create a directed graph** when exporting the street network to graph (works similarly for all libraries). \n",
     "    - When exporting network that is used for driving (i.e. `network_type=\"driving\"`), pyrosm considers the oneway restrictions that are defined in `oneway` column in the data. \n",
-    "    - With \"walking\", \"cycling\" and \"all\", pyrosm creates a bidirectional graph, meaning that the travel is allowed to both directions. \n",
+    "    - With \"walking\" and \"all\", pyrosm creates a bidirectional graph, meaning that the travel is allowed to both directions. \n",
     "- By default, **Pyrosm will only keep connected edges** in the output graph (*largest strongly connected component*). This means that all \"isolated islands\" of the network will be filtered out because those cannot be reached from other parts of the network (you can change this behavior by specifying `retain_all=True`, see [further info](#to-graph-parameters-explained)).\n",
     "- When constructing the graph all road segments are kept separately to enable good connectivity in the graph. However, it is possible to *simplify* the NetworkX graph (hence reducing it's size) using OSMnx by merging all road segments belonging to the same link (*i.e. road between two intersections*). Read more from [OSMnx docs here](https://github.com/gboeing/osmnx-examples/blob/master/notebooks/04-simplify-graph-consolidate-nodes.ipynb). (*this might be integrated into Pyrosm in the future iterations of the library*)"
    ]
@@ -2607,7 +2607,7 @@
       "      - \"networkx\",\n",
       "      - \"pandana\"\n",
       "    \n",
-      "    For walking and cycling, the output graph will be bidirectional by default\n",
+      "    For walking the output graph will be bidirectional by default\n",
       "    (i.e. travel along the street is allowed to both directions). For driving,\n",
       "    one-way streets are taken into account by default and the travel is restricted\n",
       "    based on the rules in OSM data (based on \"oneway\" attribute).\n",
@@ -2650,7 +2650,7 @@
       "        Network type for the given data. Determines how the graph will be constructed.\n",
       "        The network type is typically extracted automatically from the metadata of\n",
       "        the edges/nodes GeoDataFrames. This parameter can be used if this metadata is not\n",
-      "        available for a reason or another. By default, bidirectional graph is created for walking, cycling and all,\n",
+      "        available for a reason or another. By default, bidirectional graph is created for walking and all,\n",
       "        and directed graph for driving (i.e. oneway streets are taken into account).\n",
       "        Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.\n",
       "    \n",

--- a/pyrosm/config/osm_filters.py
+++ b/pyrosm/config/osm_filters.py
@@ -130,6 +130,7 @@ def cycling_filter():
             "raceway",
             "motorway",
             "motorway_link",
+            "busway",
         ],
         bicycle=["no"],
         service=["private"],

--- a/pyrosm/config/osm_filters.py
+++ b/pyrosm/config/osm_filters.py
@@ -130,7 +130,6 @@ def cycling_filter():
             "raceway",
             "motorway",
             "motorway_link",
-            "busway",
         ],
         bicycle=["no"],
         service=["private"],

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -71,8 +71,8 @@ def get_directed_edges(
 
     # Generate directed edges
     # Check if user wants to force bidirectional graph
-    # or if the graph is walking, cycling or all
-    if force_bidirectional or net_type in ["walking", "cycling", "all"]:
+    # or if the graph is walking or all
+    if force_bidirectional or net_type in ["walking", "all"]:
         edges = generate_directed_edges(
             edges, direction, from_id_col, to_id_col, force_bidirectional=True
         )
@@ -133,7 +133,7 @@ def to_networkx(
 
     network_type : str
         Network type for the given data. Determines how the graph will be constructed.
-        By default, bidirectional graph is created for walking, cycling and all,
+        By default, bidirectional graph is created for walking and all,
         and directed graph for driving (i.e. oneway streets are taken into account).
         Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.
 
@@ -234,7 +234,7 @@ def to_igraph(
 
     network_type : str
         Network type for the given data. Determines how the graph will be constructed.
-        By default, bidirectional graph is created for walking, cycling and all,
+        By default, bidirectional graph is created for walking and all,
         and directed graph for driving (i.e. oneway streets are taken into account).
         Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.
 

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -813,7 +813,7 @@ class OSM:
           - "networkx",
           - "pandana"
 
-        For walking and cycling, the output graph will be bidirectional by default
+        For walking the output graph will be bidirectional by default
         (i.e. travel along the street is allowed to both directions). For driving,
         one-way streets are taken into account by default and the travel is restricted
         based on the rules in OSM data (based on "oneway" attribute).
@@ -856,7 +856,7 @@ class OSM:
             Network type for the given data. Determines how the graph will be constructed.
             The network type is typically extracted automatically from the metadata of
             the edges/nodes GeoDataFrames. This parameter can be used if this metadata is not
-            available for a reason or another. By default, bidirectional graph is created for walking, cycling and all,
+            available for a reason or another. By default, bidirectional graph is created for walking and all,
             and directed graph for driving (i.e. oneway streets are taken into account).
             Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.
 


### PR DESCRIPTION
Hi! In the Netherlands we have a lot of cycleways and many are one way (directional) like the following example in Amsterdam:

https://goo.gl/maps/a5mvTZHR6RsM1h7w7
https://www.openstreetmap.org/way/164971339

As it's only possible to force bidirectional I'd like to set the default to directional so anyone who want a bidirectional cycleway network can still do so.