### PR TITLE
Remove dead duplicate test_geofabrik_download_to_directory

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -126,15 +126,6 @@ def test_bbbike_download_to_temp():
 
 
 @run_downloads_only_once
-def test_geofabrik_download_to_directory():
-    from pyrosm import get_data
-    import os
-
-    fp = get_data("monaco", update=True)
-    assert os.path.exists(fp)
-
-
-@run_downloads_only_once
 def test_geofabrik_download_to_directory(directory):
     from pyrosm import get_data
     import os


### PR DESCRIPTION
`test_geofabrik_download_to_directory` was defined **twice** in `tests/test_data.py`:
- a no-arg version (just a copy of the download-to-temp case), immediately followed by
- the real `(directory)` version.

In Python a second `def` with the same name **replaces** the first, so the no-arg version was dead code — never collected or run by pytest. This removes it; the real download-to-directory test is unchanged.

No behavior change (the dead copy never executed). Verified: the name now resolves to a single collected test, and the full suite is **105 passed, 6 skipped**.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.