### PR TITLE
Correcting Relation IDs and Overwriting Tag IDs

### DIFF
--- a/pyrosm/pbfreader.pyx
+++ b/pyrosm/pbfreader.pyx
@@ -319,12 +319,8 @@ cdef parse_relations(data, string_table, unix_time_filter):
     # Version
     versions = np.array([rel.info.version for rel in data], dtype=np.int64)
 
-    # Ids (delta coded)
-    id_deltas = np.zeros(N+1, dtype=np.int64)
-    id_deltas[1:] = [rel.id for rel in data]
-    ids = np.cumsum(id_deltas)[1:]
+    ids = np.array([rel.id for rel in data])
 
-    # Timestamp
     timestamps = np.array([rel.info.timestamp for rel in data], dtype=np.int64)
 
     # Changeset

--- a/pyrosm/tagparser.pyx
+++ b/pyrosm/tagparser.pyx
@@ -38,7 +38,10 @@ cdef explode_way_tags(ways):
     for i in range(0, n):
         way = ways[i]
         for k, v in way['tags'].items():
-            way[k] = v
+            if k == "id":
+                way["tagged_id"] = v
+            else:
+                way[k] = v
             try:
                 dummy = way_keys[k]
             except:


### PR DESCRIPTION
This pull request contains fixes for #170 and #233 - fixing relation IDs and IDs in tags that overwrite the proper OSM ID.

Addressing #170 first, I found that the IDs from the relations did not need to be delta decoded with the `np.cumsum` function - 
they already match the OSM ID for the relation. The example given in #170 now yields the expected result (and an extra three parks that have been added since the issue was made in 2022). 

#233 feels more like a patch to me, but it prevents IDs placed into the tags of buildings overwriting the actual ID from OSM. 