### PR TITLE
fix CI workflow and linting issues 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v2.1.1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: ${{ matrix.env }}
           miniforge-version: latest
@@ -77,6 +77,6 @@ jobs:
         run: pytest -v -r s --color=yes --cov=pyrosm --cov-append --cov-report term-missing --cov-report xml tests/
 
       - name: Update codecov.io
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install black and flake8

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
   lint:
     name: Linting code
     runs-on: ubuntu-latest
-    container: python:3
+    container: ubuntu:22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/pyrosm/boundary.py
+++ b/pyrosm/boundary.py
@@ -14,7 +14,6 @@ def get_boundary_data(
     name,
     bounding_box,
 ):
-
     if boundary_type == "all":
         boundary_type = True
     else:

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -60,7 +60,6 @@ class OSM:
     ]
 
     def __init__(self, filepath, bounding_box=None):
-
         # Check input file
         self.filepath = validate_input_file(filepath)
 

--- a/pyrosm/user_defined.py
+++ b/pyrosm/user_defined.py
@@ -17,7 +17,6 @@ def get_user_defined_data(
     keep_relations,
     bounding_box,
 ):
-
     if not keep_nodes:
         nodes = None
 

--- a/pyrosm/utils/__init__.py
+++ b/pyrosm/utils/__init__.py
@@ -187,7 +187,6 @@ def valid_header_block(header_block):
 
 def get_bounding_box(filepath):
     with open(filepath, "rb") as f:
-
         # Check that the data stream is valid OSM
         # =======================================
 
@@ -205,7 +204,6 @@ def get_bounding_box(filepath):
 
         # Validate header
         if valid_header_block(header_block):
-
             # Parse bounding box
             try:
                 bb = header_block.bbox.SerializeToDict()

--- a/pyrosm/utils/download.py
+++ b/pyrosm/utils/download.py
@@ -51,7 +51,6 @@ def download(url, filename, update, target_dir):
 
     # Download data to temp if it does not exist or if update is requested
     if update or file_exists is False:
-
         try:
             filepath, msg = urllib.request.urlretrieve(url, filepath)
         except HTTPError:


### PR DESCRIPTION
As discussed in https://github.com/HTenkanen/pyrosm/pull/214, the actions workflow currently fails.

The error message seems related to https://github.com/actions/setup-python/issues/560 or https://github.com/actions/setup-python/issues/572, though `tests.yaml` uses `ubuntu-latest` and no caching. 

This PR 

* uses `ubuntu:22.04` as container, instead of `python:3`.  This should be sufficient, as python should be installed via the `setup-python` action. 
* bumps some github actions versions to their current version.
* fixes some minor formatting issues highlighted by black
 