### PR TITLE
Point codecov badge at pyrosm org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Conda version](https://anaconda.org/conda-forge/pyrosm/badges/version.svg)](https://anaconda.org/conda-forge/pyrosm/)
 [![PyPI version](https://badge.fury.io/py/pyrosm.svg)](https://badge.fury.io/py/pyrosm)
 [![Documentation Status](https://readthedocs.org/projects/pyrosm/badge/?version=latest)](https://pyrosm.readthedocs.io/en/latest/?badge=latest)
-[![Coverage Status](https://codecov.io/gh/HTenkanen/pyrosm/branch/master/graph/badge.svg)](https://codecov.io/gh/HTenkanen/pyrosm) 
+[![Coverage Status](https://codecov.io/gh/pyrosm/pyrosm/branch/master/graph/badge.svg)](https://codecov.io/gh/pyrosm/pyrosm) 
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/pyrosm?color=yellow&label=Downloads)](https://pypistats.org/packages/pyrosm)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4279527.svg)](https://doi.org/10.5281/zenodo.4279527)
 [![License](https://anaconda.org/conda-forge/pyrosm/badges/license.svg)](https://anaconda.org/conda-forge/pyrosm/)


### PR DESCRIPTION
The README coverage badge URL still hardcoded the old `HTenkanen/pyrosm` path from before the repo moved to the `pyrosm` org. This updates both the badge image and its link target to `codecov.io/gh/pyrosm/pyrosm`.

Verified by diffing README.md line 5: only the owner segment changed from `HTenkanen` to `pyrosm` in the `graph/badge.svg` image URL and the link href.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.