### PR TITLE
Complete bbox-straddling way geometries (#236)

### DIFF
--- a/pyrosm/pbfreader.pyx
+++ b/pyrosm/pbfreader.pyx
@@ -91,6 +91,7 @@ cdef parse_dense(
         string_table,
         bounding_box,
         unix_time_filter,
+        node_id_filter=None,
 ):
     cdef:
         int node_granularity = pblock.granularity
@@ -138,7 +139,19 @@ cdef parse_dense(
     if visible.shape[0] == 0:
         visible = np.full(len(data.id), False, dtype=bool)
 
-    if bounding_box is not None:
+    # 'node_id_filter' (a second, completeness pass) keeps nodes by id rather than
+    # by the bounding box, to fetch a kept way's vertices that lie just outside the box.
+    if node_id_filter is not None:
+        mask = np.isin(ids, node_id_filter)
+        ids = ids[mask]
+        versions = versions[mask]
+        changesets = changesets[mask]
+        timestamps = timestamps[mask]
+        lons = lons[mask]
+        lats = lats[mask]
+        tags = tags[mask]
+        visible = visible[mask]
+    elif bounding_box is not None:
         # Filter
         xmin, ymin, xmax, ymax = bounding_box
         mask = (xmin <= lons) & (lons <= xmax) & (ymin <= lats) & (lats <= ymax)
@@ -174,7 +187,7 @@ cdef parse_dense(
                  )]
 
 
-cdef parse_nodes(pblock, data, bounding_box):
+cdef parse_nodes(pblock, data, bounding_box, node_id_filter=None):
     ids = []
     versions = []
     changesets = []
@@ -205,7 +218,16 @@ cdef parse_nodes(pblock, data, bounding_box):
     lon = (np.array(lons, dtype=np.int64) * granularity + lon_offset) / div
     lat = (np.array(lats, dtype=np.int64) * granularity + lat_offset) / div
 
-    if bounding_box is not None:
+    if node_id_filter is not None:
+        # Completeness pass: keep nodes by id rather than by the bounding box.
+        mask = np.isin(id_, node_id_filter)
+        id_ = id_[mask]
+        version = version[mask]
+        changeset = changeset[mask]
+        timestamp = timestamp[mask]
+        lon = lon[mask]
+        lat = lat[mask]
+    elif bounding_box is not None:
         # Filter
         xmin, ymin, xmax, ymax = bounding_box
         mask = (xmin <= lon) & (lon <= xmax) & (ymin <= lat) & (lat <= ymax)
@@ -448,7 +470,51 @@ cdef _parse_osm_data(
     all_nodes = {col: nodes_df[col].values for col in nodes_df.columns}
     all_relations = {col: relations_df[col].values for col in relations_df.columns}
 
+    # Complete the geometries of ways that straddle the bounding box (#236). A way is
+    # kept when >=1 of its nodes is inside the box, but the box-filtered node parse
+    # dropped the vertices that lie just outside it, so its polygon/line would otherwise
+    # be cut. Fetch ONLY those missing node coordinates with a second pass over the
+    # already-in-memory blocks (no extra I/O / decompression) and add them to the
+    # coordinate lookup used for geometry building. They are deliberately NOT added to
+    # `all_nodes` (the standalone node features), so out-of-box nodes never leak into
+    # node-feature results (e.g. POIs). bbox-only.
+    coords_df = nodes_df
+    if bounding_box is not None and len(all_ways) > 0:
+        present_ids = set(nodes_df["id"].tolist())
+        missing_ids = set()
+        for way in all_ways:
+            for node_id in way["nodes"]:
+                if node_id not in present_ids:
+                    missing_ids.add(node_id)
+        if len(missing_ids) > 0:
+            node_id_filter = np.array(sorted(missing_ids), dtype=np.int64)
+            boundary_nodes = []
+            for pblock, str_table in zip(primitive_blocks, string_tables):
+                for pgroup in pblock.primitivegroup:
+                    if len(pgroup.dense.id) > 0:
+                        boundary_nodes += parse_dense(pblock, pgroup.dense, str_table,
+                                                      None, unix_time_filter,
+                                                      node_id_filter=node_id_filter)
+                    elif len(pgroup.nodes) > 0:
+                        boundary_nodes += [parse_nodes(pblock, pgroup.nodes, None,
+                                                       node_id_filter=node_id_filter)]
+            if len(boundary_nodes) > 0:
+                boundary_df = create_df(concatenate_dicts_of_arrays(boundary_nodes))
+                if "id" in boundary_df.columns:
+                    # Apply the same OSH latest-version selection to the boundary
+                    # nodes as nodes_df received above, so timestamped geometries are
+                    # built from the latest non-deleted vertex rather than whichever
+                    # historical version drop_duplicates happens to keep first.
+                    if unix_time_filter is not None:
+                        boundary_df = boundary_df.loc[
+                            boundary_df["visible"] == True
+                        ].copy()
+                        boundary_df = get_latest_version(boundary_df)
+                    coords_df = pd.concat(
+                        [nodes_df, boundary_df], ignore_index=True
+                    ).drop_duplicates(subset="id")
+
     # Node coordinates lookup dictionary with all node attributes (all attributes required for graph building)
-    node_coordinates_lookup = nodes_df.set_index("id").to_dict(orient="index")
+    node_coordinates_lookup = coords_df.set_index("id").to_dict(orient="index")
 
     return all_nodes, all_ways, all_relations, node_coordinates_lookup

--- a/tests/test_building_parsing.py
+++ b/tests/test_building_parsing.py
@@ -126,8 +126,9 @@ def test_parse_buildings_with_bbox(test_pbf):
     assert isinstance(gdf.loc[0, "geometry"], Polygon)
     assert isinstance(gdf, GeoDataFrame)
 
-    # Test shape
-    assert gdf.shape == (577, 16)
+    # Test shape (#236: buildings straddling the bbox edge are now returned complete
+    # rather than cut, so the boundary-crossing buildings are included)
+    assert gdf.shape == (584, 16)
 
     required_cols = [
         "building",
@@ -145,11 +146,12 @@ def test_parse_buildings_with_bbox(test_pbf):
     for col in required_cols:
         assert col in gdf.columns
 
-    # The total bounds of the result should not be larger than the filter
-    # (allow some rounding error)
-    result_bounds = gdf.total_bounds
-    for coord1, coord2 in zip(bounds, result_bounds):
-        assert round(coord2, 3) >= round(coord1, 3)
+    # Every returned feature intersects the bounding box. Features that straddle the
+    # edge are returned complete (#236), so the result may extend slightly beyond the
+    # filter; clip with GeoPandas afterwards if exact bounds are required.
+    from shapely.geometry import box
+
+    assert gdf.intersects(box(*bounds)).all()
 
 
 def test_saving_buildings_to_geopackage(test_pbf, test_output_dir):

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -280,8 +280,9 @@ def test_parse_network_with_bbox(test_pbf):
     assert isinstance(gdf.loc[0, "geometry"], MultiLineString)
     assert isinstance(gdf, GeoDataFrame)
 
-    # Test shape
-    assert gdf.shape == (65, 19)
+    # Test shape (#236: edges crossing the bbox edge are now returned complete
+    # rather than cut, so boundary-crossing edges are included)
+    assert gdf.shape == (72, 19)
 
     required_cols = [
         "access",
@@ -308,11 +309,12 @@ def test_parse_network_with_bbox(test_pbf):
     # Should not include 'motorway' ways by default
     assert "motorway" not in gdf["highway"].unique()
 
-    # The total bounds of the result should not be larger than the filter
-    # (allow some rounding error)
-    result_bounds = gdf.total_bounds
-    for coord1, coord2 in zip(bounds, result_bounds):
-        assert round(coord2, 3) >= round(coord1, 3)
+    # Every returned edge intersects the bounding box. Edges that straddle the edge
+    # are returned complete (#236), so the result may extend slightly beyond the
+    # filter; clip with GeoPandas afterwards if exact bounds are required.
+    from shapely.geometry import box
+
+    assert gdf.intersects(box(*bounds)).all()
 
 
 def test_parse_network_with_shapely_bbox(test_pbf):
@@ -328,8 +330,9 @@ def test_parse_network_with_shapely_bbox(test_pbf):
     assert isinstance(gdf.loc[0, "geometry"], MultiLineString)
     assert isinstance(gdf, GeoDataFrame)
 
-    # Test shape
-    assert gdf.shape == (65, 19)
+    # Test shape (#236: edges crossing the bbox edge are now returned complete
+    # rather than cut, so boundary-crossing edges are included)
+    assert gdf.shape == (72, 19)
 
     required_cols = [
         "access",
@@ -356,11 +359,10 @@ def test_parse_network_with_shapely_bbox(test_pbf):
     # Should not include 'motorway' ways by default
     assert "motorway" not in gdf["highway"].unique()
 
-    # The total bounds of the result should not be larger than the filter
-    # (allow some rounding error)
-    result_bounds = gdf.total_bounds
-    for coord1, coord2 in zip(bounds.bounds, result_bounds):
-        assert round(coord2, 3) >= round(coord1, 3)
+    # Every returned edge intersects the bounding box. Edges that straddle the edge
+    # are returned complete (#236), so the result may extend slightly beyond the
+    # filter; clip with GeoPandas afterwards if exact bounds are required.
+    assert gdf.intersects(bounds).all()
 
 
 def test_passing_incorrect_bounding_box(test_pbf):
@@ -492,9 +494,10 @@ def test_getting_nodes_and_edges_with_bbox(test_pbf):
     assert isinstance(nodes, GeoDataFrame)
     assert isinstance(nodes.loc[0, "geometry"], Point)
 
-    # Test shape
-    assert edges.shape == (259, 21)
-    assert nodes.shape == (261, 9)
+    # Test shape (#236: edges crossing the bbox edge are now returned complete
+    # rather than cut, so boundary-crossing edges and their nodes are included)
+    assert edges.shape == (291, 21)
+    assert nodes.shape == (262, 9)
 
     # Edges should have "u" and "v" columns
     required = ["u", "v", "length"]

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -613,3 +613,54 @@ def test_valid_bbox_unchanged_by_empty_guard():
     edges = osm.get_network(network_type="all")
     assert edges is not None
     assert len(edges) == 2577
+
+
+def test_bbox_straddling_building_ways_complete_not_cut():
+    """#236 — building ways crossing the bounding-box edge must come back with
+    their complete geometry, not cut. Pre-fix, a way straddling the edge lost its
+    outside-bbox vertices and its area collapsed (some even became invalid)."""
+    from pyrosm import OSM, get_data
+
+    fp = get_data("helsinki_pbf")
+    full = OSM(fp).get_buildings()
+    full = full[full["osm_type"] == "way"].set_index("id")
+
+    sub = OSM(fp, bounding_box=[24.93, 60.16, 24.945, 60.18]).get_buildings()
+    sub = sub[sub["osm_type"] == "way"].set_index("id")
+
+    # The fix completes geometries; it does not change which ways are kept.
+    assert len(sub) == 181
+    common = full.index.intersection(sub.index)
+    assert len(common) == len(sub)  # every bbox building way exists in the full set
+
+    # No building way comes back with a smaller (cut) area than in the full dataset.
+    cut = [
+        i
+        for i in common
+        if full.loc[i].geometry.area > 0
+        and sub.loc[i].geometry.area < full.loc[i].geometry.area * 0.999
+    ]
+    assert cut == [], f"cut/incomplete building ways: {cut}"
+
+
+def test_bbox_does_not_introduce_invalid_building_ways():
+    """#236 — the bounding-box parse must not turn a building way that is valid in
+    the full dataset into an invalid one (the cut geometries were sometimes
+    invalid). Source buildings that are already invalid without a bbox are
+    tolerated."""
+    from pyrosm import OSM, get_data
+
+    fp = get_data("helsinki_pbf")
+    full = OSM(fp).get_buildings()
+    full = full[full["osm_type"] == "way"].set_index("id")
+
+    sub = OSM(fp, bounding_box=[24.93, 60.16, 24.945, 60.18]).get_buildings()
+    sub = sub[sub["osm_type"] == "way"].set_index("id")
+
+    common = full.index.intersection(sub.index)
+    introduced = [
+        i
+        for i in common
+        if full.loc[i].geometry.is_valid and not sub.loc[i].geometry.is_valid
+    ]
+    assert introduced == [], f"bbox introduced invalid geometries: {introduced}"


### PR DESCRIPTION
Closes #236.

## Problem

With a `bounding_box`, ways (buildings, network edges, relation member ways) that straddle the box edge came back with **cut / partial geometries** — the footprint was sliced at the bounding-box edge, and some polygons were even invalid. Two behaviours in `_parse_osm_data` ([pbfreader.pyx](../pyrosm/pbfreader.pyx)) combined to cause it:

1. Nodes are filtered strictly to the bbox, so the coordinate lookup held only in-bbox vertices.
2. A way is kept if **any** of its nodes is in the box (`any_int64_from_iter`).

So a way crossing the boundary was kept but built from only its in-bbox vertices (the geometry builders silently skip nodes missing from the lookup), and the final spatial `sjoin` kept the cut geometry because it still intersects the box.

## Fix

When a `bounding_box` is set, complete the geometry of every kept way: after the in-bbox parse, collect the referenced-but-missing node ids of the kept ways and run a second, id-filtered pass (`np.isin`) over the **already-in-memory** primitive blocks to fetch only those boundary-node coordinates. They feed **only** the coordinate lookup used for geometry building, never `all_nodes` — so out-of-box nodes do not leak into standalone node features (e.g. POIs). The no-bbox path is byte-for-byte unchanged (the whole block is guarded by `bounding_box is not None`). For `.osh.pbf` timestamped parses the boundary nodes get the same `visible` + latest-version selection that the in-bbox nodes receive.

This mirrors OSMnx, which recurses to fetch every node of selected ways (`(way(poly:…);>;);out;`) and keeps whole features that intersect the area without clipping. No I/O or decompression is added (the blocks are already materialised); the cost is one extra delta-decode pass over the small missing-id set. Memory stays at the bbox baseline.

Completion applies to every bbox getter, features and networks, since it lives in the shared parse — boundary-crossing edges come back complete too. Clipping to the exact bbox, if ever wanted, is a trivial final GeoPandas geometry operation and is intentionally not done here.

## Verification

- Reproduced on `helsinki_pbf` with a straddling sub-bbox: 7 building ways were cut (one invalid) before the fix; all complete after.
- New regression tests in [tests/test_regressions.py](../tests/test_regressions.py): bbox building-way geometries equal their full-dataset geometry (no cut), and no way valid in the full dataset becomes invalid under the bbox.
- Existing bbox-pinned fixtures in `test_building_parsing.py` / `test_network_parsing.py` updated to the complete-geometry counts (buildings 577→584; network 65→72; edges 259→291, nodes 261→262), and their "within-filter-bounds" assertions replaced with "intersects bbox".
- `pytest tests/test_regressions.py tests/test_building_parsing.py tests/test_network_parsing.py`: 52 passed (3 errors are pre-existing OSH-download SSL failures in this offline environment, unrelated to this change).

## Known residual

A relation whose member way lies entirely outside the box still misses that ring; full relation recursion (keep all member ways of kept relations + their nodes) is a separate, larger change.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
