### PR TITLE
Fix custom_filter with 'highway' turning closed-way polygons into lines (#144)

### DIFF
--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -356,6 +356,16 @@ cdef create_polygon_geometry(nodes, node_coordinates):
         return None
 
 
+cdef _closed_way_is_polygon(area_value, has_linear_tag):
+    # OSM area semantics for a closed way: an explicit 'area' tag wins
+    # ('area=yes' -> Polygon, 'area=no' -> LineString); otherwise the way is an
+    # area (Polygon) unless it carries a linear-feature tag (highway/barrier/route).
+    if area_value == "yes":
+        return True
+    if area_value == "no":
+        return False
+    return not has_linear_tag
+
 cdef _create_way_geometries(node_coordinates,
                             way_elements,
                             parse_network):
@@ -377,6 +387,15 @@ cdef _create_way_geometries(node_coordinates,
     node_attributes = []
     parsed_way_indices = []
 
+    # Bind the tag arrays used to type closed ways (Polygon vs LineString) once,
+    # so the per-way decision is plain array reads rather than per-iteration dict
+    # work. A way is typed from its own tag values, not from which columns happen
+    # to exist in the batch.
+    highway_arr = way_elements["highway"] if "highway" in way_elements else None
+    barrier_arr = way_elements["barrier"] if "barrier" in way_elements else None
+    route_arr = way_elements["route"] if "route" in way_elements else None
+    area_arr = way_elements["area"] if "area" in way_elements else None
+
     for i in range(0, n):
         nodes = way_elements['nodes'][i]
         # In some cases (e.g. when using clipped pbf file) the nodes list can be empty
@@ -387,12 +406,25 @@ cdef _create_way_geometries(node_coordinates,
 
         # If first and last node are the same, it's a closed way
         if  u == v:
-            tag_keys = way_elements.keys()
-            # Create Polygon by default unless way is of type 'highway', 'barrier' or 'route'
-            if "highway" in tag_keys or "barrier" in tag_keys or "route" in tag_keys:
+            if parse_network:
+                # Networks are linear: a closed way (e.g. a roundabout) is a
+                # LineString. Plazas/areas are excluded from the predefined
+                # network filters, and a Polygon is not routable anyway; keeping
+                # this branch linear also avoids leaving from/to ids unset.
                 geom, from_id, to_id, node_data = create_linestring_geometry(nodes, node_coordinates)
             else:
-                geom = create_polygon_geometry(nodes, node_coordinates)
+                # Decide from THIS way's own tags (not which columns exist in the
+                # batch), honouring the OSM 'area' tag.
+                area_value = area_arr[i] if area_arr is not None else None
+                has_linear_tag = (
+                    (highway_arr is not None and highway_arr[i] is not None)
+                    or (barrier_arr is not None and barrier_arr[i] is not None)
+                    or (route_arr is not None and route_arr[i] is not None)
+                )
+                if _closed_way_is_polygon(area_value, has_linear_tag):
+                    geom = create_polygon_geometry(nodes, node_coordinates)
+                else:
+                    geom, from_id, to_id, node_data = create_linestring_geometry(nodes, node_coordinates)
 
         # Otherwise create LineString
         else:

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -480,3 +480,81 @@ def test_count_streets_per_node_known_topology():
         nodes, edges, graph_type="networkx", network_type="walking", retain_all=True
     )
     assert nx.get_node_attributes(graph, "street_count") == {1: 1, 2: 3, 3: 1, 4: 1}
+
+
+def test_custom_filter_highway_does_not_linestringify_polygons():
+    """#144 — a custom_filter that includes 'highway' must not flip unrelated
+    closed-way polygons (buildings, etc.) into (Multi)LineStrings. The old code
+    keyed the polygon-vs-line decision on whether 'highway' existed as a column
+    in the batch, not on the individual way's tags."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    buildings = osm.get_data_by_custom_criteria(
+        custom_filter={"building": True}, filter_type="keep"
+    )
+    assert set(buildings.geometry.geom_type.unique()) == {"Polygon"}
+    assert len(buildings) == 2208
+
+    # Adding 'highway' to the filter must not change the building geometries.
+    combined = osm.get_data_by_custom_criteria(
+        custom_filter={"building": True, "highway": True}, filter_type="keep"
+    )
+    building_rows = combined[combined["building"].notna()]
+    assert len(building_rows) == 2208
+    assert set(building_rows.geometry.geom_type.unique()) == {"Polygon"}
+
+
+def test_closed_highway_without_area_is_linestring():
+    """#144 — in feature extraction, a closed 'highway' way WITHOUT area=yes (e.g.
+    a highway=service roundabout) must stay a line, not become a polygon."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("helsinki_pbf"))
+    gdf = osm.get_data_by_custom_criteria(
+        custom_filter={"highway": True}, filter_type="keep"
+    )
+    way = gdf[(gdf["osm_type"] == "way") & (gdf["id"] == 8035241)]
+    assert len(way) == 1
+    assert way.iloc[0].geometry.geom_type in ("LineString", "MultiLineString")
+
+
+def test_closed_highway_area_yes_is_polygon():
+    """#144 — in feature extraction, a closed 'highway' way tagged area=yes (a
+    pedestrian/footway plaza) must be typed as a Polygon."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("helsinki_pbf"))
+    gdf = osm.get_data_by_custom_criteria(
+        custom_filter={"highway": True}, filter_type="keep"
+    )
+    ways = gdf[gdf["osm_type"] == "way"]
+    for plaza_id in (4369051, 18379563):
+        row = ways[ways["id"] == plaza_id]
+        assert len(row) == 1
+        assert row.iloc[0]["area"] == "yes"
+        assert row.iloc[0].geometry.geom_type == "Polygon"
+
+    # The area=yes plazas as a group come back as polygons.
+    area_yes = ways[ways["area"] == "yes"]
+    assert (area_yes.geometry.geom_type == "Polygon").all()
+    assert len(area_yes) > 0
+
+
+def test_network_extraction_keeps_areas_as_lines():
+    """#144 guard — network extraction must NEVER produce polygons, even for
+    highway ways tagged area=yes (plazas). A Polygon is not routable, so the
+    parse_network path keeps every closed way linear. get_network('all') does not
+    exclude area=yes ways, so the plazas are present and must be lines."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("helsinki_pbf"))
+    edges = osm.get_network(network_type="all")
+    geom_types = set(edges.geometry.geom_type.unique())
+    assert not any("Polygon" in t for t in geom_types), geom_types
+
+    # The area=yes plazas are present (not excluded by the 'all' filter) and linear.
+    for plaza_id in (4369051, 18379563):
+        row = edges[edges["id"] == plaza_id]
+        assert len(row) >= 1
+        assert all("LineString" in t for t in row.geometry.geom_type.unique())


### PR DESCRIPTION
## What

Fixes a `custom_filter` bug where including a `highway` selector turned closed-way **polygon**
features (buildings, restaurants, shops, …) into `(Multi)LineString`. The closed-way
geometry classifier now decides from **each way's own tags** and honours the OSM `area` tag.

Fixes #144.

## Root cause

In `pyrosm/geometry.pyx`, `_create_way_geometries` classified a closed way (first node ==
last node) as Polygon vs LineString with:

```cython
tag_keys = way_elements.keys()
if "highway" in tag_keys or "barrier" in tag_keys or "route" in tag_keys:
    ... LineString
else:
    ... Polygon
```

`way_elements` is a dict of **column arrays**, so `way_elements.keys()` is the set of
**columns present in the whole batch**, not the tags of the individual way. As soon as
`highway` exists as a column — which happens whenever the filter contains `highway` — every
closed way was forced to a LineString, including features with no `highway` value.
Reproduced on the bundled `test_pbf`: `get_data_by_custom_criteria({"building": True})` → 2208
`Polygon`, but `{"building": True, "highway": True}` → the same 2208 buildings as
`MultiLineString`.

## How

`_create_way_geometries` now:
- Binds the `highway` / `barrier` / `route` / `area` tag arrays to locals **once** before the
  loop, and decides each closed way from its own per-way tag values.
- Honours the OSM `area` tag via a small `cdef _closed_way_is_polygon` helper: `area=yes` ⇒
  Polygon, `area=no` ⇒ LineString, otherwise Polygon unless the way carries a linear-feature
  tag (`highway`/`barrier`/`route`). `area` is already a column whenever `highway` is in the
  filter (it is in `Conf.tags.highway`), i.e. exactly when the bug triggered.
- Forces a `LineString` for every closed way when `parse_network=True`. Networks are linear:
  a plaza/pedestrian area (`highway` + `area=yes`) must stay a line because a `Polygon` is
  not routable, so the `area=yes ⇒ Polygon` rule applies only to feature extraction. This
  also removes a latent path that left `from_id`/`to_id` unset on a closed non-highway way
  under network parsing.

## Changes

- `pyrosm/geometry.pyx` — rewritten closed-way classification in `_create_way_geometries` +
  new `cdef _closed_way_is_polygon` helper.
- `tests/test_regressions.py` — four regression tests:
  - building + highway custom_filter keeps the building ways as `Polygon` (the #144 repro);
  - a closed `highway` way without `area=yes` (helsinki `highway=service` roundabout) stays a
    line in feature extraction;
  - closed `highway` + `area=yes` plazas (helsinki pedestrian/footway areas) become `Polygon`
    in feature extraction;
  - `get_network("all")` (which does not exclude `area=yes`) yields no polygons and keeps the
    `area=yes` plazas as line geometry — guards routing output.

## Verification

- New regression tests pass; `tests/test_regressions.py`, `tests/test_network_parsing.py`,
  `tests/test_graph_exports.py`, and the buildings/POI/natural/landuse/boundary suites pass
  (only the pre-existing OSH / external-download tests error, which require network access).
- Network output confirmed polygon-free across `get_network("walking"/"driving"/"all")`,
  `nodes=True`, and the `custom_filter` network path on `helsinki_pbf` (54 closed
  `highway`+`area=yes` plazas present, all emitted as lines).
- No speed regression: best-of-5 `helsinki_pbf` building+highway parse is 0.140s with the fix
  vs 0.148s on the master baseline (the fix hoists per-iteration dict work out of the loop).
- `black --check pyrosm` passes.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
