### PR TITLE
Stop get_* methods from mutating the shared default-tag config

### DIFF
--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -236,7 +236,7 @@ class OSM:
         """
         # Get filter
         network_filter = self._get_network_filter(network_type)
-        tags_as_columns = self.conf.tags.highway
+        tags_as_columns = list(self.conf.tags.highway)
 
         if extra_attributes is not None:
             validate_tags_as_columns(extra_attributes)
@@ -308,7 +308,7 @@ class OSM:
 
         """
         # Default tags to keep as columns
-        tags_as_columns = self.conf.tags.building
+        tags_as_columns = list(self.conf.tags.building)
 
         if extra_attributes is not None:
             validate_tags_as_columns(extra_attributes)
@@ -373,7 +373,7 @@ class OSM:
         self._read_pbf(timestamp)
 
         # Default tags to keep as columns
-        tags_as_columns = self.conf.tags.landuse
+        tags_as_columns = list(self.conf.tags.landuse)
 
         if extra_attributes is not None:
             validate_tags_as_columns(extra_attributes)
@@ -437,7 +437,7 @@ class OSM:
         self._read_pbf(timestamp)
 
         # Default tags to keep as columns
-        tags_as_columns = self.conf.tags.natural
+        tags_as_columns = list(self.conf.tags.natural)
 
         if extra_attributes is not None:
             validate_tags_as_columns(extra_attributes)
@@ -520,7 +520,7 @@ class OSM:
         self._read_pbf(timestamp)
 
         # Default tags to keep as columns
-        tags_as_columns = self.conf.tags.boundary
+        tags_as_columns = list(self.conf.tags.boundary)
 
         if extra_attributes is not None:
             validate_tags_as_columns(extra_attributes)

--- a/tests/test_boundary_parsing.py
+++ b/tests/test_boundary_parsing.py
@@ -120,8 +120,11 @@ def test_reading_all_boundaries(helsinki_region_pbf):
     osm = OSM(helsinki_region_pbf)
     gdf = osm.get_boundaries(boundary_type="all")
 
-    # Test shape
-    assert gdf.shape == (733, 21)
+    # Test shape. This previously asserted 21 columns, but that count was
+    # inflated by a bug: test_adding_extra_attribute (above) leaked its extra
+    # column into the shared Conf.tags.boundary list, and it bled into this
+    # test. With the config-mutation fix the correct, isolated count is 20.
+    assert gdf.shape == (733, 20)
 
     required_columns = [
         "name",

--- a/tests/test_config_isolation.py
+++ b/tests/test_config_isolation.py
@@ -1,0 +1,31 @@
+def test_get_methods_do_not_mutate_shared_tag_config():
+    """Regression test: get_* must not mutate the shared Conf default-tag lists.
+
+    The feature methods used to assign ``tags_as_columns = self.conf.tags.<x>``
+    (a reference to the shared default list) and then extend it in place --
+    directly via ``+= extra_attributes`` and downstream via the ``+=`` in
+    ``data_manager``/``networks``. As a result the default columns leaked and
+    accumulated across calls within a single process (e.g. ``id``/``nodes``/
+    ``timestamp``/``version`` were appended on every call, and any
+    ``extra_attributes`` stuck permanently).
+    """
+    from pyrosm import OSM, get_data
+    from pyrosm.config import Conf
+
+    osm = OSM(get_data("test_pbf"))
+
+    building_before = list(Conf.tags.building)
+    highway_before = list(Conf.tags.highway)
+    natural_before = list(Conf.tags.natural)
+
+    # Plain calls (would leak id/nodes/timestamp/version via the downstream +=)
+    osm.get_buildings()
+    osm.get_network()
+    osm.get_natural()
+    # extra_attributes (would leak the custom attribute permanently)
+    osm.get_buildings(extra_attributes=["my_extra_attr"])
+
+    assert Conf.tags.building == building_before
+    assert Conf.tags.highway == highway_before
+    assert Conf.tags.natural == natural_before
+    assert "my_extra_attr" not in Conf.tags.building


### PR DESCRIPTION
## Problem

The feature methods take a **reference** to a shared default-column list and then **mutate it in place**, so columns leak into the global config and accumulate for the rest of the process:

```python
tags_as_columns = self.conf.tags.building   # reference to the shared list
tags_as_columns += extra_attributes          # in-place mutation of the shared list
```

There are two leak vectors, both the same root cause:
- `+= extra_attributes` in `pyrosm.py` (when extras are passed), and
- the downstream `tags_as_columns += [...]` in `data_manager`/`networks`, which runs on **every** call.

Demonstration:
```
Conf.tags.building length BEFORE: 38
after get_buildings():            42     # leaked id/nodes/timestamp/version
after get_buildings() again:      46     # accumulates every call
after get_buildings(extra_attributes=["x"]): "x" is now permanently in Conf.tags.building
```

**User impact:** `osm.get_buildings(extra_attributes=["x"])` followed by a plain `osm.get_buildings()` still returns the `x` column; default columns accumulate across calls (worst in notebooks / long-running processes).

## Fix

Copy the config list at the source — `tags_as_columns = list(self.conf.tags.<x>)` — in `get_network`, `get_buildings`, `get_landuse`, `get_natural`, and `get_boundaries`. Every in-place extension then operates on a fresh per-call list, never the shared config. (Pure Python; no Cython rebuild.)

## Tests

- New `tests/test_config_isolation.py`: asserts the shared `Conf.tags.*` lists are unchanged after `get_buildings`/`get_network`/`get_natural`, including an `extra_attributes` call.
- Corrected `test_reading_all_boundaries`: it asserted `(733, 21)`, but that count was **inflated by this very bug** — `test_adding_extra_attribute` leaked its extra column into `Conf.tags.boundary`, which bled into the later test (a nice illustration of the leak). The correct, isolated count is `(733, 20)`.

## Verification (local)

Full suite **106 passed, 6 skipped, 0 failed**; the boundary tests are now deterministic in isolation; `black --check pyrosm` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.