### PR TITLE
Handle bounding boxes that select no nodes instead of KeyError (#241)

### DIFF
--- a/pyrosm/data_manager.pyx
+++ b/pyrosm/data_manager.pyx
@@ -164,9 +164,13 @@ cdef _get_osm_data(node_arrays, way_records, relations, tags_as_columns, data_fi
         # Convert filter to appropriate form and parse keys
         data_filter, osm_keys = get_data_filter_and_osm_keys(data_filter)
 
-    if node_arrays is not None:
+    # A truthy node_arrays is a non-empty dict of node columns. An empty dict (e.g. when a
+    # bounding box selected no nodes) or None means there are no nodes to filter.
+    if node_arrays:
         # Get nodes
         node_arrays = get_osm_nodes(node_arrays, osm_keys, tags_as_columns, data_filter, filter_type)
+    else:
+        node_arrays = None
 
     # Parse ways and relations
     ways, relation_ways, filtered_relations = get_osm_ways_and_relations(way_records, relations, osm_keys, tags_as_columns, data_filter, filter_type)

--- a/pyrosm/pbfreader.pyx
+++ b/pyrosm/pbfreader.pyx
@@ -1,5 +1,6 @@
 from pyrosm.exceptions import PBFNotImplemented
 from struct import unpack
+import warnings
 import zlib
 from pyrosm_proto import BlobHeader, Blob, HeaderBlock, PrimitiveBlock
 from pyrosm.tagparser cimport tounicode, parse_dense_tags, parse_tags, explode_way_tags
@@ -411,6 +412,20 @@ cdef _parse_osm_data(
     # Concatenate nodes and create a DataFrame
     nodes_df = create_df(concatenate_dicts_of_arrays(all_nodes))
     relations_df = create_df(concatenate_dicts_of_arrays(all_relations))
+
+    # If no nodes were parsed the nodes DataFrame is empty and has no 'id' column. Without
+    # any nodes the ways cannot be georeferenced anyway, so return an empty result instead
+    # of crashing later at nodes_df.set_index("id"). (A swapped/inverted bounding box is
+    # rejected earlier with a ValueError at OSM() construction; reaching here means the
+    # bounding box is well-formed but does not overlap this PBF's data extent.)
+    if "id" not in nodes_df.columns:
+        warnings.warn(
+            "The given bounding box did not contain any OSM nodes, so no data could be "
+            "parsed. It likely does not overlap the data extent of this PBF file.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return {}, [], {}, {}
 
     # Keep the closest record to the timestamp if filter is used
     if unix_time_filter is not None:

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -78,6 +78,15 @@ class OSM:
                     "When passing bounding box as a list it should contain 4 coordinates: "
                     "[minx, miny, maxx, maxy]."
                 )
+            minx, miny, maxx, maxy = bounding_box
+            if minx >= maxx or miny >= maxy:
+                raise ValueError(
+                    "Invalid bounding box {bbox}: expected [minx, miny, maxx, maxy] with "
+                    "minx < maxx and miny < maxy. Please double-check the order of the "
+                    "coordinates (they may be swapped/inverted).".format(
+                        bbox=bounding_box
+                    )
+                )
             self.bounding_box = bounding_box
         else:
             raise ValueError(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -558,3 +558,58 @@ def test_network_extraction_keeps_areas_as_lines():
         row = edges[edges["id"] == plaza_id]
         assert len(row) >= 1
         assert all("LineString" in t for t in row.geometry.geom_type.unique())
+
+
+def test_bbox_outside_extent_returns_empty_not_keyerror():
+    """#241 — a bounding box that selects no nodes must not crash with
+    KeyError "None of ['id'] are in the columns"; it should return empty data and
+    warn instead."""
+    import pytest
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("helsinki_pbf"), bounding_box=[0.0, 0.0, 0.001, 0.001])
+    with pytest.warns(UserWarning):
+        edges = osm.get_network(network_type="all")
+    assert edges is None
+
+
+def test_inverted_bbox_raises_valueerror_with_coord_order_hint():
+    """#241 — an inverted/degenerate bounding box (e.g. min_x > max_x, the
+    reproduction from the issue) is malformed input and must be rejected at OSM()
+    construction with a ValueError that hints at the coordinate order, rather than
+    crashing later with a cryptic KeyError."""
+    import pytest
+    from pyrosm import OSM, get_data
+
+    fp = get_data("helsinki_pbf")
+    # Inverted x (min_x > max_x), the openbrian shape.
+    with pytest.raises(ValueError, match="minx"):
+        OSM(fp, bounding_box=[24.96, 60.16, 24.93, 60.20])
+    # Degenerate (zero-width) bbox is also rejected.
+    with pytest.raises(ValueError, match="minx"):
+        OSM(fp, bounding_box=[24.93, 60.16, 24.93, 60.20])
+
+
+def test_empty_bbox_pois_and_buildings_do_not_crash():
+    """#241 — the node-using getters (get_pois, get_buildings) must also handle an
+    empty bounding box gracefully (the original report used get_pois)."""
+    import warnings
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("helsinki_pbf"), bounding_box=[0.0, 0.0, 0.001, 0.001])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        pois = osm.get_pois(custom_filter={"amenity": True})
+        buildings = osm.get_buildings()
+    assert pois is None
+    assert buildings is None
+
+
+def test_valid_bbox_unchanged_by_empty_guard():
+    """#241 guard — a valid in-extent bounding box still parses normally."""
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("helsinki_pbf"), bounding_box=[24.93, 60.16, 24.96, 60.20])
+    edges = osm.get_network(network_type="all")
+    assert edges is not None
+    assert len(edges) == 2577


### PR DESCRIPTION
## What

Fixes the cryptic `KeyError: "None of ['id'] are in the columns"` that pyrosm raised when a
`bounding_box` selected no OSM nodes. The behaviour now splits cleanly:

- a **malformed** bounding box (inverted/degenerate) raises a clear `ValueError` at `OSM()`
  construction;
- a **well-formed** bounding box that simply doesn't overlap the data returns an empty
  result with an informative `UserWarning` (instead of crashing).

Fixes #241.

## Reproduction (was)

The decisive report (openbrian) reproduces with bundled data and no external converter:

```python
osm = OSM(get_data("virginia"),
          bounding_box=[-77.4136051, 37.5213636, -77.4722127, 37.5684523])
osm.get_network(network_type="driving")   # KeyError "None of ['id'] are in the columns"
```

That bbox is also inverted (`min_x=-77.4136 > max_x=-77.4722`). The same crash reproduces on
the bundled `helsinki_pbf` with an inverted bbox and with a well-formed bbox outside the data
extent.

## Root cause

In `pyrosm/pbfreader.pyx` `_parse_osm_data`, when the bounding box selects no nodes
`all_nodes` is empty, so `create_df(concatenate_dicts_of_arrays([]))` is an empty,
column-less DataFrame and `nodes_df.set_index("id")` raises. (With no nodes, the ways are all
dropped too, so the parse result is genuinely empty — pyrosm should return empty, not crash.)
A list bounding box was also never validated for coordinate order, so a swapped
`[minx, miny, maxx, maxy]` silently filtered everything out.

## How

- **`pyrosm/pyrosm.py` (`OSM.__init__`)** — validate a list bounding box: raise `ValueError`
  when `minx >= maxx` or `miny >= maxy`, with a message hinting that the coordinates may be
  swapped/inverted (expected `[minx, miny, maxx, maxy]`). Shapely-geometry bboxes are
  inherently ordered, so only list input needs this.
- **`pyrosm/pbfreader.pyx` (`_parse_osm_data`)** — if the parsed `nodes_df` has no `id`
  column (empty node set for a well-formed bbox that doesn't overlap the data), emit a
  `UserWarning` and return empty containers `({}, [], {}, {})` before the OSH filter and the
  `set_index("id")`. Added `import warnings`.
- **`pyrosm/data_manager.pyx` (`_get_osm_data`)** — treat a falsy/empty `node_arrays` dict as
  "no nodes" so the node-using getters (`get_pois`, `get_natural`, `get_landuse`,
  `get_data_by_custom_criteria`) don't hit a secondary `KeyError: 'tags'` in
  `filter_node_indices` for the empty case.

## Changes

- `pyrosm/pyrosm.py`, `pyrosm/pbfreader.pyx`, `pyrosm/data_manager.pyx` — as above.
- `tests/test_regressions.py` — four regression tests on `helsinki_pbf`:
  - inverted (`min_x > max_x`) and degenerate (`min_x == max_x`) bboxes raise `ValueError`
    with a coordinate-order hint;
  - a well-formed outside-extent bbox returns `None` from `get_network("all")` with a
    `UserWarning` (no crash);
  - `get_pois` and `get_buildings` also return `None` without crashing for an empty bbox;
  - a valid in-extent bbox still returns the expected network (row count pinned).

## Verification

- New regression tests pass; `tests/test_regressions.py` plus the POI / building / network /
  graph / pbf-parsing suites pass (only the pre-existing OSH / external-download tests error,
  which require network access).
- Confirmed on `helsinki_pbf`: inverted/degenerate bbox → `ValueError` at construction;
  outside-extent bbox → empty + warning across `get_network`/`get_pois`/`get_buildings`;
  valid bbox unchanged.
- `black --check pyrosm` passes.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
