### PR TITLE
Fix Geofabrik UK sub-region downloads (moved under united-kingdom)

### DIFF
--- a/pyrosm/data/__init__.py
+++ b/pyrosm/data/__init__.py
@@ -19,6 +19,7 @@ from pyrosm.data.geofabrik import (
     Netherlands,
     Poland,
     Russia,
+    UnitedKingdom,
     USA,
     SubRegions,
 )

--- a/pyrosm/data/geofabrik.py
+++ b/pyrosm/data/geofabrik.py
@@ -13,9 +13,9 @@ baden_wuerttemberg_url = "europe/germany/baden-wuerttemberg/"
 bayern_url = "europe/germany/bayern/"
 brazil_url = "south-america/brazil/"
 canada_url = "north-america/canada/"
-england_url = "europe/great-britain/england/"
+england_url = "europe/united-kingdom/england/"
 france_url = "europe/france/"
-gb_url = "europe/great-britain/"
+uk_url = "europe/united-kingdom/"
 germany_url = "europe/germany/"
 italy_url = "europe/italy/"
 japan_url = "asia/japan/"
@@ -240,7 +240,46 @@ class England:
         return self.available
 
 
+class UnitedKingdom:
+    regions = ["england", "scotland", "wales"]
+    england = England()
+
+    available = regions + england.available
+    available.sort()
+
+    country = {
+        "name": "united-kingdom" + suffix,
+        "url": URL + europe_url + "united-kingdom" + suffix,
+    }
+
+    # Create data sources
+    _sources = {
+        region: {
+            "name": region.replace("_", "-") + suffix,
+            "url": URL + uk_url + region.replace("_", "-") + suffix,
+        }
+        for region in regions
+    }
+
+    for region in england.available:
+        _sources[region] = {
+            "name": region.replace("_", "-") + suffix,
+            "url": URL + england_url + region.replace("_", "-") + suffix,
+        }
+
+    __dict__ = _sources
+
+    def __getattr__(self, name):
+        return self.__dict__[name]
+
+    def __call__(self):
+        return self.available
+
+
 class GreatBritain:
+    # Great Britain (England, Scotland, Wales; no Northern Ireland). Geofabrik
+    # serves these sub-regions under the "united-kingdom" path, so only the
+    # whole-region country file differs from UnitedKingdom.
     regions = ["england", "scotland", "wales"]
     england = England()
 
@@ -256,7 +295,7 @@ class GreatBritain:
     _sources = {
         region: {
             "name": region.replace("_", "-") + suffix,
-            "url": URL + gb_url + region.replace("_", "-") + suffix,
+            "url": URL + uk_url + region.replace("_", "-") + suffix,
         }
         for region in regions
     }
@@ -878,6 +917,7 @@ class Europe:
     # Country specific subregions
     france = France()
     great_britain = GreatBritain()
+    united_kingdom = UnitedKingdom()
     italy = Italy()
     russia = Russia()
     poland = Poland()
@@ -934,6 +974,7 @@ class Europe:
         "switzerland",
         "turkey",
         "ukraine",
+        "united_kingdom",
     ]
 
     available = regions
@@ -1147,6 +1188,7 @@ class SubRegions:
             "netherlands",
             "poland",
             "russia",
+            "united_kingdom",
             "usa",
         ]
         available = self.regions
@@ -1157,6 +1199,7 @@ class SubRegions:
         self.france = France()
         self.germany = Germany()
         self.great_britain = GreatBritain()
+        self.united_kingdom = UnitedKingdom()
         self.italy = Italy()
         self.japan = Japan()
         self.netherlands = Netherlands()

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -47,3 +47,25 @@ def test_frame_building_emits_no_chained_assignment_warning():
         osm.get_natural()
         osm.get_boundaries()
         osm.get_data_by_custom_criteria(custom_filter={"building": True})
+
+
+def test_uk_subregions_use_united_kingdom_path():
+    """#239 — Geofabrik moved the UK sub-regions (England, Scotland, Wales and
+    the English counties) under the 'united-kingdom' path. 'great-britain' and
+    'united-kingdom' remain distinct whole-region files (GB without vs. with
+    Northern Ireland)."""
+    from pyrosm.data import search_source
+
+    # Sub-regions now live under europe/united-kingdom/...
+    for name in ["england", "scotland", "wales", "greater_london", "merseyside"]:
+        url = search_source(name)["url"]
+        assert "united-kingdom" in url
+        assert "great-britain" not in url
+
+    # The two whole-region country files stay distinct and both valid.
+    assert search_source("united_kingdom")["url"].endswith(
+        "europe/united-kingdom-latest.osm.pbf"
+    )
+    assert search_source("great_britain")["url"].endswith(
+        "europe/great-britain-latest.osm.pbf"
+    )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -69,3 +69,11 @@ def test_uk_subregions_use_united_kingdom_path():
     assert search_source("great_britain")["url"].endswith(
         "europe/great-britain-latest.osm.pbf"
     )
+
+    # Sub-region navigation via the great_britain group still works and resolves
+    # to the united-kingdom path.
+    from pyrosm.data import sources
+
+    gb = sources.subregions.great_britain
+    assert "europe/united-kingdom/" in gb.scotland["url"]
+    assert gb() == gb.available


### PR DESCRIPTION
Fixes #239 and #243.

Geofabrik moved the UK sub-regions (England, Scotland, Wales, and the English counties) from `europe/great-britain/<region>` to `europe/united-kingdom/<region>`, so `get_data("england")` / `"scotland"` / `"wales"` and the English counties (e.g. `"merseyside"`) failed with HTTP 404.

`great-britain` and `united-kingdom` are **distinct** Geofabrik datasets, and both are kept as such here:
- `great-britain` = England + Scotland + Wales (no Northern Ireland), still served as `europe/great-britain-latest.osm.pbf`.
- `united-kingdom` = Great Britain **+ Northern Ireland** (`europe/united-kingdom-latest.osm.pbf`), and is where the sub-regions now live.

## Changes
- Sub-region URLs (England, Scotland, Wales, and all English counties) now use `europe/united-kingdom/...`.
- Added `united_kingdom` as its own region (`europe/united-kingdom-latest.osm.pbf`) in `Europe` and `SubRegions`; `great_britain` stays the GB-only country file (`europe/great-britain-latest.osm.pbf`), unchanged.
- New `UnitedKingdom` class; `GreatBritain` retained as a distinct class (own country file, sub-regions repointed) so existing `get_data("great_britain")` and `sources.*.great_britain` access keeps working.
- Regression test added to `tests/test_regressions.py`.

## Verification
- `get_data("england")` / `"scotland"` / `"wales"` and English counties (e.g. `greater_london`, `merseyside`) resolve to `europe/united-kingdom/<region>-latest.osm.pbf`.
- `get_data("great_britain")` → `europe/great-britain-latest.osm.pbf`; `get_data("united_kingdom")` → `europe/united-kingdom-latest.osm.pbf` (distinct).
- The England county list was checked against the live Geofabrik England page (`europe/united-kingdom/england.html`): 47 sub-regions, exact match (none missing, none extra).
- `black --check` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
