### PR TITLE
Fix Read the Docs build: modernize config, drop pyrosm compile

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-    os: ubuntu-20.04
+    os: ubuntu-24.04
     tools:
-        python: "3.10"
+        python: "3.12"
 
 python:
     install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,13 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-# sys.path.insert(0, os.path.abspath(".."))
-# sys.path.append(os.path.join(os.path.dirname(__name__), ".."))
+import os
+import sys
+
+# Make the pyrosm source importable for autodoc without installing/compiling
+# the package. The compiled Cython modules are mocked below, so autodoc reads
+# docstrings straight from the pure-Python wrappers in the repo.
+sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
 
@@ -20,7 +25,7 @@ copyright = "2020, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.6.0"
+version = release = "0.6.2"
 
 # -- General configuration ---------------------------------------------------
 
@@ -36,6 +41,24 @@ extensions = [
     "IPython.sphinxext.ipython_console_highlighting",
     "IPython.sphinxext.ipython_directive",
     "myst_nb",
+]
+
+# pyrosm is not installed for the docs build; mock its compiled Cython
+# extensions (and binary deps) so autodoc can import the pure-Python wrappers
+# and read their docstrings without compiling anything.
+autodoc_mock_imports = [
+    "pyrosm._arrays",
+    "pyrosm.data_filter",
+    "pyrosm.data_manager",
+    "pyrosm.delta_compression",
+    "pyrosm.frames",
+    "pyrosm.geometry",
+    "pyrosm.graph_export",
+    "pyrosm.pbfreader",
+    "pyrosm.relations",
+    "pyrosm.tagparser",
+    "pyrosm_proto",
+    "cykhash",
 ]
 
 
@@ -97,11 +120,6 @@ master_doc = "index"
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
-# Allow errors
-execution_allow_errors = True
-
-# Do not execute cells
-jupyter_execute_notebooks = "off"
-
-# Allow myst admonition style
-myst_admonition_enable = True
+# Render notebooks from their stored outputs; never execute them at build time.
+nb_execution_mode = "off"
+nb_execution_allow_errors = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,23 +1,23 @@
-ipycache
-ipykernel
-ipyleaflet
-ipython
-ipython-genutils
-ipywidgets
-jupyter-book>=0.7.0b
-myst-nb
-myst-parser
-nbsphinx
-numpydoc
-pyrosm
-Sphinx
-sphinx-book-theme
-sphinx-togglebutton
-sphinx_copybutton
-sphinxcontrib-applehelp
-sphinxcontrib-devhelp
-sphinxcontrib-htmlhelp
-sphinxcontrib-jsmath
-sphinxcontrib-qthelp
-sphinxcontrib-serializinghtml
-sphinxcontrib.bibtex
+# Documentation toolchain for Read the Docs (Sphinx + MyST-NB).
+#
+# Notebooks are rendered from their stored outputs (execution is disabled in
+# conf.py), so the doc build does NOT run pyrosm and does NOT need the compiled
+# package. The only consumer of pyrosm is the autodoc API reference, whose
+# compiled Cython modules are mocked via autodoc_mock_imports in conf.py.
+# Hence pyrosm itself is intentionally NOT installed here (no from-source
+# compilation, no pyrobuf, no build toolchain required).
+
+# Sphinx + MyST-NB Markdown/notebook rendering
+myst-nb>=1.0,<2.0
+sphinx>=7.0,<9.0
+sphinx-book-theme>=1.1,<2.0
+
+# Provides the ipython_console_highlighting and ipython_directive Sphinx
+# extensions referenced in conf.py.
+ipython>=8.0
+
+# Pure-Python runtime imports pulled in when autodoc imports the pyrosm
+# wrappers (the compiled modules are mocked, these are not).
+pandas
+geopandas
+shapely>=2.0


### PR DESCRIPTION
## Problem

The Read the Docs build was failing. The RTD configuration had not been touched since 2022 and had rotted on several axes:

- **Deprecated build image** — `build.os: ubuntu-20.04` is deprecated on Read the Docs.
- **pyrosm was being compiled from source.** `docs/requirements.txt` installed `pyrosm`, which is sdist-only on PyPI. Its build pulls in `pyrobuf` (also sdist-only, last released 2020), which fails under modern setuptools build isolation (`'PyrobufDistribution' has no 'dry_run'` — the same reason CI builds with `--no-build-isolation` against conda-provided deps). RTD's default `pip install -r` uses build isolation, so the dependency step died before Sphinx ran.
- **Stale toolchain** — unpinned `jupyter-book` + `nbsphinx` + bare `Sphinx` pulling mutually incompatible versions, plus the dead `ipython-genutils`.
- **Removed conf.py options** — `jupyter_execute_notebooks` (renamed to `nb_execution_mode` in myst-nb 0.14) and `myst_admonition_enable` (removed from myst-parser).

## Approach

Notebooks render from their stored outputs (`execution = off`), so pyrosm never needs to run during the build. The only consumer is the autodoc API reference. So instead of compiling pyrosm, this **mocks its compiled Cython modules** via `autodoc_mock_imports` — autodoc reads docstrings straight from the pure-Python wrappers. No pyrobuf, no compiler, no conda; just the doc toolchain plus the pure-Python deps the wrappers import.

## Changes

- **`.readthedocs.yml`** — `ubuntu-24.04` + Python `3.12`.
- **`docs/requirements.txt`** — MyST-NB toolchain only (`myst-nb`, `sphinx`, `sphinx-book-theme`, `ipython`), version-bounded; dropped `jupyter-book`, `nbsphinx`, `ipython-genutils`, `numpydoc`, `sphinxcontrib.bibtex` (unused) and `pyrosm` itself; added `pandas`/`geopandas`/`shapely` (imported by the wrappers).
- **`docs/conf.py`** — add repo root to `sys.path` + `autodoc_mock_imports` for the 10 compiled modules (plus `pyrosm_proto`, `cykhash`); rename `jupyter_execute_notebooks` → `nb_execution_mode` and `execution_allow_errors` → `nb_execution_allow_errors`; drop `myst_admonition_enable`; sync documented version `0.6.0` → `0.6.2`.

## Validation

Built the docs locally in a clean, pyrosm-free venv with the compiled `.so` moved aside (replicating a fresh RTD checkout where the mocks engage), against Sphinx 8.2 / myst-nb 1.4 / sphinx-book-theme 1.2:

- build succeeded — mocks engaged, nothing compiled
- API reference page fully rendered (`OSM` + 8 methods + `get_data`)
- notebooks rendered from stored outputs
- zero warnings introduced by these changes; the remaining 33 build warnings are pre-existing content issues (broken MyST cross-refs in notebooks, a `.. benchmarking` toctree typo, docutils emphasis nits), which RTD does not fail on

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
