### PR TITLE
Add pandarm graph-export backend; deprecate pandana (#270)

### DIFF
--- a/ci/310-conda.yaml
+++ b/ci/310-conda.yaml
@@ -14,6 +14,7 @@ dependencies:
   # optional
   - networkx
   - pandana
+  - pandarm
   - python-igraph
   # testing
   - osmnx

--- a/ci/311-conda.yaml
+++ b/ci/311-conda.yaml
@@ -14,6 +14,7 @@ dependencies:
   # optional
   - networkx
   - pandana
+  - pandarm
   - python-igraph
   # testing
   - osmnx

--- a/ci/312-conda.yaml
+++ b/ci/312-conda.yaml
@@ -14,6 +14,7 @@ dependencies:
   # optional
   - networkx
   - pandana
+  - pandarm
   - python-igraph
   # testing
   - osmnx

--- a/ci/313-conda.yaml
+++ b/ci/313-conda.yaml
@@ -15,6 +15,8 @@ dependencies:
   - networkx
   # NOTE: pandana has no Python 3.13 build on conda-forge yet; the pandana
   # graph-export tests are skipped on 3.13 (see tests/test_graph_exports.py).
+  # pandarm (the maintained fork) does build on 3.13 and is exercised instead.
+  - pandarm
   - python-igraph
   # testing
   - osmnx

--- a/ci/314-conda.yaml
+++ b/ci/314-conda.yaml
@@ -15,6 +15,8 @@ dependencies:
   - networkx
   # NOTE: pandana has no Python 3.13+ build on conda-forge yet; the pandana
   # graph-export tests are skipped on 3.13/3.14 (see tests/test_graph_exports.py).
+  # pandarm (the maintained fork) does build on 3.13/3.14 and is exercised instead.
+  - pandarm
   - python-igraph
   # testing
   - osmnx

--- a/pyrosm/graph_export.pyx
+++ b/pyrosm/graph_export.pyx
@@ -1,4 +1,4 @@
-from pyrosm.utils._compat import HAS_IGRAPH, HAS_NETWORKX, HAS_PANDANA
+from pyrosm.utils._compat import HAS_IGRAPH, HAS_NETWORKX, HAS_PANDANA, HAS_PANDARM
 from pyrosm.config import Conf
 from collections import Counter
 from itertools import chain
@@ -193,6 +193,19 @@ cpdef _create_nxgraph(nodes,
 
     return graph
 
+cdef _build_routing_network(Network, nodes, edges, from_id_col, to_id_col, weight_cols):
+    """
+    Builds a pandana/pandarm Network from directed edges and nodes.
+    NOTE: Assumes that the input edges GeoDataFrame is directed.
+    """
+    return Network(node_x=nodes["x"],
+                   node_y=nodes["y"],
+                   edge_from=edges[from_id_col],
+                   edge_to=edges[to_id_col],
+                   edge_weights=edges[weight_cols],
+                   twoway=False)
+
+
 cpdef _create_pdgraph(nodes,
                       edges,
                       from_id_col,
@@ -200,18 +213,27 @@ cpdef _create_pdgraph(nodes,
                       weight_cols):
     """
     Creates a Pandana Network from directed edges and nodes.
-    NOTE: Assumes that the input edges GeoDataFrame is directed.
     """
     if not HAS_PANDANA:
         raise ImportError("'pandana' needs to be installed "
                           "in order to export the network for it.")
     from pandana import Network
-    return Network(node_x=nodes["x"],
-                   node_y=nodes["y"],
-                   edge_from=edges[from_id_col],
-                   edge_to=edges[to_id_col],
-                   edge_weights=edges[weight_cols],
-                   twoway=False)
+    return _build_routing_network(Network, nodes, edges, from_id_col, to_id_col, weight_cols)
+
+
+cpdef _create_pandarm_graph(nodes,
+                            edges,
+                            from_id_col,
+                            to_id_col,
+                            weight_cols):
+    """
+    Creates a pandarm Network from directed edges and nodes.
+    """
+    if not HAS_PANDARM:
+        raise ImportError("'pandarm' needs to be installed "
+                          "in order to export the network for it.")
+    from pandarm import Network
+    return _build_routing_network(Network, nodes, edges, from_id_col, to_id_col, weight_cols)
 
 
 cpdef generate_directed_edges(edges,

--- a/pyrosm/graphs.py
+++ b/pyrosm/graphs.py
@@ -2,6 +2,7 @@ from pyrosm.graph_export import (
     _create_igraph,
     _create_nxgraph,
     _create_pdgraph,
+    _create_pandarm_graph,
     generate_directed_edges,
 )
 from pyrosm.graph_connectivity import get_connected_edges
@@ -325,3 +326,40 @@ def to_pandana(
     nodes = nodes.rename_axis([None])
 
     return _create_pdgraph(nodes, edges, from_id_col, to_id_col, weight_cols)
+
+
+def to_pandarm(
+    nodes,
+    edges,
+    direction="oneway",
+    from_id_col="u",
+    to_id_col="v",
+    node_id_col="id",
+    force_bidirectional=False,
+    network_type=None,
+    retain_all=False,
+    weight_cols=["length"],
+):
+    # Prepare the data
+    nodes, edges = get_directed_edges(
+        nodes,
+        edges,
+        direction,
+        from_id_col,
+        to_id_col,
+        node_id_col,
+        force_bidirectional,
+        network_type,
+    )
+
+    # Keep only strongly connected component if not specifically requested otherwise
+    if not retain_all:
+        nodes, edges = get_connected_edges(
+            nodes, edges, from_id_col, to_id_col, node_id_col
+        )
+
+    nodes = nodes.rename(columns={"lat": "y", "lon": "x"})
+    nodes = nodes.set_index("id", drop=False)
+    nodes = nodes.rename_axis([None])
+
+    return _create_pandarm_graph(nodes, edges, from_id_col, to_id_col, weight_cols)

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 from pyrosm.config import Conf
 from pyrosm.pbfreader import parse_osm_data
@@ -30,7 +32,7 @@ from pyrosm.natural import get_natural_data
 from pyrosm.networks import get_network_data
 from pyrosm.pois import get_poi_data
 from pyrosm.user_defined import get_user_defined_data
-from pyrosm.graphs import to_networkx, to_igraph, to_pandana
+from pyrosm.graphs import to_networkx, to_igraph, to_pandana, to_pandarm
 
 
 class OSM:
@@ -864,7 +866,8 @@ class OSM:
         Export OSM network to routable graph. Supported output graph types are:
           - "igraph" (default),
           - "networkx",
-          - "pandana"
+          - "pandarm",
+          - "pandana" (deprecated; use "pandarm")
 
         For walking, the output graph will be bidirectional by default
         (i.e. travel along the street is allowed to both directions). For driving
@@ -887,7 +890,11 @@ class OSM:
             Type of the output graph. Available graphs are:
               - "igraph" --> returns an igraph.Graph -object.
               - "networkx" --> returns a networkx.MultiDiGraph -object.
-              - "pandana" --> returns an pandana.Network -object.
+              - "pandarm" --> returns a pandarm.Network -object.
+              - "pandana" --> returns a pandana.Network -object.
+                (deprecated: pandana is unmaintained and incompatible with
+                NumPy 2 on Windows; use "pandarm" instead. Will be removed in
+                a future release.)
 
         direction : str
             Name for the column containing information about the allowed driving directions
@@ -956,7 +963,28 @@ class OSM:
                 retain_all,
                 osmnx_compatible,
             )
+        elif graph_type == "pandarm":
+            return to_pandarm(
+                nodes,
+                edges,
+                direction,
+                from_id_col,
+                to_id_col,
+                node_id_col,
+                force_bidirectional,
+                network_type,
+                retain_all,
+                pandana_weights,
+            )
         elif graph_type == "pandana":
+            warnings.warn(
+                "graph_type='pandana' is deprecated because pandana is "
+                "unmaintained and incompatible with NumPy 2 on Windows; use "
+                "graph_type='pandarm' instead. The 'pandana' backend will be "
+                "removed in a future pyrosm release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return to_pandana(
                 nodes,
                 edges,

--- a/pyrosm/utils/__init__.py
+++ b/pyrosm/utils/__init__.py
@@ -151,9 +151,9 @@ def validate_graph_type(graph_type):
     if not isinstance(graph_type, str):
         raise ValueError("'graph_type' should be a string.")
     graph_type = graph_type.lower()
-    if graph_type not in ["networkx", "igraph", "pandana"]:
+    if graph_type not in ["networkx", "igraph", "pandana", "pandarm"]:
         raise ValueError(
-            f"'graph_type' should be 'networkx', 'igraph', or 'panadana'. "
+            f"'graph_type' should be 'networkx', 'igraph', 'pandana', or 'pandarm'. "
             f"Got '{graph_type}'."
         )
     return graph_type

--- a/pyrosm/utils/_compat.py
+++ b/pyrosm/utils/_compat.py
@@ -23,3 +23,11 @@ try:
     HAS_PANDANA = True
 except ImportError:
     HAS_PANDANA = False
+
+# pandarm is an optional dependency (the maintained, NumPy 2-compatible fork of pandana)
+try:
+    import pandarm
+
+    HAS_PANDARM = True
+except ImportError:
+    HAS_PANDARM = False

--- a/tests/test_graph_exports.py
+++ b/tests/test_graph_exports.py
@@ -770,3 +770,48 @@ def test_to_graph_api_pandarm(test_pbf):
     nodes, edges = osm.get_network(nodes=True)
     pdg = osm.to_graph(nodes, edges, graph_type="pandarm")
     assert isinstance(pdg, pandarm.Network)
+
+
+def test_validate_graph_type_rejects_unknown_type():
+    """#270 — validate_graph_type raises for unknown graph types and lists the
+    supported ones (incl. pandarm)."""
+    from pyrosm.utils import validate_graph_type
+
+    with pytest.raises(ValueError, match="pandarm"):
+        validate_graph_type("bogus")
+
+
+def test_to_graph_pandarm_retain_all(test_pbf):
+    """#270 — pandarm export with retain_all=True skips the connected-component
+    pruning and still builds a Network."""
+    pytest.importorskip("pandarm")
+    from pyrosm import OSM
+    import pandarm
+
+    osm = OSM(test_pbf)
+    nodes, edges = osm.get_network(nodes=True)
+    g = osm.to_graph(nodes, edges, graph_type="pandarm", retain_all=True)
+    assert isinstance(g, pandarm.Network)
+
+
+def test_has_pandarm_false_without_pandarm(monkeypatch):
+    """#270 — _compat.HAS_PANDARM falls back to False when pandarm is absent."""
+    import builtins
+    import importlib
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "pandarm":
+            raise ImportError("simulated missing pandarm")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    import pyrosm.utils._compat as compat
+
+    reloaded = importlib.reload(compat)
+    try:
+        assert reloaded.HAS_PANDARM is False
+    finally:
+        monkeypatch.undo()
+        importlib.reload(compat)

--- a/tests/test_graph_exports.py
+++ b/tests/test_graph_exports.py
@@ -703,3 +703,70 @@ def test_get_directed_edges_explicit_oneway_bicycle_direction():
     assert len(out) == 5  # twoway(2) + oneway(1) + contraflow(2)
     assert (2, 3) in pairs and (3, 2) not in pairs  # base oneway respected
     assert (3, 4) in pairs and (4, 3) in pairs  # oneway:bicycle=no -> both ways
+
+
+def test_pandarm_connectivity():
+    """pandarm graph export (#270).
+
+    pandarm is the maintained, NumPy 2-compatible fork of pandana, so unlike the
+    pandana tests this is NOT skipped on Windows. Skipped only when pandarm is
+    not installed.
+    """
+    pytest.importorskip("pandarm")
+    from pyrosm.graphs import to_pandarm
+    import pandas as pd
+    from pyrosm import OSM
+
+    osm = OSM(get_data("helsinki_pbf"))
+    nodes, edges = osm.get_network(nodes=True)
+
+    restaurants = osm.get_pois(custom_filter={"amenity": ["restaurant"]})
+    restaurants = restaurants.loc[restaurants["osm_type"] == "node"]
+    restaurants["employee_cnt"] = 1
+    x = restaurants["lon"]
+    y = restaurants["lat"]
+
+    g = to_pandarm(nodes, edges, retain_all=False)
+
+    assert isinstance(g.nodes_df, pd.DataFrame)
+    assert isinstance(g.edges_df, pd.DataFrame)
+
+    g.precompute(1000)
+    g.set_pois("restaurants", 1000, 5, x, y)
+
+    nearest_restaurants = g.nearest_pois(1000, "restaurants", num_pois=5)
+    assert isinstance(nearest_restaurants, pd.DataFrame)
+    assert nearest_restaurants.shape == (5297, 5)
+
+    node_ids = g.get_node_ids(x, y)
+    assert isinstance(node_ids, pd.Series)
+    assert node_ids.min() > 0
+    restaurants["node_id"] = node_ids
+
+    g.set(node_ids, variable=restaurants.employee_cnt, name="employee_cnt")
+
+    access = g.aggregate(500, type="sum", decay="linear", name="employee_cnt")
+    assert isinstance(access, pd.Series)
+    assert len(access) == 5297
+
+    shortest_distances = g.shortest_path_lengths(
+        node_ids[0:100], node_ids[100:200], imp_name="length"
+    )
+    assert isinstance(shortest_distances, list)
+    assert len(shortest_distances) == 100
+    shortest_distances = pd.Series(shortest_distances)
+    assert round(shortest_distances.min(), 0) == 22
+    assert round(shortest_distances.max(), 0) == 2457
+    assert round(shortest_distances.mean(), 0) == 879
+
+
+def test_to_graph_api_pandarm(test_pbf):
+    """Smoke-test to_graph(graph_type="pandarm") (#270). Not skipped on Windows."""
+    pytest.importorskip("pandarm")
+    from pyrosm import OSM
+    import pandarm
+
+    osm = OSM(test_pbf)
+    nodes, edges = osm.get_network(nodes=True)
+    pdg = osm.to_graph(nodes, edges, graph_type="pandarm")
+    assert isinstance(pdg, pandarm.Network)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -690,6 +690,7 @@ def test_bbox_network_nodes_cover_all_edge_endpoints():
     [
         "networkx",
         "igraph",
+        "pandarm",
         # pandana's compiled cyaccess uses C `long` buffers (32-bit on Windows),
         # but NumPy 2 makes the default integer int64, so its export is broken on
         # Windows regardless of this fix; skip there as the graph-export tests do.
@@ -717,4 +718,22 @@ def test_bbox_network_to_graph(graph_type):
     nodes, edges = osm.get_network(nodes=True)
 
     g = osm.to_graph(nodes, edges, graph_type=graph_type)
+    assert g is not None
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="pandana is incompatible with NumPy 2 on Windows (C long is 32-bit)",
+)
+def test_to_graph_pandana_emits_deprecation_warning():
+    """#270 — graph_type='pandana' still works but warns that it is deprecated in
+    favour of 'pandarm'."""
+    pytest.importorskip("pandana")
+    from pyrosm import OSM, get_data
+
+    osm = OSM(get_data("test_pbf"))
+    nodes, edges = osm.get_network(nodes=True)
+
+    with pytest.warns(DeprecationWarning, match="pandarm"):
+        g = osm.to_graph(nodes, edges, graph_type="pandana")
     assert g is not None


### PR DESCRIPTION
Closes #270.

## Summary

Adds [`pandarm`](https://github.com/oturns/pandarm) ("the pandas routing machine") — a maintained, NumPy 2-compatible friendly fork of pandana — as a new `graph_type="pandarm"` backend for `OSM.to_graph(...)`, and deprecates the `pandana` backend.

`pandana` is unmaintained and its compiled `cyaccess` uses C `long` buffers (32-bit on Windows); with NumPy 2 the default integer is int64, so pandana's own internal node-index array fails with `Buffer dtype mismatch, expected 'long' but got 'long long'` on Windows (hit on the Win 3.10–3.12 runners in #269). pandarm restores NumPy 2 compatibility and mirrors pandana's `Network` API.

## Changes

- **New backend**: `graph_type="pandarm"` returns a `pandarm.Network`. pandarm's `Network` constructor is a superset of pandana's (same first six params), so the construction logic is shared via a new `_build_routing_network` helper in `graph_export.pyx`, used by both `_create_pdgraph` (pandana) and the new `_create_pandarm_graph` (pandarm). A `to_pandarm` entry point parallels `to_pandana`.
- **Deprecation**: `graph_type="pandana"` still works where pandana is installed but now emits a `DeprecationWarning` pointing to `"pandarm"`. Removal is deferred to a future release.
- **Validation/guards**: `validate_graph_type` accepts `"pandarm"` (and the pre-existing `"panadana"` typo in its error message is fixed); `HAS_PANDARM` added to `pyrosm/utils/_compat.py` mirroring `HAS_PANDANA`. The `to_graph` docstring lists `"pandarm"` and marks `"pandana"` deprecated.
- **CI**: `pandarm` added to all `ci/*-conda.yaml` environments. pandarm has conda-forge builds for Python 3.10–3.14 on osx/linux/win, so unlike pandana its export is exercised on Windows and on 3.13/3.14.
- **Tests**: `test_pandarm_connectivity` and `test_to_graph_api_pandarm` in `test_graph_exports.py` (not Windows-skipped, since pandarm works there); a `test_to_graph_pandana_emits_deprecation_warning` regression; and `"pandarm"` added to the `#199` `test_bbox_network_to_graph` parametrization.

## Backwards compatibility

`graph_type="pandana"` continues to work where pandana is installed; only a deprecation warning is added. `HAS_PANDANA`, `to_pandana`, and `_create_pdgraph` are unchanged. The `pandana_weights` kwarg is reused for the pandarm path; no public kwarg is renamed or removed.

## Verification

- pandarm export builds a `pandarm.Network` from `get_network(nodes=True)` output (incl. the bbox case); accessibility / shortest-path results match pandana's (same OSRM engine).
- pandana export still builds and emits the `DeprecationWarning`; invalid graph types raise the corrected error message.
- `pytest tests/test_graph_exports.py tests/test_regressions.py tests/test_network_parsing.py`: all pass locally. `black --check pyrosm` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.