### PR TITLE
Fix duplicate 'phantom' nodes in _create_nxgraph (#247)

### DIFF
--- a/pyrosm/graph_export.pyx
+++ b/pyrosm/graph_export.pyx
@@ -116,11 +116,13 @@ cpdef _create_nxgraph(nodes,
     edge_attributes = edges.to_dict(orient="index")
 
     # Prepare node dictionary for fast lookups
-    node_dict = {k: None for k in nodes[node_id_col].to_list()}
+    node_ids = nodes[node_id_col].to_list()
+    node_dict = {k: None for k in node_ids}
 
-    # Node attributes
-    node_attributes = nodes.to_dict(orient="index")
-    node_attributes = [(k, v) for k, v in node_attributes.items()]
+    # Node attributes keyed by the node id (node_id_col), not the DataFrame
+    # index, so the nodes match the edge endpoints regardless of the index of
+    # the input frame (avoids duplicate "phantom" index-keyed nodes).
+    node_attributes = list(zip(node_ids, nodes.to_dict(orient="records")))
 
     # Generate edge dictionary
     for i in range(0, n_edges):

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -203,11 +203,8 @@ def to_networkx(
         edges = edges.rename(columns={edge_id_col: "osmid"})
         node_id_col = "osmid"
 
-    # Add node-id as index
-    nodes = nodes.set_index(node_id_col, drop=False)
-    nodes = nodes.rename_axis([None])
-
-    # Create NetworkX graph
+    # Create NetworkX graph (nodes are keyed by node_id_col internally, so the
+    # input frame's index does not need to be set to the node id).
     return _create_nxgraph(nodes, edges, from_id_col, to_id_col, node_id_col)
 
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -77,3 +77,43 @@ def test_uk_subregions_use_united_kingdom_path():
     gb = sources.subregions.great_britain
     assert "europe/united-kingdom/" in gb.scotland["url"]
     assert gb() == gb.available
+
+
+def test_nxgraph_keys_nodes_by_id_not_dataframe_index():
+    """#247 — _create_nxgraph must key nodes by node_id_col, not the DataFrame
+    index, so it does not create duplicate 'phantom' nodes when the input nodes
+    have a non-id index (e.g. a default RangeIndex)."""
+    import pytest
+
+    pytest.importorskip("networkx")
+    import geopandas as gpd
+    from shapely.geometry import Point, LineString
+    from pyrosm.graph_export import _create_nxgraph
+
+    # Nodes with non-sequential ids and a default RangeIndex (0, 1, 2).
+    nodes = gpd.GeoDataFrame(
+        {
+            "id": [1000, 2000, 3000],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        },
+        crs="EPSG:4326",
+    )
+    edges = gpd.GeoDataFrame(
+        {
+            "u": [1000, 2000],
+            "v": [2000, 3000],
+            "geometry": [
+                LineString([(0, 0), (1, 1)]),
+                LineString([(1, 1), (2, 2)]),
+            ],
+        },
+        crs="EPSG:4326",
+    )
+
+    graph = _create_nxgraph(nodes, edges, "u", "v", "id")
+
+    # Exactly the three real node ids, no index-keyed phantoms (0, 1, 2).
+    assert graph.number_of_nodes() == 3
+    assert sorted(graph.nodes()) == [1000, 2000, 3000]
+    # Every node carries its attributes.
+    assert all("geometry" in data for _, data in graph.nodes(data=True))


### PR DESCRIPTION
Fixes #247.

`_create_nxgraph` built the NetworkX node attributes from `nodes.to_dict(orient="index")` — keyed by the **DataFrame index** — while edges reference nodes by their `u`/`v` values (the OSM ids). When the input `nodes` frame's index is not the node id (e.g. a default `RangeIndex`), the graph ended up with 2×N nodes: N index-keyed "phantom" nodes (attributes, no edges) plus N id-keyed real nodes (edges, no attributes).

The public API (`to_networkx` / `to_graph(graph_type="networkx")`) masked this because `to_networkx` did `nodes.set_index(node_id_col, drop=False)` immediately before the call, so the index already equalled the node id. The bug surfaces when the internal `_create_nxgraph` is called directly with a non-id index (as in the issue's reproduction).

## Changes
- `pyrosm/graph_export.pyx`: key the node attributes by `node_id_col` (reusing the already-computed id list and pairing it with `to_dict(orient="records")` via `zip`), so the nodes match the edge endpoints regardless of the input frame's index.
- `pyrosm/graphs.py` (`to_networkx`): remove the now-redundant `set_index(node_id_col)` / `rename_axis` before the call.
- `tests/test_regressions.py`: regression test calling `_create_nxgraph` directly with a default `RangeIndex` and non-sequential ids; asserts exactly the three real node ids (no `0/1/2` phantoms) and that every node carries its attributes.

Only the NetworkX path is changed; `_create_igraph` / `_create_pdgraph` and their wrappers are untouched. The public-API output is unchanged (node keys were already the node id via the old `set_index`; they remain so via explicit keying).

## Verification
- Rebuilt the Cython extension; the new regression test plus the full `tests/test_graph_exports.py` suite pass (20 passed), confirming the public `to_networkx` / `to_graph` graphs are unchanged.
- `black --check` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
