### PR TITLE
Bump GitHub Actions to Node 24 (checkout v5, setup-python v6)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Install black and flake8
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v1


### PR DESCRIPTION
Updates the two GitHub Actions flagged as Node.js 20-deprecated in the CI workflow:

- `actions/checkout` v4 → v5
- `actions/setup-python` v5 → v6

Both target versions run on Node.js 24, clearing the runner deprecation warning ahead of the forced migration to Node 24 (Node 20 removed from runners on 2026-09-16). None of the workflow inputs used by these steps changed across the major bumps.

`codecov/codecov-action@v5` and `mamba-org/setup-micromamba@v1` are not Node 20-deprecated and are left unchanged.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
