### PR TITLE
Fix network exclude/keep filter leaking on multi-key filters (#108, #112)

### DIFF
--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -106,24 +106,8 @@ cdef filter_osm_records(data_records,
             k: [True] if v is True else v for k, v in data_filter.items()
         }
 
-        # Check if there are duplicate filter values
-        # e.g. a situation where {"route": "tram"} and {"railway": "tram"}
-        # filters are present simultaneously.
-        overlapping_filter = False
-
-        # Check for overlapping filter
-        filter_values = []
+        # Filter keys to test each record against.
         filter_keys = data_filter.keys()
-        for values in data_filter.values():
-            # Check for {osm-key: True} cases, for which should always check all tag key/values
-            if True in values:
-                overlapping_filter = True
-                break
-            
-            filter_values += values
-
-        if not overlapping_filter and len(filter_values) > len(list(set(filter_values))):
-                overlapping_filter = True
 
     relation_check = False
     if relation_way_ids is not None:
@@ -143,32 +127,30 @@ cdef filter_osm_records(data_records,
         if not has_osm_data_type(osm_data_type, record_keys):
             continue
 
-        # Check if should be filtered based on given data_filter
+        # Check if should be filtered based on given data_filter.
+        # Evaluate ALL filter keys present in the record (OR semantics): a record
+        # matches the filter if any present filter key's value is in that key's
+        # list. The old code broke on the first filter key in the record, so
+        # exclusions/keeps on secondary keys were skipped and depended on tag
+        # order (issues #108, #112). This mirrors the relations/nodes path
+        # (record_should_be_kept).
         if data_filter is not None:
-            filter_out = False
-            filter_was_in_record = False
-
-            for k, v in record.items():
-                if k in filter_keys:
-                    filter_was_in_record = True
-                    if solver.check(v, data_filter[k]):
-                        filter_out = True
-                        # If there are identical filter criteria used in multiple OSM-keys
-                        # Check that none of them matches, hence do not break the loop
-                        # after the first match is found.
-                        if not overlapping_filter:
-                            break
-                    else:
-                        filter_out = False
+            matched = False
+            for k in filter_keys:
+                if k in record:
+                    if solver.isin_check(record[k], data_filter[k]):
+                        matched = True
                         break
 
-            # If none of the filter keys are present in the element,
-            # it should not be kept
-            if not filter_was_in_record:
-                continue
-
-            if not filter_out:
-                filtered_data.append(record)
+            # keep: retain the record only if a filter key matched.
+            # exclude: retain it only if no filter key matched (a record with
+            # none of the filter keys is kept under exclude).
+            if filter_type == "keep":
+                if matched:
+                    filtered_data.append(record)
+            else:
+                if not matched:
+                    filtered_data.append(record)
 
         # If data_filter has not been specified,
         # all data for specified osm-keys should be kept.

--- a/tests/test_graph_exports.py
+++ b/tests/test_graph_exports.py
@@ -219,7 +219,7 @@ def test_igraph_immutable_counts(test_pbf):
 
     assert isinstance(g, igraph.Graph)
     # Check that the edge count matches
-    assert g.ecount() == 2430
+    assert g.ecount() == 2076
     assert g.vcount() == n_nodes
 
 
@@ -283,7 +283,7 @@ def test_nxgraph_immutable_counts(test_pbf):
 
     assert isinstance(g, nx.MultiDiGraph)
     # Check that the edge count matches
-    assert nx.number_of_edges(g) == 2430
+    assert nx.number_of_edges(g) == 2076
     assert nx.number_of_nodes(g) == n_nodes
 
 
@@ -348,8 +348,8 @@ def test_connected_component(immutable_nodes_and_edges):
     assert len(cn) <= len(nodes)
 
     # Test exact shape
-    assert ce.shape == (2034, 23)
-    assert cn.shape == (954, 9)
+    assert ce.shape == (1676, 21)
+    assert cn.shape == (793, 9)
 
 
 def test_igraph_connectivity(immutable_nodes_and_edges):
@@ -373,14 +373,14 @@ def test_igraph_connectivity(immutable_nodes_and_edges):
 
     # Check couple of exact lengths (allow some flexibility due to floating point calculations)
     assert round(shortest_paths[0][0], 0) in [499, 500]
-    assert round(shortest_paths[0][-1], 0) == 2315
+    assert round(shortest_paths[0][-1], 0) == 2803
 
     # Check summaries
     arr = np.array(shortest_paths[0])
     arr[arr == np.inf] = 0
     assert arr.min() == 0
-    assert arr.max().round(0) == 2838
-    assert arr.mean().round(0) == 1372
+    assert arr.max().round(0) == 3126
+    assert arr.mean().round(0) == 1421
 
 
 def test_nxgraph_connectivity(immutable_nodes_and_edges):
@@ -408,14 +408,14 @@ def test_nxgraph_connectivity(immutable_nodes_and_edges):
 
     # Check couple of exact lengths
     assert round(shortest_paths[0], 0) in [499, 500]
-    assert round(shortest_paths[-1], 0) == 2315
+    assert round(shortest_paths[-1], 0) == 2803
 
     # Check summaries
     arr = np.array(shortest_paths)
     arr[arr == np.inf] = 0
     assert arr.min() == 0
-    assert arr.max().round(0) == 2838
-    assert arr.mean().round(0) == 1372
+    assert arr.max().round(0) == 3126
+    assert arr.mean().round(0) == 1421
 
 
 @_pandana_unsupported_on_win
@@ -455,7 +455,7 @@ def test_pdgraph_connectivity():
     # Find the distance to nearest 5 restaurants from each node
     nearest_restaurants = g.nearest_pois(1000, "restaurants", num_pois=5)
     assert isinstance(nearest_restaurants, pd.DataFrame)
-    assert nearest_restaurants.shape == (5750, 5)
+    assert nearest_restaurants.shape == (5297, 5)
 
     # Get closest node_ids for each restaurant
     node_ids = g.get_node_ids(x, y)
@@ -469,7 +469,7 @@ def test_pdgraph_connectivity():
     # Aggregate the number of employees within 500 meters from each node
     access = g.aggregate(500, type="sum", decay="linear", name="employee_cnt")
     assert isinstance(access, pd.Series)
-    assert len(access) == 5750
+    assert len(access) == 5297
 
     # Test shortest path calculations
     shortest_distances = g.shortest_path_lengths(
@@ -479,8 +479,8 @@ def test_pdgraph_connectivity():
     assert len(shortest_distances) == 100
     shortest_distances = pd.Series(shortest_distances)
     assert round(shortest_distances.min(), 0) == 22
-    assert round(shortest_distances.max(), 0) == 2453
-    assert round(shortest_distances.mean(), 0) == 869
+    assert round(shortest_distances.max(), 0) == 2457
+    assert round(shortest_distances.mean(), 0) == 879
 
 
 @_pandana_unsupported_on_win
@@ -578,7 +578,7 @@ def test_nxgraph_export_from_osh(helsinki_history_pbf):
     # Windows gives a slightly different result
     # most likely due to float handling differences between Unix and Windows
     assert round(shortest_paths[0], 0) in [478, 470]
-    assert round(shortest_paths[-1], 0) in [797, 793]
+    assert round(shortest_paths[-1], 0) in [810]
 
 
 def _edge_pairs(directed_edges, from_id_col="u", to_id_col="v"):

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -39,7 +39,7 @@ def test_filter_network_by_walking(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (265, 21)
+    assert gdf.shape == (238, 19)
 
     required_cols = [
         "access",
@@ -79,7 +79,7 @@ def test_filter_network_by_driving(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 19)
+    assert gdf.shape == (200, 19)
 
     required_cols = [
         "access",
@@ -120,7 +120,7 @@ def test_filter_network_by_driving_with_service_roads(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (207, 19)
+    assert gdf.shape == (200, 19)
 
     required_cols = [
         "access",
@@ -281,7 +281,7 @@ def test_parse_network_with_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 21)
+    assert gdf.shape == (65, 19)
 
     required_cols = [
         "access",
@@ -329,7 +329,7 @@ def test_parse_network_with_shapely_bbox(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
     # Test shape
-    assert gdf.shape == (74, 21)
+    assert gdf.shape == (65, 19)
 
     required_cols = [
         "access",
@@ -458,8 +458,8 @@ def test_getting_nodes_and_edges(test_pbf):
     assert isinstance(nodes.loc[0, "geometry"], Point)
 
     # Test shape
-    assert edges.shape == (1215, 23)
-    assert nodes.shape == (1147, 9)
+    assert edges.shape == (1038, 21)
+    assert nodes.shape == (989, 9)
 
     # Edges should have "u" and "v" columns
     required = ["u", "v", "length"]
@@ -493,8 +493,8 @@ def test_getting_nodes_and_edges_with_bbox(test_pbf):
     assert isinstance(nodes.loc[0, "geometry"], Point)
 
     # Test shape
-    assert edges.shape == (321, 23)
-    assert nodes.shape == (317, 9)
+    assert edges.shape == (259, 21)
+    assert nodes.shape == (261, 9)
 
     # Edges should have "u" and "v" columns
     required = ["u", "v", "length"]
@@ -525,7 +525,7 @@ def test_reading_network_from_osh(helsinki_history_pbf):
 
     assert isinstance(gdf, GeoDataFrame)
     assert isinstance(gdf.loc[0, "geometry"], MultiLineString)
-    assert gdf.shape == (210, 25)
+    assert gdf.shape == (206, 24)
 
     required_cols = ["highway", "id", "timestamp", "version", "geometry"]
 
@@ -585,5 +585,6 @@ def test_osh_network_does_not_leak_empty_tag_columns(helsinki_history_pbf):
     phantom = [c for c in gdf.columns if c != "geometry" and gdf[c].isna().all()]
     assert phantom == [], f"empty tag columns leaked into OSH output: {phantom}"
 
-    # The column set must stay lean (25 with the fix; 27 with the bug).
-    assert gdf.shape == (210, 25)
+    # The column set must stay lean (24 after the network-filter fix; was 25
+    # before it, and 27 with the #248 NA-leak bug).
+    assert gdf.shape == (206, 24)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -117,3 +117,123 @@ def test_nxgraph_keys_nodes_by_id_not_dataframe_index():
     assert sorted(graph.nodes()) == [1000, 2000, 3000]
     # Every node carries its attributes.
     assert all("geometry" in data for _, data in graph.nodes(data=True))
+
+
+_EXCLUDED_SERVICE = {"parking", "parking_aisle", "private", "emergency_access"}
+
+
+def test_exclude_filter_does_not_leak_secondary_keys():
+    """#112 — an exclude custom_filter that lists `service` values must drop those
+    ways. The old ways filter broke on the first filter key in the record, so a
+    `highway=service` way leaked because `highway` was checked before `service`."""
+    from pyrosm import OSM, get_data
+
+    drive_filter = dict(
+        area=["yes"],
+        service=["parking", "parking_aisle", "private", "emergency_access"],
+        highway=[
+            "cycleway",
+            "footway",
+            "path",
+            "pedestrian",
+            "steps",
+            "track",
+            "corridor",
+            "elevator",
+            "escalator",
+            "proposed",
+            "construction",
+            "bridleway",
+            "abandoned",
+            "platform",
+            "raceway",
+        ],
+        motor_vehicle=["no"],
+        motorcar=["no"],
+    )
+    osm = OSM(get_data("test_pbf"))
+    gdf = osm.get_data_by_custom_criteria(
+        custom_filter=drive_filter,
+        osm_keys_to_keep="highway",
+        filter_type="exclude",
+    )
+    present = set(gdf["service"].dropna().unique())
+    assert not (present & _EXCLUDED_SERVICE), f"leaked: {present & _EXCLUDED_SERVICE}"
+
+
+def test_driving_network_excludes_service_roads():
+    """#108 — get_network('driving') must not leak roads excluded by a secondary
+    driving-filter key (e.g. service=parking_aisle on a highway=service road),
+    which the old early-break ways filter kept."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    edges = osm.get_network(network_type="driving")
+
+    excluded_highway = {
+        "cycleway",
+        "footway",
+        "path",
+        "pedestrian",
+        "steps",
+        "track",
+        "corridor",
+        "elevator",
+        "escalator",
+        "proposed",
+        "construction",
+        "bridleway",
+        "abandoned",
+        "platform",
+        "raceway",
+    }
+    hw = set(edges["highway"].dropna().unique())
+    assert not (
+        hw & excluded_highway
+    ), f"non-drivable highway leaked: {hw & excluded_highway}"
+
+    if "service" in edges.columns:
+        sv = set(edges["service"].dropna().unique())
+        assert not (
+            sv & _EXCLUDED_SERVICE
+        ), f"excluded service leaked: {sv & _EXCLUDED_SERVICE}"
+
+
+def test_keep_filter_matches_any_key_or_semantics():
+    """#108/#112 follow-on — keep filters with multiple keys must match if ANY key
+    matches (OR), not only when the first-visited filter key matches. Pre-fix a
+    way with highway=service + service=driveway was dropped by
+    keep={'highway':['path'], 'service':['driveway']}."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    gdf = osm.get_data_by_custom_criteria(
+        custom_filter={"highway": ["path"], "service": ["driveway"]},
+        osm_keys_to_keep="highway",
+        filter_type="keep",
+    )
+    assert gdf is not None and len(gdf) > 0
+    assert "driveway" in set(gdf["service"].dropna().unique())
+
+
+def test_single_key_keep_filter_unchanged():
+    """Parity guard: single-key keep filters and {key: True} are unaffected by the
+    OR rewrite (only multi-key keep filters were buggy). Row counts are pinned to
+    the current-master values so a regression in the unaffected paths is caught."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+
+    # Single-key keep on "building" (get_buildings) is unchanged.
+    buildings = osm.get_buildings()
+    assert len(buildings) == 2208
+
+    # {"building": True} keep recovers the same building ways.
+    by_true = osm.get_data_by_custom_criteria(
+        custom_filter={"building": True}, filter_type="keep"
+    )
+    assert len(by_true) == 2208
+
+    # A single-key POI keep is unchanged (exercises the keep path for POIs).
+    pois = osm.get_pois(custom_filter={"amenity": True})
+    assert len(pois) == 20


### PR DESCRIPTION
Fixes #108 and #112.

`filter_osm_records` (the **ways** filter path) decided keep/exclude by iterating a record's own tags and breaking on the first tag that is also a filter key. Filter keys after the first non-matching one were never checked, so the outcome depended on tag iteration order:

- **#112**: a `highway=service` + `service=parking_aisle` way leaked through an exclude filter because `highway` (not in the highway exclude list) was checked before `service`.
- **#108**: non-drivable roads leaked into `get_network("driving")` by the same mechanism.

The relations/nodes path (`record_should_be_kept`) already evaluated all filter keys with OR semantics; only the ways path was wrong, and networks are ways.

## Change
- `filter_osm_records` now evaluates **all** filter keys present in a record (OR semantics), matching `record_should_be_kept`: **exclude** drops a record if any present filter key's value is in its list; **keep** retains it if any matches. A record with none of the filter keys is kept under exclude and dropped under keep. The order-dependent early break and the now-unnecessary `overlapping_filter` precompute are removed.
- This also corrects the latent **keep-mode** counterpart of the same bug: multi-key keep filters with different values across keys were order-dependent and could drop matching records; they now OR correctly. Single-key keep filters and `{key: True}` are unchanged.

## Tests
- New regression tests in `tests/test_regressions.py`: the #112 service-leak, the #108 driving-network service/highway leak, multi-key keep OR, and a single-key keep parity guard with pinned counts.
- Updated network/graph fixture counts in `tests/test_network_parsing.py` and `tests/test_graph_exports.py` that encoded the old leaked-road networks — the driving network drops from 207 to 200 (removing 7 leaked `service=parking_aisle` ways), and walking and the derived graphs shrink correspondingly.

## Verification
- Rebuilt the Cython extension; the full suite passes (115 passed locally; the two shapefile/geopackage save tests are skipped here due to a local GDAL-data environment issue and run in CI).
- `black --check pyrosm` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
