### PR TITLE
Fix: Reading PBF from osmfilter -> osmconvert fails #176

### DIFF
--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -265,7 +265,7 @@ cdef record_should_be_kept(tag, osm_keys, data_filter, filter_type):
 
 
 cdef filter_relation_indices(relations, osm_keys, data_filter, filter_type):
-    cdef int i, n = len(relations["tags"])
+    cdef int i, n = len(relations.get("tags", []))
     indices = []
 
     # Ensure keys

--- a/tests/test_custom_filter.py
+++ b/tests/test_custom_filter.py
@@ -1,5 +1,14 @@
 import pytest
+
 from pyrosm import get_data
+from pyrosm.utils.download import download
+
+
+@pytest.fixture
+def california_highway_motorway_pbf():
+    filename = "california_highway_motorway.osm.pbf"
+    url = f"https://github.com/eracle/pyrosm-test-data/raw/refs/heads/main/{filename}"
+    return download(url=url, filename=filename, update=None, target_dir=None)
 
 
 @pytest.fixture
@@ -37,6 +46,15 @@ def test_output_dir():
     import os, tempfile
 
     return os.path.join(tempfile.gettempdir(), "pyrosm_test_results")
+
+
+def test_get_data_by_custom_criteria_custom_filter(california_highway_motorway_pbf):
+    from geopandas import GeoDataFrame
+    from pyrosm import OSM
+    osm = OSM(filepath=california_highway_motorway_pbf)
+    gdf = osm.get_data_by_custom_criteria(custom_filter={"highway": ["motorway"]})
+
+    assert isinstance(gdf, GeoDataFrame)
 
 
 def test_parsing_osm_with_custom_filter_by_excluding_tags(test_pbf):
@@ -494,7 +512,6 @@ def test_custom_filters_with_custom_keys(helsinki_region_pbf):
 
 def test_reading_custom_from_area_having_none(helsinki_pbf):
     from pyrosm import OSM
-    from geopandas import GeoDataFrame
 
     # Bounding box for area that does not have any data
     bbox = [24.940514, 60.173849, 24.942, 60.175892]


### PR DESCRIPTION
### Pull Request: Fix for Pyrosm KeyError when Filtering PBF Files with Osmium

#### Summary
This pull request addresses an issue where the `pyrosm` library throws a `KeyError: 'tags'` when filtering certain PBF files using `osmium` and processing them with custom tag criteria. The error occurs specifically for certain key-value pairs like `highway=motorhead`, which cause the `tags` key to be missing in some OSM relationships.

#### Problem
The following error traceback is observed when attempting to process OSM data using custom filter criteria:

```
tests/test_custom_filter.py:55: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pyrosm/pyrosm.py:767: in get_data_by_custom_criteria
    gdf = get_user_defined_data(
pyrosm/user_defined.py:36: in get_user_defined_data
    nodes, ways, relation_ways, relations = get_osm_data(
pyrosm/data_manager.pyx:175: in pyrosm.data_manager.get_osm_data
    cpdef get_osm_data(node_arrays, way_records, relations, tags_as_columns, data_filter, filter_type, osm_keys=None):
pyrosm/data_manager.pyx:176: in pyrosm.data_manager.get_osm_data
    return _get_osm_data(node_arrays, way_records, relations, tags_as_columns, data_filter, filter_type, osm_keys)
pyrosm/data_manager.pyx:172: in pyrosm.data_manager._get_osm_data
    ways, relation_ways, filtered_relations = get_osm_ways_and_relations(way_records, relations, osm_keys, tags_as_columns, data_filter, filter_type)
pyrosm/data_manager.pyx:115: in pyrosm.data_manager.get_osm_ways_and_relations
    filtered_relations = get_relation_arrays(relations, osm_keys, data_filter, filter_type)
pyrosm/data_manager.pyx:48: in pyrosm.data_manager.get_relation_arrays
    indices = filter_relation_indices(relations, osm_keys, data_filter, filter_type)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   cdef int i, n = len(relations["tags"])
E   KeyError: 'tags'

pyrosm/data_filter.pyx:268: KeyError
```

The error originates from the `pyrosm` library, which attempts to access the `tags` key in relationships that do not have any tags. This is observed when using the following Osmium command to filter tags in PBF files:

```python
osmium tags-filter --overwrite -o {filtered_output_file} {osm_input_file} nwr/{query_tag}
```
For instance, filtering with `highway=motorhead` leads to the error due to some relations not having the `tags` key.

#### Testing
- **Added a unit test** that downloads a filtered PBF file from my personal repository. The unit test ensures that the fix works correctly by running the filter process on a known dataset with missing `tags` keys.

Btw Fixing #176 

Thank you for reviewing this PR!