### PR TITLE
Add custom_filter to get_network so custom-filtered networks return graph nodes (#118, #181)

### DIFF
--- a/pyrosm/networks.py
+++ b/pyrosm/networks.py
@@ -10,6 +10,7 @@ def get_network_data(
     network_filter,
     bounding_box,
     slice_to_segments,
+    filter_type="exclude",
 ):
     # Tags to keep as separate columns
     tags_as_columns += ["id", "nodes", "timestamp", "changeset", "version"]
@@ -21,7 +22,7 @@ def get_network_data(
         relations=None,
         tags_as_columns=tags_as_columns,
         data_filter=network_filter,
-        filter_type="exclude",
+        filter_type=filter_type,
         # Keep only records having 'highway' tag
         osm_keys="highway",
     )

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -183,6 +183,8 @@ class OSM:
         extra_attributes=None,
         nodes=False,
         timestamp=None,
+        custom_filter=None,
+        filter_type="exclude",
     ):
         """
         Parses street networks from OSM
@@ -200,13 +202,34 @@ class OSM:
               - `'driving+service'`
               - `'all'`.
 
+            When `custom_filter` is given, `network_type` no longer selects the
+            ways to keep; it only determines the graph semantics used by
+            `OSM.to_graph` (directionality / connectivity), e.g. pass
+            `network_type='driving'` for a directed custom network or keep the
+            default `'walking'` for a bidirectional one.
+
         extra_attributes : list (optional)
             Additional OSM tag keys that will be converted into columns in the resulting GeoDataFrame.
 
         nodes : bool (default: False)
             If True, 1) the nodes associated with the network will be returned in addition to edges,
             and 2) every segment of a road constituting a way is parsed as a separate row
-            (to enable full connectivity in the graph).
+            (to enable full connectivity in the graph). Works together with
+            `custom_filter` so that custom-filtered networks can also be exported
+            to a graph.
+
+        custom_filter : dict (optional)
+            A custom filter for selecting which highway ways to keep, e.g.
+            `{'highway': ['footway', 'residential'], 'bicycle': ['yes']}`. When
+            given, it replaces the predefined `network_type` filter (the two are
+            not combined). Only ways having a `highway` tag are considered; the
+            filter then keeps or excludes among those according to `filter_type`.
+            The filter keys are also added as columns to the result.
+
+        filter_type : str (default: 'exclude')
+            Whether `custom_filter` should `'keep'` or `'exclude'` the matching
+            ways. Only consulted when `custom_filter` is given; the predefined
+            `network_type` filters are always applied as `'exclude'`.
 
         timestamp: str | datetime | int
             If provided, the data from given moment of time will be returned. The time should be provided in UTC.
@@ -234,9 +257,33 @@ class OSM:
         Take a look at the OSM documentation for further details about the data:
         `https://wiki.openstreetmap.org/wiki/Key:highway <https://wiki.openstreetmap.org/wiki/Key:highway>`__
         """
-        # Get filter
+        # Get filter (also validates network_type, which still drives the graph
+        # semantics even when a custom_filter is provided)
         network_filter = self._get_network_filter(network_type)
         tags_as_columns = list(self.conf.tags.highway)
+
+        # A custom_filter replaces the predefined network filter and may use any
+        # 'keep'/'exclude' semantics; the predefined filters are always 'exclude'.
+        if custom_filter is not None:
+            custom_filter = validate_custom_filter(custom_filter)
+
+            if not isinstance(filter_type, str) or filter_type.lower() not in [
+                "keep",
+                "exclude",
+            ]:
+                raise ValueError(
+                    "'filter_type' -parameter should be either 'keep' or 'exclude'. "
+                )
+            filter_type = filter_type.lower()
+
+            network_filter = custom_filter
+            # Expose the filter keys as columns too (e.g. 'bicycle', 'service').
+            for key in custom_filter.keys():
+                if key not in tags_as_columns:
+                    tags_as_columns.append(key)
+        else:
+            # Predefined networks are always exclude filters.
+            filter_type = "exclude"
 
         if extra_attributes is not None:
             validate_tags_as_columns(extra_attributes)
@@ -253,6 +300,7 @@ class OSM:
             network_filter,
             self.bounding_box,
             slice_to_segments=nodes,
+            filter_type=filter_type,
         )
 
         if edges is not None:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -285,6 +285,32 @@ def test_get_network_custom_filter_exclude():
     assert len(excluded) > len(kept)
 
 
+def test_get_network_custom_filter_validation_and_extra_keys():
+    """#118/#181 — get_network rejects an invalid filter_type, and a custom_filter
+    key outside the default 'highway' tag set is accepted (and added as a column
+    when present in the data)."""
+    import pytest
+    from pyrosm import OSM, get_data
+    from pyrosm.config import Conf
+
+    osm = OSM(get_data("test_pbf"))
+
+    with pytest.raises(ValueError):
+        osm.get_network(
+            custom_filter={"highway": ["footway"]}, filter_type="not-a-filter"
+        )
+
+    # 'moped' is not one of the default highway tag columns; the filter key must
+    # still be accepted and routed through (it becomes a column only if present).
+    assert "moped" not in list(Conf.tags.highway)
+    edges = osm.get_network(
+        custom_filter={"highway": ["footway", "residential"], "moped": ["yes"]},
+        filter_type="keep",
+    )
+    assert edges is not None and len(edges) > 0
+    assert set(edges["highway"].dropna().unique()) <= {"footway", "residential"}
+
+
 def test_get_network_without_custom_filter_unchanged():
     """Parity guard: the default (no custom_filter) get_network path is unchanged.
     Pins row count, column set, network_type metadata, and a platform-stable hash

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -216,6 +216,115 @@ def test_keep_filter_matches_any_key_or_semantics():
     assert "driveway" in set(gdf["service"].dropna().unique())
 
 
+def test_get_network_custom_filter_returns_nodes():
+    """#118/#181 — get_network must accept a custom_filter and, with nodes=True,
+    return graph-ready (nodes, edges) so a custom-filtered network can be turned
+    into a routable graph."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    result = osm.get_network(
+        custom_filter={"highway": ["footway", "residential"]},
+        filter_type="keep",
+        nodes=True,
+    )
+
+    assert isinstance(result, tuple) and len(result) == 2
+    nodes, edges = result
+
+    assert edges is not None and len(edges) > 0
+    for col in ["u", "v", "length"]:
+        assert col in edges.columns
+    assert set(edges["highway"].dropna().unique()) <= {"footway", "residential"}
+
+    assert nodes is not None and len(nodes) > 0
+    assert "id" in nodes.columns
+    assert not nodes.geometry.is_empty.any()
+    assert set(nodes.geometry.geom_type.unique()) == {"Point"}
+
+
+def test_get_network_custom_filter_graph_export():
+    """#181 — the (nodes, edges) from a custom_filter network must export to a
+    graph. With retain_all=True no nodes are dropped (the default retain_all=False
+    prunes weakly-connected components, so the strict count needs retain_all)."""
+    import pytest
+
+    pytest.importorskip("networkx")
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    nodes, edges = osm.get_network(
+        custom_filter={"highway": ["footway", "residential"]},
+        filter_type="keep",
+        nodes=True,
+    )
+
+    graph = OSM.to_graph(nodes, edges, graph_type="networkx", retain_all=True)
+    assert graph.number_of_nodes() > 0
+    assert graph.number_of_nodes() == len(nodes)
+
+    # Default connectivity pruning keeps a subset of the returned node ids.
+    pruned = OSM.to_graph(nodes, edges, graph_type="networkx")
+    assert set(pruned.nodes()).issubset(set(nodes["id"]))
+
+
+def test_get_network_custom_filter_exclude():
+    """#118/#181 — a 'exclude' custom_filter drops the matching ways, and is the
+    complement of the matching 'keep' filter."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    excluded = osm.get_network(
+        custom_filter={"highway": ["footway"]}, filter_type="exclude", nodes=False
+    )
+    kept = osm.get_network(
+        custom_filter={"highway": ["footway"]}, filter_type="keep", nodes=False
+    )
+
+    assert "footway" not in set(excluded["highway"].dropna().unique())
+    assert len(excluded) > len(kept)
+
+
+def test_get_network_without_custom_filter_unchanged():
+    """Parity guard: the default (no custom_filter) get_network path is unchanged.
+    Pins row count, column set, network_type metadata, and a platform-stable hash
+    of the per-row id/highway values for the bundled extract."""
+    import hashlib
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    edges = osm.get_network(network_type="driving")
+
+    assert len(edges) == 200
+    assert edges["id"].nunique() == 200
+    assert sorted(edges.columns) == [
+        "access",
+        "bridge",
+        "geometry",
+        "highway",
+        "id",
+        "int_ref",
+        "lanes",
+        "length",
+        "lit",
+        "maxspeed",
+        "name",
+        "oneway",
+        "osm_type",
+        "ref",
+        "service",
+        "surface",
+        "tags",
+        "timestamp",
+        "version",
+    ]
+    assert edges._metadata[-1] == "driving"
+
+    rows = sorted(f"{i}:{h}" for i, h in zip(edges["id"], edges["highway"].fillna("")))
+    digest = hashlib.sha256("\n".join(rows).encode("utf-8")).hexdigest()
+    assert digest == "8ce8c63b51ee14f8008a6af4d642cb3adf95e83a6f926fa6c9e4381bb3f3b072"
+
+
 def test_single_key_keep_filter_unchanged():
     """Parity guard: single-key keep filters and {key: True} are unaffected by the
     OR rewrite (only multi-key keep filters were buggy). Row counts are pinned to


### PR DESCRIPTION
## What

`OSM.get_network()` now accepts a `custom_filter` (and a companion `filter_type`) so a user-defined tag selection runs through the existing network pipeline and returns graph-ready output. With `nodes=True`, `get_network(custom_filter=..., nodes=True)` returns a `(nodes, edges)` tuple — segment-level edges with `u`/`v`/`length` plus the intersection nodes — that `OSM.to_graph(...)` consumes unchanged. This closes the gap where a custom-filtered network could not be turned into a routable graph because only the fixed `network_type` path produced graph nodes.

Fixes #118, #181.

## Behaviour

- `custom_filter=None` (default): unchanged. The predefined `network_type` filter is applied with `'exclude'` semantics exactly as before; `filter_type` is ignored and forced to `'exclude'` in this branch, so a stray `filter_type='keep'` without a custom filter cannot flip predefined-network semantics.
- `custom_filter` given (dict): it replaces the predefined filter and is applied with the user's `filter_type` (`'keep'` or `'exclude'`). Only ways having a `highway` tag are considered; the filter keeps/excludes among those. `network_type` still selects the graph semantics (directionality/connectivity via `edges._metadata`), and the custom-filter keys are added as result columns.

## Changes

- `pyrosm/pyrosm.py` — `get_network` gains `custom_filter` and `filter_type` (appended after `timestamp` to preserve the existing positional order), validates them, and passes the effective filter/`filter_type` to `get_network_data`.
- `pyrosm/networks.py` — `get_network_data` gains a `filter_type='exclude'` parameter, passed through to `get_osm_data` instead of the hardcoded value.
- `tests/test_regressions.py` — regression tests: custom-filter `nodes=True` returns `(nodes, edges)` with `u`/`v`/`length` and point-geometry nodes; the tuple exports to a NetworkX graph (node count equals the node frame with `retain_all=True`, subset under the default pruning); `keep`/`exclude` are complements; and a parity guard pinning the default driving path's row count, column set, `network_type` metadata, and a content hash of the per-row `id`/`highway` values.

## Verification

- `pytest tests/test_regressions.py` — 12 passed.
- `tests/test_network_parsing.py` and `tests/test_graph_exports.py` pinned-count suites pass (pre-existing GDAL-data and OSH-download failures are environmental and unrelated to this change).
- `black --check` passes on the changed files.
- Plan and code reviewed with Codex.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
