### PR TITLE
Keep bbox network nodes consistent with kept edges (#199)

### DIFF
--- a/pyrosm/frames.pyx
+++ b/pyrosm/frames.pyx
@@ -181,9 +181,16 @@ cpdef prepare_geodataframe(nodes, node_coordinates, ways,
         gdf = gdf[orig_cols].reset_index(drop=True)
 
         if node_attr is not None:
-            orig_node_cols = list(node_attr.columns)
-            node_attr = gpd.sjoin(node_attr, filter_gdf, how="inner")
-            node_attr = node_attr[orig_node_cols]
+            # Keep every node referenced by the kept (whole) edges, including
+            # endpoints just outside the box. Spatially clipping the nodes to the
+            # box instead would drop boundary endpoints of edges that straddle the
+            # edge, leaving dangling u/v that break graph export (#199).
+            referenced = pd.unique(
+                np.concatenate([gdf["u"].to_numpy(), gdf["v"].to_numpy()])
+            )
+            node_attr = node_attr[node_attr["id"].isin(referenced)].reset_index(
+                drop=True
+            )
 
     if len(gdf) == 0:
         if parse_network:

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -495,9 +495,12 @@ def test_getting_nodes_and_edges_with_bbox(test_pbf):
     assert isinstance(nodes.loc[0, "geometry"], Point)
 
     # Test shape (#236: edges crossing the bbox edge are now returned complete
-    # rather than cut, so boundary-crossing edges and their nodes are included)
+    # rather than cut, so boundary-crossing edges and their nodes are included.
+    # #199: the nodes frame now retains every endpoint referenced by the kept
+    # edges, including boundary endpoints just outside the box, so the
+    # nodes/edges pair stays consistent for graph export.)
     assert edges.shape == (291, 21)
-    assert nodes.shape == (262, 9)
+    assert nodes.shape == (293, 9)
 
     # Edges should have "u" and "v" columns
     required = ["u", "v", "length"]

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,5 +1,7 @@
 """Regression tests guarding against specific bugs reappearing."""
 
+import pytest
+
 
 def test_get_methods_do_not_mutate_shared_tag_config():
     """#252 — get_* must not mutate the shared Conf default-tag lists."""
@@ -664,3 +666,37 @@ def test_bbox_does_not_introduce_invalid_building_ways():
         if full.loc[i].geometry.is_valid and not sub.loc[i].geometry.is_valid
     ]
     assert introduced == [], f"bbox introduced invalid geometries: {introduced}"
+
+
+def test_bbox_network_nodes_cover_all_edge_endpoints():
+    """#199 — with a bounding box, get_network(nodes=True) must return a nodes
+    frame containing every endpoint referenced by the edges. Boundary endpoints
+    of edges that straddle the box used to be clipped away, leaving dangling
+    u/v."""
+    from pyrosm import OSM, get_data
+
+    fp = get_data("test_pbf")
+    bounds = [26.94, 60.525, 26.96, 60.535]
+    nodes, edges = OSM(filepath=fp, bounding_box=bounds).get_network(nodes=True)
+
+    missing = (set(edges["u"]) | set(edges["v"])) - set(nodes["id"])
+    assert missing == set(), f"edge endpoints missing from nodes: {missing}"
+
+
+@pytest.mark.parametrize("graph_type", ["networkx", "igraph", "pandana"])
+def test_bbox_network_to_graph(graph_type):
+    """#199 — to_graph must build from the get_network(nodes=True) output of a
+    bbox reader without manual cleanup. Pre-fix the pandana export raised
+    'Buffer dtype mismatch, expected long but got double'. Parametrized so each
+    backend is exercised (or skipped) independently — a missing optional backend
+    must not mask the others."""
+    pytest.importorskip(graph_type)
+    from pyrosm import OSM, get_data
+
+    fp = get_data("test_pbf")
+    bounds = [26.94, 60.525, 26.96, 60.535]
+    osm = OSM(filepath=fp, bounding_box=bounds)
+    nodes, edges = osm.get_network(nodes=True)
+
+    g = osm.to_graph(nodes, edges, graph_type=graph_type)
+    assert g is not None

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,5 +1,7 @@
 """Regression tests guarding against specific bugs reappearing."""
 
+import sys
+
 import pytest
 
 
@@ -683,7 +685,23 @@ def test_bbox_network_nodes_cover_all_edge_endpoints():
     assert missing == set(), f"edge endpoints missing from nodes: {missing}"
 
 
-@pytest.mark.parametrize("graph_type", ["networkx", "igraph", "pandana"])
+@pytest.mark.parametrize(
+    "graph_type",
+    [
+        "networkx",
+        "igraph",
+        # pandana's compiled cyaccess uses C `long` buffers (32-bit on Windows),
+        # but NumPy 2 makes the default integer int64, so its export is broken on
+        # Windows regardless of this fix; skip there as the graph-export tests do.
+        pytest.param(
+            "pandana",
+            marks=pytest.mark.skipif(
+                sys.platform.startswith("win"),
+                reason="pandana is incompatible with NumPy 2 on Windows (C long is 32-bit)",
+            ),
+        ),
+    ],
+)
 def test_bbox_network_to_graph(graph_type):
     """#199 — to_graph must build from the get_network(nodes=True) output of a
     bbox reader without manual cleanup. Pre-fix the pandana export raised


### PR DESCRIPTION
Closes #199.

## Problem

With an `OSM` reader created from a `bounding_box`, `get_network(nodes=True)` returned a `(nodes, edges)` pair where some `edges.u`/`edges.v` endpoint ids were **not present** in `nodes.id`. Feeding that pair to `to_graph(graph_type="pandana")` raised `ValueError: Buffer dtype mismatch, expected 'long' but got 'double'` (pandana indexes nodes and the missing ids collapse the edge-endpoint lookup to NaN).

Root cause is in `prepare_geodataframe` ([frames.pyx](../pyrosm/frames.pyx)): when a bbox is set, the **edges** are kept by an intersect spatial join (whole edges, including ones straddling the box edge), but the **nodes** were filtered by a *separate* spatial join to strictly inside the box. So a boundary-crossing edge was kept whole while its out-of-box endpoint node was dropped, leaving a dangling `u`/`v`.

## Fix

Instead of spatially clipping the node frame to the box, select the returned nodes by the endpoints the kept edges actually reference:

```python
referenced = pd.unique(np.concatenate([gdf["u"].to_numpy(), gdf["v"].to_numpy()]))
node_attr = node_attr[node_attr["id"].isin(referenced)].reset_index(drop=True)
```

`node_attr` already contains an attribute row for every segment endpoint (built in `create_linestring_geometry`), including the boundary endpoints, so this both retains the boundary nodes the edges need and excludes orphan nodes of edges that were dropped entirely. The node set is then exactly the edges' endpoint set — consistent for graph export. This is consistent with the #236 "return whole features that intersect the box" decision; the node frame now follows the same rule as the edge frame. The edges themselves are unchanged; only the node selection changes. The no-bbox path and non-network feature paths are untouched (the change is inside the `if bounding_box is not None` block, node branch only).

## Verification

- Reproduced on `helsinki_region_pbf` (282 dangling endpoints, pandana `ValueError`) and on the bundled `test_pbf` (2 dangling endpoints) before the fix.
- After the fix: dangling endpoints drop to 0 and `to_graph` builds for pandana, networkx and igraph.
- New regression tests in [tests/test_regressions.py](../tests/test_regressions.py): one asserting the bbox network's nodes cover every edge endpoint, and one parametrized over networkx/igraph/pandana asserting `to_graph` builds (each backend guarded by `importorskip` so a missing optional backend does not mask the others).
- Existing bbox fixture in `test_network_parsing.py` (`test_getting_nodes_and_edges_with_bbox`) updated: nodes `(262, 9)` -> `(293, 9)` (boundary endpoints now retained); edges unchanged at `(291, 21)`.
- `pytest tests/test_regressions.py tests/test_network_parsing.py tests/test_graph_exports.py`: 66 passed. `black --check pyrosm` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.