### PR TITLE
Run live external downloads on a single CI runner (gist snapshot elsewhere); dedupe push/PR runs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,6 +75,11 @@ jobs:
 
       - name: Test pyrosm
         shell: bash -l {0}
+        # Exercise the live download tests (BBBike + Geofabrik) on a single
+        # runner only (see tests/test_data.py) so we don't overload those
+        # services by fetching from every OS/Python combination in the matrix.
+        env:
+          RUN_DOWNLOAD_TESTS: "${{ matrix.os == 'windows-latest' && matrix.env == 'ci/314-conda.yaml' }}"
         run: pytest -v -r s --color=yes --cov=pyrosm --cov-append --cov-report term-missing --cov-report xml tests/
 
       - name: Update codecov.io

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,9 @@
 name: test
 on:
+  # Run on pushes to the default branch and on PRs. Scoping push to master
+  # avoids the duplicate push+pull_request runs on every PR branch.
   push:
+    branches: [master]
   pull_request:
   workflow_call:
   workflow_dispatch:

--- a/pyrosm/data/__init__.py
+++ b/pyrosm/data/__init__.py
@@ -54,6 +54,18 @@ _helsinki_test_history_pbf = {
     "helsinki-test.osh.pbf",
 }
 
+# A pinned, uncropped snapshot of BBBike's UlanBator extract, hosted on a gist
+# (like the Helsinki test data above). Used by the graph-export tests so they
+# don't hit BBBike from every CI runner; the live BBBike file is still fetched
+# on a single runner as an availability check. See tests/test_graph_exports.py.
+_ulanbator_test_pbf = {
+    "name": "UlanBator-test.osm.pbf",
+    "url": "https://gist.github.com/HTenkanen/"
+    "cebaf5abdc2356b14d3538fe021609ec/"
+    "raw/5cf6f19d924108b6ea55b7e51016b56fb0618669/"
+    "UlanBator.osm.pbf",
+}
+
 
 class DataSources:
     def __init__(self):
@@ -105,6 +117,7 @@ class DataSources:
             "helsinki_region_pbf",
             "helsinki_history_pbf",
             "helsinki_test_history_pbf",
+            "ulanbator_test_pbf",
         ]
         self._all_sources = list(set(self._all_sources))
 
@@ -114,7 +127,12 @@ sources = DataSources()
 
 available = {
     "test_data": list(_package_files.keys())
-    + ["helsinki_region_pbf", "helsinki_history_pbf", "helsinki_test_history_pbf"],
+    + [
+        "helsinki_region_pbf",
+        "helsinki_history_pbf",
+        "helsinki_test_history_pbf",
+        "ulanbator_test_pbf",
+    ],
     "regions": {
         k: v for k, v in sources.available.items() if k not in ["cities", "subregions"]
     },
@@ -179,6 +197,9 @@ def get_data(dataset, update=False, directory=None):
 
     elif dataset == "helsinki_test_history_pbf":
         return retrieve(_helsinki_test_history_pbf, update, directory)
+
+    elif dataset == "ulanbator_test_pbf":
+        return retrieve(_ulanbator_test_pbf, update, directory)
 
     elif dataset in sources._all_sources:
         return retrieve(search_source(dataset), update, directory)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,6 +1,19 @@
 import pytest
 from pyrosm import get_data
 import sys
+import os
+
+# The download tests fetch real extracts from external services (BBBike and
+# Geofabrik). To avoid overloading those services from every OS/Python
+# combination in the CI matrix (and to stop a transient outage from reddening
+# unrelated jobs), download availability is exercised on a single runner only:
+# the workflow sets RUN_DOWNLOAD_TESTS=true for the windows-latest + Python 3.14
+# job. Elsewhere these tests skip. Set RUN_DOWNLOAD_TESTS=true to run locally.
+run_downloads_only_once = pytest.mark.skipif(
+    os.environ.get("RUN_DOWNLOAD_TESTS") != "true",
+    reason="Live download tests run on a single CI runner "
+    "(windows-latest + Python 3.14); set RUN_DOWNLOAD_TESTS=true to run locally.",
+)
 
 
 def get_source_url(name):
@@ -94,6 +107,7 @@ def test_test_data():
     assert os.path.exists(fp5)
 
 
+@run_downloads_only_once
 def test_geofabrik_download_to_temp():
     from pyrosm import get_data
     import os
@@ -102,6 +116,7 @@ def test_geofabrik_download_to_temp():
     assert os.path.exists(fp)
 
 
+@run_downloads_only_once
 def test_bbbike_download_to_temp():
     from pyrosm import get_data
     import os
@@ -110,6 +125,7 @@ def test_bbbike_download_to_temp():
     assert os.path.exists(fp)
 
 
+@run_downloads_only_once
 def test_geofabrik_download_to_directory():
     from pyrosm import get_data
     import os
@@ -118,6 +134,7 @@ def test_geofabrik_download_to_directory():
     assert os.path.exists(fp)
 
 
+@run_downloads_only_once
 def test_geofabrik_download_to_directory(directory):
     from pyrosm import get_data
     import os
@@ -126,6 +143,7 @@ def test_geofabrik_download_to_directory(directory):
     assert os.path.exists(fp)
 
 
+@run_downloads_only_once
 def test_bbbike_download_to_directory(directory):
     from pyrosm import get_data
     import os

--- a/tests/test_graph_exports.py
+++ b/tests/test_graph_exports.py
@@ -1,7 +1,25 @@
+import os
 import sys
 import pytest
 from pyrosm import get_data
 from pyrosm.config import Conf
+
+
+def _ulanbator_pbf():
+    """Path to the UlanBator test network.
+
+    On the single CI canary runner (``RUN_DOWNLOAD_TESTS=true``) the live
+    BBBike extract is fetched, so we notice if BBBike breaks. Everywhere else
+    (and locally) a pinned, uncropped snapshot hosted on a gist is used --
+    reliable, fast, and friendly to BBBike's small server. The data must stay
+    uncropped: the export tests assert ``ecount == 2 * n_edges`` and
+    ``vcount == n_nodes``, which only hold when no boundary nodes/edges are
+    dropped.
+    """
+    if os.environ.get("RUN_DOWNLOAD_TESTS") == "true":
+        return get_data("ulanbator")
+    return get_data("ulanbator_test_pbf")
+
 
 # pandana's compiled cyaccess uses C `long` buffers. On Windows C `long` is
 # 32-bit, but NumPy 2 makes the default integer int64 ("long long"), so pandana
@@ -36,7 +54,7 @@ def walk_nodes_and_edges():
 
     # UlanBator is good small dataset for testing
     # (unmodified, i.e. not cropped)
-    pbf_path = get_data("ulanbator")
+    pbf_path = _ulanbator_pbf()
     osm = OSM(pbf_path)
     return osm.get_network(nodes=True)
 
@@ -47,7 +65,7 @@ def bike_nodes_and_edges():
 
     # UlanBator is good small dataset for testing
     # (unmodified, i.e. not cropped)
-    pbf_path = get_data("ulanbator")
+    pbf_path = _ulanbator_pbf()
     osm = OSM(pbf_path)
     return osm.get_network(nodes=True, network_type="cycling")
 
@@ -56,7 +74,7 @@ def bike_nodes_and_edges():
 def driving_nodes_and_edges():
     from pyrosm import OSM
 
-    pbf_path = get_data("ulanbator")
+    pbf_path = _ulanbator_pbf()
     osm = OSM(pbf_path)
     return osm.get_network(network_type="driving", nodes=True)
 


### PR DESCRIPTION
## Problem

The `tests/test_data.py` and `tests/test_graph_exports.py` tests fetch real extracts from external services (BBBike's `download.bbbike.org`, Geofabrik) on **every** OS × Python combination — ~15 jobs per CI run. This:

- overloads those services (BBBike especially is a small community server) — effectively a mini-DoS on every push;
- makes CI flaky: a transient BBBike hiccup reds unrelated jobs (recently *every* macOS job was failing purely on a BBBike connection timeout, while everything else passed);
- and the workflow triggered duplicate `push` + `pull_request` runs on every PR branch.

## Changes

**1. Graph-export tests use a pinned, gist-hosted UlanBator snapshot.**
These tests require *uncropped* data — the assertions `ecount == 2 * n_edges` and `vcount == n_nodes` only hold when no boundary nodes/edges are dropped, so the bundled (cropped) `Helsinki`/`test` extracts can't be substituted. Instead, a new `ulanbator_test_pbf` data source points at a pinned, uncropped UlanBator snapshot hosted on a gist (same pattern as the existing Helsinki test data — kept off the PyPI wheel). The graph fixtures use this snapshot on every runner, so graph-export coverage is unchanged across the matrix, with **zero BBBike load**.

**2. Live external downloads run on a single canary runner only.**
A `RUN_DOWNLOAD_TESTS` env var is set (by the workflow) for exactly one job — `windows-latest` + `ci/314-conda.yaml`. On that job:
- the BBBike/Geofabrik *availability* tests in `test_data.py` run (they skip everywhere else), and
- the graph fixtures fetch the **live** BBBike file instead of the snapshot,

so we still notice if BBBike breaks or its data shifts. Everywhere else (and in local `pytest`) these download paths are skipped; set `RUN_DOWNLOAD_TESTS=true` to exercise them locally.

**3. `push` CI trigger scoped to `master`.**
PR branches no longer get duplicate `push` + `pull_request` runs; `master` still runs on push after merge.

## Effect

- macOS jobs go green (they were failing only on the BBBike download).
- BBBike/Geofabrik are hit by 1 job per run instead of ~15.
- Full graph-export coverage retained on all runners (via the snapshot), unlike a blanket skip.
- No more duplicate CI runs per PR.

## Verification (local)

- Full suite: **105 passed, 6 skipped** on the normal-runner path (4 download-availability tests + 2 pre-existing `sources` skips); graph-export tests pass on the gist snapshot.
- `black --check pyrosm` clean; workflow YAML parses; the `RUN_DOWNLOAD_TESTS` gate is `true` for exactly one matrix combination.

## Note

Pre-existing and left untouched: `test_geofabrik_download_to_directory` is defined twice (the no-arg version is silently shadowed) — a candidate for a separate small cleanup.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.