### PR TITLE
Support combining custom_filter True + explicit values (supersedes #226, fixes #224)

### DIFF
--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -98,6 +98,14 @@ cdef filter_osm_records(data_records,
             data_filter = None
 
     if data_filter is not None:
+        # A bare True value ({osm_key: True}) means "match any value for this
+        # key". Normalize it to [True] so the membership checks below and the
+        # Solver can treat every filter value as an iterable, rather than
+        # choking on a non-iterable bool (TypeError on `True in True`).
+        data_filter = {
+            k: [True] if v is True else v for k, v in data_filter.items()
+        }
+
         # Check if there are duplicate filter values
         # e.g. a situation where {"route": "tram"} and {"railway": "tram"}
         # filters are present simultaneously.

--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -16,14 +16,12 @@ class Solver:
             raise ValueError("filter type should be 'keep' or 'exclude'")
 
     def isin_check(self, value, container):
-        if value in container:
+        if True in container or value in container:
             return True
         return False
 
     def notin_check(self, value, container):
-        if value not in container:
-            return True
-        return False
+        return not self.isin_check(value, container)
 
     def check(self, value, container):
         return self.solver(value, container)
@@ -105,27 +103,19 @@ cdef filter_osm_records(data_records,
         # filters are present simultaneously.
         overlapping_filter = False
 
-        filter_values = []
-        way_filter = {}
-        for key, vals in data_filter.items():
-
-            # Check for {osm-key: True} cases
-            if vals is True or vals == [True]:
-                continue
-
-            filter_values += vals
-            way_filter[key] = vals
-
-        # Update data filter
-        if len(way_filter) == 0:
-            data_filter = None
-        else:
-            data_filter = {k: v for k, v in way_filter.items()}
-            filter_keys = list(data_filter.keys())
-
         # Check for overlapping filter
-        if len(filter_values) > len(list(set(filter_values))):
-            overlapping_filter = True
+        filter_values = []
+        filter_keys = data_filter.keys()
+        for values in data_filter.values():
+            # Check for {osm-key: True} cases, for which should always check all tag key/values
+            if True in values:
+                overlapping_filter = True
+                break
+            
+            filter_values += values
+
+        if not overlapping_filter and len(filter_values) > len(list(set(filter_values))):
+                overlapping_filter = True
 
     relation_check = False
     if relation_way_ids is not None:

--- a/tests/test_custom_filter.py
+++ b/tests/test_custom_filter.py
@@ -443,6 +443,12 @@ def test_custom_filters_with_custom_keys(helsinki_region_pbf):
     assert isinstance(filtered, GeoDataFrame)
     assert len(filtered) == 5542
 
+    # Test combination of True and specific value
+    gdf = osm.get_data_by_custom_criteria(
+        custom_filter={"building": True, "railway": ["station"]}
+    )
+    assert gdf.shape == (176742, 49)
+
     # Test a more complicated query
     # -----------------------------
 

--- a/tests/test_custom_filter.py
+++ b/tests/test_custom_filter.py
@@ -443,12 +443,18 @@ def test_custom_filters_with_custom_keys(helsinki_region_pbf):
     assert isinstance(filtered, GeoDataFrame)
     assert len(filtered) == 5542
 
-    # Test combination of True and specific value
+    # Combining a True ("any value") filter with an explicit-value filter
+    # should keep all buildings AND railway=station features (issue #224).
     gdf = osm.get_data_by_custom_criteria(
         custom_filter={"building": True, "railway": ["station"]},
         filter_type="keep",
     )
-    assert gdf.shape == (176742, 49)
+    # Assert on row/content counts (stable), not the column count: the latter
+    # can be polluted by extra_attributes leaking into the shared config when
+    # other tests run first.
+    assert len(gdf) == 176742
+    assert gdf["building"].notna().sum() == 176675
+    assert (gdf["railway"] == "station").sum() == 67
 
     # Test a more complicated query
     # -----------------------------

--- a/tests/test_custom_filter.py
+++ b/tests/test_custom_filter.py
@@ -445,7 +445,8 @@ def test_custom_filters_with_custom_keys(helsinki_region_pbf):
 
     # Test combination of True and specific value
     gdf = osm.get_data_by_custom_criteria(
-        custom_filter={"building": True, "railway": ["station"]}
+        custom_filter={"building": True, "railway": ["station"]},
+        filter_type="keep",
     )
     assert gdf.shape == (176742, 49)
 


### PR DESCRIPTION
Supersedes #226 — adopts @mattijsdp's fix for combining a `True` filter with explicit values (#224), with a bug fix and a hardened test. His original commits are preserved here; this PR adds one commit on top.

## What #224/#226 fixes
`custom_filter={"building": True, "railway": ["station"]}` (a `{key: True}` "any value" filter combined with an explicit-value filter) now correctly keeps **both** all buildings and `railway=station` features.

## The bug I fixed on top
#226 as submitted assumed every `custom_filter` value is iterable. A bare `{osm_key: True}` arrives as a raw `bool`, so `True in values` (and the per-record `Solver`) raised:
```
TypeError: argument of type 'bool' is not iterable
```
This broke `get_osm_data({"building": True})` and the `test_building_parsing` tests (the high-level `get_buildings`/`get_natural`/`get_landuse` were unaffected — they pre-normalize to `[True]`). Fix: normalize a bare `True` → `[True]` once at the top of `filter_osm_records`, so the overlap check and the `Solver` treat every value uniformly.

## Test hardening
The added test asserted an exact `gdf.shape == (176742, 49)`. The **column** count is fragile — it shifts to 50 when another test's `extra_attributes` leaks into the shared config (a pre-existing global-state issue, worth a separate fix). Reworked it to assert the stable row/content counts instead: 176742 rows = 176675 buildings + 67 `railway=station`.

## Verification (local, micromamba env)
- Full suite: **105 passed, 6 skipped, 0 failed** — deterministic in the full-suite ordering that previously failed.
- `test_custom_filter.py` passes both in isolation and in the full suite.
- `black --check pyrosm` clean.

Closes #224. Please close #226 in favour of this.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.