### PR TITLE
Make cycling networks directed + honour oneway:bicycle (supersedes #174, #178)

### DIFF
--- a/pyrosm/config/default_tags.py
+++ b/pyrosm/config/default_tags.py
@@ -65,6 +65,7 @@ highway_columns = [
     "motor_vehicle",
     "name",
     "oneway",
+    "oneway:bicycle",
     "overtaking",
     "path",
     "passing_places",

--- a/pyrosm/graph_export.pxd
+++ b/pyrosm/graph_export.pxd
@@ -1,5 +1,5 @@
 cpdef _create_igraph(nodes, edges, from_id_col, to_id_col, node_id_col)
 cpdef _create_nxgraph(nodes, edges, from_id_col, to_id_col, node_id_col)
 cpdef _create_pdgraph(nodes, edges, from_id_col, to_id_col, weight_cols)
-cpdef generate_directed_edges(edges, direction, from_id_col, to_id_col, force_bidirectional)
+cpdef generate_directed_edges(edges, direction, direction_suffix, from_id_col, to_id_col, force_bidirectional)
 

--- a/pyrosm/graph_export.pyx
+++ b/pyrosm/graph_export.pyx
@@ -188,13 +188,19 @@ cpdef _create_pdgraph(nodes,
 
 cpdef generate_directed_edges(edges,
                               direction,
+                              direction_suffix,
                               from_id_col,
                               to_id_col,
                               force_bidirectional):
     """
-    Generates directed set of edges from network 
+    Generates directed set of edges from network
     following rules specified in 'direction' column.
-    
+
+    If 'direction_suffix' is given, the "<direction>:<direction_suffix>" column
+    (e.g. "oneway:bicycle") overrides the base direction per edge wherever it is
+    set. This allows mode-specific exceptions such as contraflow cycling
+    (oneway=yes + oneway:bicycle=no -> two-way for bikes).
+
     If 'force_bidirectional=True' travel to both direction is allowed for all edges.
     """
     if force_bidirectional:
@@ -209,16 +215,21 @@ cpdef generate_directed_edges(edges,
     # Directed edges according 'oneway' rules
     # ========================================
 
-    if "junction" in edges.columns:
-        roundabouts = True
-    else:
-        roundabouts = False
+    # Effective per-edge direction: a "<direction>:<direction_suffix>" override
+    # column (e.g. "oneway:bicycle") takes precedence where it is set, otherwise
+    # the base direction is used.
+    effective_direction = edges[direction]
+    if direction_suffix:
+        override_col = direction + ":" + direction_suffix
+        if override_col in edges.columns:
+            override = edges[override_col]
+            effective_direction = override.where(override.notna(), effective_direction)
 
-    if roundabouts:
+    if "junction" in edges.columns:
         # Edge is oneway if it is tagged as such OR if it tagged as roundabout
-        oneway_mask = (edges[direction].isin(oneway_values)) | (edges["junction"] == "roundabout")
+        oneway_mask = (effective_direction.isin(oneway_values)) | (edges["junction"] == "roundabout")
     else:
-        oneway_mask = edges[direction].isin(oneway_values)
+        oneway_mask = effective_direction.isin(oneway_values)
 
     edge_cnt = len(edges)
     oneway_edges = edges.loc[oneway_mask].copy()
@@ -226,8 +237,8 @@ cpdef generate_directed_edges(edges,
     twoway_edges_dir2 = twoway_edges.copy(deep=True).rename(columns={to_id_col: from_id_col, from_id_col: to_id_col})
     twoway_edges_dir2.index = np.arange(edge_cnt, edge_cnt + len(twoway_edges))
 
-    # Select edges that are allowed only to opposite direction
-    against_mask = oneway_edges[direction].isin(["-1", "T"])
+    # Select edges that are allowed only to opposite direction (per effective direction)
+    against_mask = effective_direction.loc[oneway_edges.index].isin(["-1", "T"])
     against_edges = oneway_edges.loc[against_mask].copy()
     along_edges = oneway_edges.loc[~against_mask].copy()  # Nothing needs to be done for these
 

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -33,6 +33,13 @@ def get_directed_edges(
                 "Required column '{col}' does not exist in edges.".format(col=col)
             )
 
+    # A direction may be given as "<base>:<suffix>" (e.g. "oneway:bicycle"); the
+    # suffix column overrides the base direction per edge. Split it off here so
+    # the base column is what gets validated below.
+    direction_suffix = None
+    if ":" in direction:
+        direction, direction_suffix = direction.split(":", 1)
+
     if direction not in edges.columns:
         warnings.warn(
             f"Column '{direction}' missing in the edges GeoDataFrame. "
@@ -66,19 +73,35 @@ def get_directed_edges(
                 "Possible network types are: " + txt
             )
 
+    # Cycling honours bicycle-specific direction tags (oneway:bicycle) so that
+    # contraflow cycling on one-way streets is modelled correctly.
+    if direction_suffix is None and net_type == "cycling":
+        direction_suffix = "bicycle"
+
     edges = edges.copy()
     nodes = nodes.copy()
 
-    # Generate directed edges
-    # Check if user wants to force bidirectional graph
-    # or if the graph is walking, cycling or all
-    if force_bidirectional or net_type in ["walking", "cycling", "all"]:
+    # Generate directed edges.
+    # Walking and "all" are bidirectional by default; driving and cycling are
+    # directed (they honour oneway, and cycling additionally honours
+    # oneway:bicycle). force_bidirectional overrides this for any type.
+    if force_bidirectional or net_type in ["walking", "all"]:
         edges = generate_directed_edges(
-            edges, direction, from_id_col, to_id_col, force_bidirectional=True
+            edges,
+            direction,
+            direction_suffix,
+            from_id_col,
+            to_id_col,
+            force_bidirectional=True,
         )
     else:
         edges = generate_directed_edges(
-            edges, direction, from_id_col, to_id_col, force_bidirectional=False
+            edges,
+            direction,
+            direction_suffix,
+            from_id_col,
+            to_id_col,
+            force_bidirectional=False,
         )
 
     return nodes, edges
@@ -133,8 +156,9 @@ def to_networkx(
 
     network_type : str
         Network type for the given data. Determines how the graph will be constructed.
-        By default, bidirectional graph is created for walking, cycling and all,
-        and directed graph for driving (i.e. oneway streets are taken into account).
+        By default, a bidirectional graph is created for walking and all, and a
+        directed graph for driving and cycling (oneway streets are taken into
+        account; cycling additionally honours oneway:bicycle for contraflow).
         Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.
 
     retain_all : bool
@@ -234,8 +258,9 @@ def to_igraph(
 
     network_type : str
         Network type for the given data. Determines how the graph will be constructed.
-        By default, bidirectional graph is created for walking, cycling and all,
-        and directed graph for driving (i.e. oneway streets are taken into account).
+        By default, a bidirectional graph is created for walking and all, and a
+        directed graph for driving and cycling (oneway streets are taken into
+        account; cycling additionally honours oneway:bicycle for contraflow).
         Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.
 
     retain_all : bool

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -809,10 +809,12 @@ class OSM:
           - "networkx",
           - "pandana"
 
-        For walking and cycling, the output graph will be bidirectional by default
-        (i.e. travel along the street is allowed to both directions). For driving,
-        one-way streets are taken into account by default and the travel is restricted
-        based on the rules in OSM data (based on "oneway" attribute).
+        For walking, the output graph will be bidirectional by default
+        (i.e. travel along the street is allowed to both directions). For driving
+        and cycling, one-way streets are taken into account by default and the
+        travel is restricted based on the rules in OSM data (the "oneway"
+        attribute; cycling additionally honours "oneway:bicycle" so that
+        contraflow cycling on one-way streets is modelled correctly).
 
         Parameters
         ----------
@@ -852,8 +854,9 @@ class OSM:
             Network type for the given data. Determines how the graph will be constructed.
             The network type is typically extracted automatically from the metadata of
             the edges/nodes GeoDataFrames. This parameter can be used if this metadata is not
-            available for a reason or another. By default, bidirectional graph is created for walking, cycling and all,
-            and directed graph for driving (i.e. oneway streets are taken into account).
+            available for a reason or another. By default, a bidirectional graph is created for walking and all,
+            and a directed graph for driving and cycling (oneway streets are taken into account;
+            cycling additionally honours oneway:bicycle for contraflow).
             Possible values are: 'walking', 'cycling', 'driving', 'driving+service', 'all'.
 
         retain_all : bool

--- a/tests/test_graph_exports.py
+++ b/tests/test_graph_exports.py
@@ -137,10 +137,11 @@ def test_igraph_export_by_cycling(bike_nodes_and_edges):
 
     assert isinstance(g, igraph.Graph)
 
-    # In case of walking/cycling there should be 2x the num of edges
-    # as in the orig gdf (one edge for each direction)
-    # --> assuming the data has not been cropped (which might drop nodes/edges)
-    assert g.ecount() == 2 * n_edges
+    # Cycling is now directed (it honours oneway / oneway:bicycle). Two-way edges
+    # are still duplicated (one per direction) but one-way cycleways/streets are
+    # not, so the directed edge count is strictly between n_edges and 2*n_edges
+    # (assuming the data is uncropped and contains a mix of one-way and two-way).
+    assert n_edges < g.ecount() < 2 * n_edges
 
     # The number of nodes should be the same
     assert g.vcount() == n_nodes
@@ -303,6 +304,7 @@ def test_directed_edge_generator(test_pbf):
     bidir_edges = generate_directed_edges(
         edges,
         direction="oneway",
+        direction_suffix=None,
         from_id_col="u",
         to_id_col="v",
         force_bidirectional=True,
@@ -314,6 +316,7 @@ def test_directed_edge_generator(test_pbf):
     dir_edges = generate_directed_edges(
         edges,
         direction="oneway",
+        direction_suffix=None,
         from_id_col="u",
         to_id_col="v",
         force_bidirectional=False,
@@ -333,6 +336,7 @@ def test_connected_component(immutable_nodes_and_edges):
     bidir_edges = generate_directed_edges(
         edges,
         direction="oneway",
+        direction_suffix=None,
         from_id_col="u",
         to_id_col="v",
         force_bidirectional=True,
@@ -575,3 +579,109 @@ def test_nxgraph_export_from_osh(helsinki_history_pbf):
     # most likely due to float handling differences between Unix and Windows
     assert round(shortest_paths[0], 0) in [478, 470]
     assert round(shortest_paths[-1], 0) in [797, 793]
+
+
+def _edge_pairs(directed_edges, from_id_col="u", to_id_col="v"):
+    return set(zip(directed_edges[from_id_col], directed_edges[to_id_col]))
+
+
+def test_generate_directed_edges_honours_oneway_bicycle():
+    """generate_directed_edges: oneway:bicycle overrides oneway per edge.
+
+    Covers a two-way street, a one-way street, a contraflow street
+    (oneway=yes + oneway:bicycle=no -> two-way for bikes), a bike-only one-way
+    (oneway:bicycle=yes), and a reverse one-way (oneway=-1).
+    """
+    import pandas as pd
+    from pyrosm.graph_export import generate_directed_edges
+
+    edges = pd.DataFrame(
+        {
+            "u": [1, 3, 5, 7, 9],
+            "v": [2, 4, 6, 8, 10],
+            "oneway": [None, "yes", "yes", None, "-1"],
+            "oneway:bicycle": [None, None, "no", "yes", None],
+        }
+    )
+    out = generate_directed_edges(edges, "oneway", "bicycle", "u", "v", False)
+    pairs = _edge_pairs(out)
+
+    # 2 (two-way) + 1 + 2 (contraflow) + 1 + 1 = 7 directed edges
+    assert len(out) == 7
+    # two-way street -> both directions
+    assert (1, 2) in pairs and (2, 1) in pairs
+    # one-way street -> single direction
+    assert (3, 4) in pairs and (4, 3) not in pairs
+    # contraflow (oneway=yes, oneway:bicycle=no) -> both directions for bikes
+    assert (5, 6) in pairs and (6, 5) in pairs
+    # bike-only one-way (oneway:bicycle=yes) -> single direction
+    assert (7, 8) in pairs and (8, 7) not in pairs
+    # reverse one-way (oneway=-1) -> flipped
+    assert (10, 9) in pairs and (9, 10) not in pairs
+
+
+def test_generate_directed_edges_without_suffix_is_oneway_only():
+    """Without a direction_suffix the base 'oneway' column drives everything
+    (the driving path is unaffected by the oneway:bicycle change)."""
+    import pandas as pd
+    from pyrosm.graph_export import generate_directed_edges
+
+    edges = pd.DataFrame(
+        {
+            "u": [1, 3],
+            "v": [2, 4],
+            "oneway": [None, "yes"],
+            # present but must be ignored when no suffix is requested
+            "oneway:bicycle": ["no", "no"],
+        }
+    )
+    out = generate_directed_edges(edges, "oneway", None, "u", "v", False)
+    pairs = _edge_pairs(out)
+    assert len(out) == 3  # two-way + one-way
+    assert (1, 2) in pairs and (2, 1) in pairs
+    assert (3, 4) in pairs and (4, 3) not in pairs
+
+
+def _toy_network():
+    import geopandas as gpd
+    from shapely.geometry import Point, LineString
+
+    nodes = gpd.GeoDataFrame(
+        {"id": [1, 2, 3, 4]},
+        geometry=[Point(0, 0), Point(1, 0), Point(2, 0), Point(3, 0)],
+        crs="epsg:4326",
+    )
+    edges = gpd.GeoDataFrame(
+        {
+            "u": [1, 2, 3],
+            "v": [2, 3, 4],
+            "oneway": [None, "yes", "yes"],
+            "oneway:bicycle": [None, None, "no"],
+        },
+        geometry=[
+            LineString([(0, 0), (1, 0)]),
+            LineString([(1, 0), (2, 0)]),
+            LineString([(2, 0), (3, 0)]),
+        ],
+        crs="epsg:4326",
+    )
+    return nodes, edges
+
+
+def test_get_directed_edges_cycling_is_directed_with_contraflow():
+    """Cycling is directed by default and honours oneway:bicycle; walking stays
+    bidirectional."""
+    from pyrosm.graphs import get_directed_edges
+
+    # twoway + oneway + contraflow
+    nodes, edges = _toy_network()
+    _, cyc = get_directed_edges(nodes, edges, network_type="cycling")
+    pairs = _edge_pairs(cyc)
+    assert len(cyc) == 5  # 2 + 1 + 2
+    assert (2, 3) in pairs and (3, 2) not in pairs  # one-way respected
+    assert (3, 4) in pairs and (4, 3) in pairs  # contraflow both ways
+
+    # Walking ignores oneway entirely (bidirectional)
+    nodes, edges = _toy_network()
+    _, walk = get_directed_edges(nodes, edges, network_type="walking")
+    assert len(walk) == 6  # every edge both ways

--- a/tests/test_graph_exports.py
+++ b/tests/test_graph_exports.py
@@ -685,3 +685,21 @@ def test_get_directed_edges_cycling_is_directed_with_contraflow():
     nodes, edges = _toy_network()
     _, walk = get_directed_edges(nodes, edges, network_type="walking")
     assert len(walk) == 6  # every edge both ways
+
+
+def test_get_directed_edges_explicit_oneway_bicycle_direction():
+    """An explicit direction='oneway:bicycle' is split into base + override.
+
+    This exercises the "<base>:<suffix>" parsing path independently of the
+    cycling auto-default (here the network type is driving).
+    """
+    from pyrosm.graphs import get_directed_edges
+
+    nodes, edges = _toy_network()
+    _, out = get_directed_edges(
+        nodes, edges, direction="oneway:bicycle", network_type="driving"
+    )
+    pairs = _edge_pairs(out)
+    assert len(out) == 5  # twoway(2) + oneway(1) + contraflow(2)
+    assert (2, 3) in pairs and (3, 2) not in pairs  # base oneway respected
+    assert (3, 4) in pairs and (4, 3) in pairs  # oneway:bicycle=no -> both ways


### PR DESCRIPTION
Implements **@meeuw's #174 + #178 together** (and supersedes both): make cycling networks **directed** and honour **`oneway:bicycle`**.

## Why
Cycling graphs were forced *bidirectional*, so routing could travel the wrong way down a one-way cycleway. This makes cycling directed (like driving) — but crucially also honours `oneway:bicycle`, so **contraflow cycling** (a one-way street where bikes may go both ways: `oneway=yes` + `oneway:bicycle=no`, very common in NL/DK/BE/DE) stays two-way for bikes.

This is why the two PRs belong together: #174 alone would have *wrongly* one-wayed those contraflow streets, and #178 (the `oneway:bicycle` machinery) had an uninitialised-variable `NameError`. Both are fixed here. This also matches OSMnx, whose bike graph is directed + contraflow-aware by default.

## Changes
- **`default_tags`**: promote `oneway:bicycle` to a dedicated column so the override is available to the graph builder.
- **`graph_export.generate_directed_edges`**: new `direction_suffix` parameter. A `"<direction>:<suffix>"` column (e.g. `oneway:bicycle`) overrides the base direction *per edge* (an "effective direction"), used both for the one-way mask and the reverse (`-1`/`T`) handling. The no-suffix path is unchanged → **driving is unaffected**.
- **`graphs.get_directed_edges`**: drop `cycling` from the force-bidirectional set; derive the bicycle override for cycling (and accept an explicit `direction="oneway:bicycle"`); initialise `direction_suffix` so there's no `NameError` when the direction has no suffix.
- **Docstrings** updated (`to_graph`/`to_networkx`/`to_igraph`).

## Behaviour (effective direction)
| `oneway` | `oneway:bicycle` | cycling result |
|---|---|---|
| (none) | (none) | two-way |
| `yes` | (none) | one-way |
| `yes` | `no` | **two-way (contraflow)** |
| (none) | `yes` | one-way |
| `-1` | (none) | one-way, reversed |

## Tests
- Unit tests of `generate_directed_edges` covering all five rows above, plus the no-suffix (driving) path.
- An integration test that `get_directed_edges(network_type="cycling")` is directed with contraflow while `walking` stays bidirectional.
- Updated the existing cycling igraph test (directed: `n_edges < ecount < 2*n_edges`) and the `generate_directed_edges` call sites for the new signature.

Verified locally: full suite **109 passed, 6 skipped**; `black --check pyrosm` clean.

## ⚠️ Breaking change
Cycling graph exports change from **bidirectional → directed**.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.