### PR TITLE
allow multiple directions

### DIFF
--- a/pyrosm/config/default_tags.py
+++ b/pyrosm/config/default_tags.py
@@ -65,6 +65,7 @@ highway_columns = [
     "motor_vehicle",
     "name",
     "oneway",
+    "oneway:bicycle",
     "overtaking",
     "path",
     "passing_places",

--- a/pyrosm/graph_export.pxd
+++ b/pyrosm/graph_export.pxd
@@ -1,5 +1,5 @@
 cpdef _create_igraph(nodes, edges, from_id_col, to_id_col, node_id_col)
 cpdef _create_nxgraph(nodes, edges, from_id_col, to_id_col, node_id_col)
 cpdef _create_pdgraph(nodes, edges, from_id_col, to_id_col, weight_cols)
-cpdef generate_directed_edges(edges, direction, from_id_col, to_id_col, force_bidirectional)
+cpdef generate_directed_edges(edges, directions, from_id_col, to_id_col, force_bidirectional)
 

--- a/pyrosm/graph_export.pxd
+++ b/pyrosm/graph_export.pxd
@@ -1,5 +1,5 @@
 cpdef _create_igraph(nodes, edges, from_id_col, to_id_col, node_id_col)
 cpdef _create_nxgraph(nodes, edges, from_id_col, to_id_col, node_id_col)
 cpdef _create_pdgraph(nodes, edges, from_id_col, to_id_col, weight_cols)
-cpdef generate_directed_edges(edges, directions, from_id_col, to_id_col, force_bidirectional)
+cpdef generate_directed_edges(edges, direction, direction_suffix, from_id_col, to_id_col, force_bidirectional)
 

--- a/pyrosm/graph_export.pyx
+++ b/pyrosm/graph_export.pyx
@@ -187,13 +187,13 @@ cpdef _create_pdgraph(nodes,
 
 
 cpdef generate_directed_edges(edges,
-                              direction,
+                              directions,
                               from_id_col,
                               to_id_col,
                               force_bidirectional):
     """
     Generates directed set of edges from network 
-    following rules specified in 'direction' column.
+    following rules specified in 'directions' column.
     
     If 'force_bidirectional=True' travel to both direction is allowed for all edges.
     """
@@ -214,11 +214,16 @@ cpdef generate_directed_edges(edges,
     else:
         roundabouts = False
 
+    for _direction in directions:
+        if _direction in edges:
+            direction = edges[_direction]
+            break
+
     if roundabouts:
         # Edge is oneway if it is tagged as such OR if it tagged as roundabout
-        oneway_mask = (edges[direction].isin(oneway_values)) | (edges["junction"] == "roundabout")
+        oneway_mask = (direction.isin(oneway_values)) | (edges["junction"] == "roundabout")
     else:
-        oneway_mask = edges[direction].isin(oneway_values)
+        oneway_mask = direction.isin(oneway_values)
 
     edge_cnt = len(edges)
     oneway_edges = edges.loc[oneway_mask].copy()
@@ -227,7 +232,7 @@ cpdef generate_directed_edges(edges,
     twoway_edges_dir2.index = np.arange(edge_cnt, edge_cnt + len(twoway_edges))
 
     # Select edges that are allowed only to opposite direction
-    against_mask = oneway_edges[direction].isin(["-1", "T"])
+    against_mask = direction.isin(["-1", "T"])
     against_edges = oneway_edges.loc[against_mask].copy()
     along_edges = oneway_edges.loc[~against_mask].copy()  # Nothing needs to be done for these
 

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -13,7 +13,7 @@ import warnings
 def get_directed_edges(
     nodes,
     edges,
-    directions=("oneway", ),
+    direction="oneway",
     from_id_col="u",
     to_id_col="v",
     node_id_col="id",
@@ -33,7 +33,6 @@ def get_directed_edges(
                 "Required column '{col}' does not exist in edges.".format(col=col)
             )
 
-    direction = directions[-1]
     if direction not in edges.columns:
         warnings.warn(
             f"Column '{direction}' missing in the edges GeoDataFrame. "
@@ -72,14 +71,20 @@ def get_directed_edges(
 
     # Generate directed edges
     # Check if user wants to force bidirectional graph
-    # or if the graph is walking, cycling or all
-    if force_bidirectional or net_type in ["walking", "cycling", "all"]:
+    # or if the graph is walking or all
+
+    direction_split = direction.split(":", 1)
+    direction = direction_split[0]
+    if len(direction_split) == 2:
+        direction_suffix = direction_split[1]
+
+    if force_bidirectional or net_type in ["walking", "all"]:
         edges = generate_directed_edges(
-            edges, directions, from_id_col, to_id_col, force_bidirectional=True
+            edges, direction, direction_suffix, from_id_col, to_id_col, force_bidirectional=True
         )
     else:
         edges = generate_directed_edges(
-            edges, directions, from_id_col, to_id_col, force_bidirectional=False
+            edges, direction, direction_suffix, from_id_col, to_id_col, force_bidirectional=False
         )
 
     return nodes, edges
@@ -88,7 +93,7 @@ def get_directed_edges(
 def to_networkx(
     nodes,
     edges,
-    directions=("oneway", ),
+    direction="oneway",
     from_id_col="u",
     to_id_col="v",
     edge_id_col="id",
@@ -156,7 +161,7 @@ def to_networkx(
     nodes, edges = get_directed_edges(
         nodes,
         edges,
-        directions,
+        direction,
         from_id_col,
         to_id_col,
         node_id_col,
@@ -191,7 +196,7 @@ def to_networkx(
 def to_igraph(
     nodes,
     edges,
-    directions=("oneway", ),
+    direction="oneway",
     from_id_col="u",
     to_id_col="v",
     node_id_col="id",
@@ -252,7 +257,7 @@ def to_igraph(
     nodes, edges = get_directed_edges(
         nodes,
         edges,
-        directions,
+        direction,
         from_id_col,
         to_id_col,
         node_id_col,
@@ -272,7 +277,7 @@ def to_igraph(
 def to_pandana(
     nodes,
     edges,
-    directions=("oneway", ),
+    direction="oneway",
     from_id_col="u",
     to_id_col="v",
     node_id_col="id",
@@ -285,7 +290,7 @@ def to_pandana(
     nodes, edges = get_directed_edges(
         nodes,
         edges,
-        directions,
+        direction,
         from_id_col,
         to_id_col,
         node_id_col,

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -13,7 +13,7 @@ import warnings
 def get_directed_edges(
     nodes,
     edges,
-    direction="oneway",
+    directions=("oneway", ),
     from_id_col="u",
     to_id_col="v",
     node_id_col="id",
@@ -33,6 +33,7 @@ def get_directed_edges(
                 "Required column '{col}' does not exist in edges.".format(col=col)
             )
 
+    direction = directions[-1]
     if direction not in edges.columns:
         warnings.warn(
             f"Column '{direction}' missing in the edges GeoDataFrame. "
@@ -74,11 +75,11 @@ def get_directed_edges(
     # or if the graph is walking, cycling or all
     if force_bidirectional or net_type in ["walking", "cycling", "all"]:
         edges = generate_directed_edges(
-            edges, direction, from_id_col, to_id_col, force_bidirectional=True
+            edges, directions, from_id_col, to_id_col, force_bidirectional=True
         )
     else:
         edges = generate_directed_edges(
-            edges, direction, from_id_col, to_id_col, force_bidirectional=False
+            edges, directions, from_id_col, to_id_col, force_bidirectional=False
         )
 
     return nodes, edges
@@ -87,7 +88,7 @@ def get_directed_edges(
 def to_networkx(
     nodes,
     edges,
-    direction="oneway",
+    directions=("oneway", ),
     from_id_col="u",
     to_id_col="v",
     edge_id_col="id",
@@ -155,7 +156,7 @@ def to_networkx(
     nodes, edges = get_directed_edges(
         nodes,
         edges,
-        direction,
+        directions,
         from_id_col,
         to_id_col,
         node_id_col,
@@ -190,7 +191,7 @@ def to_networkx(
 def to_igraph(
     nodes,
     edges,
-    direction="oneway",
+    directions=("oneway", ),
     from_id_col="u",
     to_id_col="v",
     node_id_col="id",
@@ -251,7 +252,7 @@ def to_igraph(
     nodes, edges = get_directed_edges(
         nodes,
         edges,
-        direction,
+        directions,
         from_id_col,
         to_id_col,
         node_id_col,
@@ -271,7 +272,7 @@ def to_igraph(
 def to_pandana(
     nodes,
     edges,
-    direction="oneway",
+    directions=("oneway", ),
     from_id_col="u",
     to_id_col="v",
     node_id_col="id",
@@ -284,7 +285,7 @@ def to_pandana(
     nodes, edges = get_directed_edges(
         nodes,
         edges,
-        direction,
+        directions,
         from_id_col,
         to_id_col,
         node_id_col,

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -795,7 +795,7 @@ class OSM:
         nodes,
         edges,
         graph_type="igraph",
-        direction="oneway",
+        directions=("oneway", ),
         from_id_col="u",
         to_id_col="v",
         edge_id_col="id",
@@ -834,8 +834,8 @@ class OSM:
               - "networkx" --> returns a networkx.MultiDiGraph -object.
               - "pandana" --> returns an pandana.Network -object.
 
-        direction : str
-            Name for the column containing information about the allowed driving directions
+        directions : list
+            Name for the columns containing information about the allowed driving directions
 
         from_id_col : str
             Name for the column having the from-node-ids of edges.
@@ -878,7 +878,7 @@ class OSM:
             return to_igraph(
                 nodes,
                 edges,
-                direction,
+                directions,
                 from_id_col,
                 to_id_col,
                 node_id_col,
@@ -890,7 +890,7 @@ class OSM:
             return to_networkx(
                 nodes,
                 edges,
-                direction,
+                directions,
                 from_id_col,
                 to_id_col,
                 edge_id_col,
@@ -904,7 +904,7 @@ class OSM:
             return to_pandana(
                 nodes,
                 edges,
-                direction,
+                directions,
                 from_id_col,
                 to_id_col,
                 node_id_col,

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -795,7 +795,7 @@ class OSM:
         nodes,
         edges,
         graph_type="igraph",
-        directions=("oneway", ),
+        direction="oneway",
         from_id_col="u",
         to_id_col="v",
         edge_id_col="id",
@@ -834,8 +834,8 @@ class OSM:
               - "networkx" --> returns a networkx.MultiDiGraph -object.
               - "pandana" --> returns an pandana.Network -object.
 
-        directions : list
-            Name for the columns containing information about the allowed driving directions
+        direction : str
+            Name for the column containing information about the allowed driving directions
 
         from_id_col : str
             Name for the column having the from-node-ids of edges.
@@ -878,7 +878,7 @@ class OSM:
             return to_igraph(
                 nodes,
                 edges,
-                directions,
+                direction,
                 from_id_col,
                 to_id_col,
                 node_id_col,
@@ -890,7 +890,7 @@ class OSM:
             return to_networkx(
                 nodes,
                 edges,
-                directions,
+                direction,
                 from_id_col,
                 to_id_col,
                 edge_id_col,
@@ -904,7 +904,7 @@ class OSM:
             return to_pandana(
                 nodes,
                 edges,
-                directions,
+                direction,
                 from_id_col,
                 to_id_col,
                 node_id_col,


### PR DESCRIPTION
Allow multiple "directions" tags.

This is useful when multiple "oneway" tags are used, for able "oneway:bicycle" and "oneway". The first supplied has the highest priority in evaluating the value.

This will allow exceptions on oneway roads.