### PR TITLE
Point Zenodo DOI badge at concept DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/pyrosm/badge/?version=latest)](https://pyrosm.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://codecov.io/gh/pyrosm/pyrosm/branch/master/graph/badge.svg)](https://codecov.io/gh/pyrosm/pyrosm) 
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/pyrosm?color=yellow&label=Downloads)](https://pypistats.org/packages/pyrosm)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4279527.svg)](https://doi.org/10.5281/zenodo.4279527)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3755057.svg)](https://doi.org/10.5281/zenodo.3755057)
 [![License](https://anaconda.org/conda-forge/pyrosm/badges/license.svg)](https://anaconda.org/conda-forge/pyrosm/)
 
 


### PR DESCRIPTION
The README DOI badge pointed at the version-specific Zenodo DOI `10.5281/zenodo.4279527`, which is pinned to the v0.6.0 release (published 2020-11-18) and does not advance with new releases. This switches both the badge image and link to the record's concept DOI `10.5281/zenodo.3755057`, which always resolves to the latest version.

Verified the concept DOI via the Zenodo API for record 4279527 (`conceptdoi` field = `10.5281/zenodo.3755057`, `conceptrecid` = 3755057). Only the DOI number changed on README.md line 7.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.