### PR TITLE
Follow-up to #234: rename id_tag column, pin relation id dtype, add regression tests

### DIFF
--- a/pyrosm/pbfreader.pyx
+++ b/pyrosm/pbfreader.pyx
@@ -319,7 +319,7 @@ cdef parse_relations(data, string_table, unix_time_filter):
     # Version
     versions = np.array([rel.info.version for rel in data], dtype=np.int64)
 
-    ids = np.array([rel.id for rel in data])
+    ids = np.array([rel.id for rel in data], dtype=np.int64)
 
     timestamps = np.array([rel.info.timestamp for rel in data], dtype=np.int64)
 

--- a/pyrosm/tagparser.pxd
+++ b/pyrosm/tagparser.pxd
@@ -1,5 +1,5 @@
 cdef unicode tounicode(char *s)
 cdef parse_tags(keys, vals, stringtable)
 cdef parse_dense_tags(keys_vals, string_table)
-cdef explode_way_tags(ways)
+cpdef explode_way_tags(ways)
 cdef explode_tag_array(tag_array, tags_as_columns)

--- a/pyrosm/tagparser.pyx
+++ b/pyrosm/tagparser.pyx
@@ -31,7 +31,7 @@ cdef parse_dense_tags(keys_vals, string_table):
         tag_idx += 1
     return tag_list
 
-cdef explode_way_tags(ways):
+cpdef explode_way_tags(ways):
     exploded = []
     cdef int i, n=len(ways)
     way_keys = {}
@@ -39,7 +39,9 @@ cdef explode_way_tags(ways):
         way = ways[i]
         for k, v in way['tags'].items():
             if k == "id":
-                way["tagged_id"] = v
+                # An OSM tag literally keyed "id" would otherwise overwrite the
+                # element's OSM id; surface it as "id_tag" to keep both.
+                way["id_tag"] = v
             else:
                 way[k] = v
             try:

--- a/tests/test_pbf_parsing.py
+++ b/tests/test_pbf_parsing.py
@@ -137,3 +137,63 @@ def test_getting_nodes(test_pbf):
 
     # Check shape
     assert nodes.shape == (14222, 9)
+
+
+def test_relation_ids_are_not_delta_decoded(test_pbf):
+    """Regression test for #170.
+
+    Relation object ids in the PBF format are plain int64 values (only
+    DenseNodes ids and relation member references are delta-encoded). They must
+    therefore be read as-is, not cumulatively summed. The cumsum bug produced
+    inflated, monotonically increasing ids; here we assert the real OSM ids.
+    """
+    import numpy as np
+    from pyrosm import OSM
+
+    osm = OSM(filepath=test_pbf)
+    osm._read_pbf()
+    ids = osm._relations["id"]
+
+    # Ids must stay int64 (consistent with the rest of the id handling)
+    assert ids.dtype == np.int64
+
+    # Real OSM relation ids in test.osm.pbf. The old cumsum bug would instead
+    # have produced cumulative sums [32694, 352283, 2617378, 5307012, 8486578].
+    assert ids.tolist() == [32694, 319589, 2265095, 2689634, 3179566]
+
+
+def test_id_tag_does_not_overwrite_osm_id():
+    """Regression test for #233.
+
+    An OSM tag literally keyed ``id`` would otherwise overwrite the element's
+    OSM id when way tags are flattened. It must instead be surfaced under the
+    ``id_tag`` column, leaving the element ``id`` intact.
+    """
+    from pyrosm.tagparser import explode_way_tags
+
+    ways = [
+        {
+            "id": 12345,
+            "version": 1,
+            "nodes": [1, 2, 3],
+            "tags": {"building": "yes", "id": "stray-tag-value"},
+        },
+        {
+            "id": 67890,
+            "version": 1,
+            "nodes": [4, 5],
+            "tags": {"highway": "residential"},
+        },
+    ]
+
+    exploded = explode_way_tags(ways)
+
+    # The colliding 'id' tag is surfaced as 'id_tag', element id is preserved
+    assert exploded[0]["id"] == 12345
+    assert exploded[0]["id_tag"] == "stray-tag-value"
+    assert exploded[0]["building"] == "yes"
+    assert "tags" not in exploded[0]
+
+    # A way without an 'id' tag is unaffected (no spurious id_tag key)
+    assert exploded[1]["id"] == 67890
+    assert "id_tag" not in exploded[1]


### PR DESCRIPTION
Follow-up polish to the merged #234. This does not change #234's behaviour — it refines naming, restores a dtype, and locks both fixes in with regression tests.

## Changes
- **Rename `tagged_id` → `id_tag`.** #234 surfaces a colliding OSM `id` tag (a tag literally keyed `id`) under a dedicated column so it can't overwrite the element's OSM `id`. `id_tag` reads more clearly as "the value of the `id` tag" than `tagged_id`.
- **Restore `dtype=np.int64` on parsed relation ids** (`parse_relations`). #234 dropped the explicit dtype; without it a bare integer array is platform-dependent (int32 on Windows), inconsistent with the rest of the id handling.
- **Expose `explode_way_tags` as `cpdef`.** Purely to make the id-tag handling unit-testable from Python — no behaviour or performance change (`pbfreader` still `cimport`s it at the C level).

## Tests
- `test_relation_ids_are_not_delta_decoded` — relation ids are read as the real OSM ids (not the inflated cumulative-sum values the old delta-decoding bug produced) and stay `int64`. Regression guard for #170.
- `test_id_tag_does_not_overwrite_osm_id` — a way tag keyed `id` is surfaced as `id_tag` while the element `id` is preserved; a way without such a tag is unaffected. Regression guard for #233.

Full suite: 109 passed, 2 skipped locally; `black --check pyrosm` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.