### PR TITLE
Fix non-dense PBF node parsing (parse_nodes) (#274)

### DIFF
--- a/ci/310-conda.yaml
+++ b/ci/310-conda.yaml
@@ -18,6 +18,7 @@ dependencies:
   - python-igraph
   # testing
   - osmnx
+  - pyosmium
   - black
   - codecov
   - pytest

--- a/ci/311-conda.yaml
+++ b/ci/311-conda.yaml
@@ -18,6 +18,7 @@ dependencies:
   - python-igraph
   # testing
   - osmnx
+  - pyosmium
   - black
   - codecov
   - pytest

--- a/ci/312-conda.yaml
+++ b/ci/312-conda.yaml
@@ -18,6 +18,7 @@ dependencies:
   - python-igraph
   # testing
   - osmnx
+  - pyosmium
   - black
   - codecov
   - pytest

--- a/ci/313-conda.yaml
+++ b/ci/313-conda.yaml
@@ -20,6 +20,7 @@ dependencies:
   - python-igraph
   # testing
   - osmnx
+  - pyosmium
   - black
   - codecov
   - pytest

--- a/ci/314-conda.yaml
+++ b/ci/314-conda.yaml
@@ -20,6 +20,7 @@ dependencies:
   - python-igraph
   # testing
   - osmnx
+  - pyosmium
   - black
   - codecov
   - pytest

--- a/pyrosm/pbfreader.pxd
+++ b/pyrosm/pbfreader.pxd
@@ -1,5 +1,5 @@
 cpdef parse_osm_data(filepath, bounding_box, exclude_relations, unix_time_filter)
 cdef get_primitive_blocks_and_string_tables(filepath)
 cdef parse_dense(pblock, data, string_table, bounding_box, unix_time_filter)
-cdef parse_nodes(pblock, data, bounding_box)
+cdef parse_nodes(pblock, data, string_table, bounding_box, unix_time_filter=*, node_id_filter=*)
 cdef parse_ways(data, stringtable, node_lookup, unix_time_filter)

--- a/pyrosm/pbfreader.pyx
+++ b/pyrosm/pbfreader.pyx
@@ -187,13 +187,18 @@ cdef parse_dense(
                  )]
 
 
-cdef parse_nodes(pblock, data, bounding_box, node_id_filter=None):
+# Handles the non-dense PBF node encoding (exercised via an osmium-generated
+# non-dense fixture in the tests).
+cdef parse_nodes(pblock, data, string_table, bounding_box, unix_time_filter=None,
+                 node_id_filter=None):
     ids = []
     versions = []
     changesets = []
     timestamps = []
     lons = []
     lats = []
+    visibles = []
+    tag_dicts = []
 
     granularity = pblock.granularity
     lon_offset = pblock.lon_offset
@@ -210,6 +215,8 @@ cdef parse_nodes(pblock, data, bounding_box, node_id_filter=None):
         timestamps.append(node.info.timestamp)
         lons.append(node.lon)
         lats.append(node.lat)
+        visibles.append(node.info.visible)
+        tag_dicts.append(parse_tags(node.keys, node.vals, string_table))
 
     id_ = np.array(ids, dtype=np.int64)
     version = np.array(versions, dtype=np.int64)
@@ -217,33 +224,52 @@ cdef parse_nodes(pblock, data, bounding_box, node_id_filter=None):
     timestamp = np.array(timestamps, dtype=np.int64)
     lon = (np.array(lons, dtype=np.int64) * granularity + lon_offset) / div
     lat = (np.array(lats, dtype=np.int64) * granularity + lat_offset) / div
+    visible = np.array(visibles, dtype=bool)
+    # Keep the same schema as parse_dense (incl. 'tags' and 'visible') so the
+    # node frame concatenates with dense nodes and the OSH 'visible' filter works.
+    tags = np.empty(len(ids), dtype=object)
+    tags[:] = tag_dicts
 
     if node_id_filter is not None:
         # Completeness pass: keep nodes by id rather than by the bounding box.
         mask = np.isin(id_, node_id_filter)
-        id_ = id_[mask]
-        version = version[mask]
-        changeset = changeset[mask]
-        timestamp = timestamp[mask]
-        lon = lon[mask]
-        lat = lat[mask]
     elif bounding_box is not None:
-        # Filter
         xmin, ymin, xmax, ymax = bounding_box
         mask = (xmin <= lon) & (lon <= xmax) & (ymin <= lat) & (lat <= ymax)
+    else:
+        mask = None
+
+    if mask is not None:
         id_ = id_[mask]
         version = version[mask]
         changeset = changeset[mask]
         timestamp = timestamp[mask]
         lon = lon[mask]
         lat = lat[mask]
+        visible = visible[mask]
+        tags = tags[mask]
+
+    if unix_time_filter is not None:
+        # Drop node versions newer than the requested timestamp (OSH files), so
+        # get_latest_version later picks the latest version at/before it.
+        time_mask = timestamp <= unix_time_filter
+        id_ = id_[time_mask]
+        version = version[time_mask]
+        changeset = changeset[time_mask]
+        timestamp = timestamp[time_mask]
+        lon = lon[time_mask]
+        lat = lat[time_mask]
+        visible = visible[time_mask]
+        tags = tags[time_mask]
 
     return dict(id=id_,
                 version=version,
                 changeset=changeset,
                 timestamp=timestamp,
                 lon=lon,
-                lat=lat
+                lat=lat,
+                tags=tags,
+                visible=visible,
                 )
 
 
@@ -414,7 +440,8 @@ cdef _parse_osm_data(
             if len(pgroup.dense.id) > 0:
                 all_nodes += parse_dense(pblock, pgroup.dense, str_table, bounding_box, unix_time_filter)
             elif len(pgroup.nodes) > 0:
-                all_nodes += parse_nodes(pblock, pgroup.nodes, bounding_box)
+                all_nodes += [parse_nodes(pblock, pgroup.nodes, str_table,
+                                          bounding_box, unix_time_filter)]
             elif len(pgroup.ways) > 0:
                 # Once all the nodes have been parsed comes Ways
                 if bounding_box is not None:
@@ -496,7 +523,8 @@ cdef _parse_osm_data(
                                                       None, unix_time_filter,
                                                       node_id_filter=node_id_filter)
                     elif len(pgroup.nodes) > 0:
-                        boundary_nodes += [parse_nodes(pblock, pgroup.nodes, None,
+                        boundary_nodes += [parse_nodes(pblock, pgroup.nodes, str_table,
+                                                       None, unix_time_filter,
                                                        node_id_filter=node_id_filter)]
             if len(boundary_nodes) > 0:
                 boundary_df = create_df(concatenate_dicts_of_arrays(boundary_nodes))

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -737,3 +737,82 @@ def test_to_graph_pandana_emits_deprecation_warning():
     with pytest.warns(DeprecationWarning, match="pandarm"):
         g = osm.to_graph(nodes, edges, graph_type="pandana")
     assert g is not None
+
+
+def test_parse_nodes_non_dense_pbf_matches_dense(tmp_path):
+    """#274 — pyrosm parses non-dense PBF node groups (pbfreader.parse_nodes) and
+    produces the same network and buildings as the dense encoding. Guards the
+    regression where parse_nodes' dict result was spread into the all_nodes list
+    as bare keys, crashing non-dense reads with 'str object has no attribute
+    keys'. A non-dense copy of the bundled test PBF is generated with osmium."""
+    import numpy as np
+
+    osmium = pytest.importorskip("osmium")
+    from pyrosm import OSM, get_data
+
+    src = get_data("test_pbf")
+    nondense = str(tmp_path / "test_nondense.osm.pbf")
+    with osmium.SimpleWriter(
+        osmium.io.File(nondense, "pbf,pbf_dense_nodes=false")
+    ) as writer:
+        for obj in osmium.FileProcessor(src):
+            writer.add(obj)
+
+    dense_edges = OSM(src).get_network()
+    nondense_edges = OSM(nondense).get_network()
+    assert nondense_edges is not None
+    assert len(nondense_edges) == len(dense_edges)
+
+    dense_buildings = OSM(src).get_buildings()
+    nondense_buildings = OSM(nondense).get_buildings()
+    assert len(nondense_buildings) == len(dense_buildings)
+    # Same geometric extent -> node coordinates parsed identically.
+    assert np.allclose(
+        nondense_buildings.total_bounds, dense_buildings.total_bounds, atol=1e-6
+    )
+
+    # POIs come from standalone (tagged) nodes, so this checks parse_nodes emits
+    # the 'tags' column with the same schema as parse_dense.
+    dense_pois = OSM(src).get_pois()
+    nondense_pois = OSM(nondense).get_pois()
+    assert nondense_pois is not None
+    assert len(nondense_pois) == len(dense_pois)
+    assert set(nondense_pois.columns) == set(dense_pois.columns)
+
+    # A bounding box exercises parse_nodes' bbox filter and the #236
+    # boundary-completion (id-filter) pass on the non-dense node groups.
+    bounds = [26.94, 60.525, 26.96, 60.535]
+    dense_bbox = OSM(src, bounding_box=bounds).get_buildings()
+    nondense_bbox = OSM(nondense, bounding_box=bounds).get_buildings()
+    assert nondense_bbox is not None
+    assert len(nondense_bbox) == len(dense_bbox)
+
+
+def test_parse_nodes_non_dense_osh_history_with_timestamp(tmp_path):
+    """#274 — parse_nodes must emit the 'visible' column like parse_dense, so a
+    non-dense *history* PBF read with a timestamp filter (which selects on
+    'visible') works instead of crashing on a missing column."""
+    osmium = pytest.importorskip("osmium")
+    from pyrosm import OSM, get_data
+
+    history = get_data("helsinki_test_history_pbf")
+    nondense = str(tmp_path / "history_nondense.osh.pbf")
+    with osmium.SimpleWriter(
+        osmium.io.File(nondense, "osh.pbf,pbf_dense_nodes=false")
+    ) as writer:
+        for obj in osmium.FileProcessor(history):
+            writer.add(obj)
+
+    dense = OSM(history).get_buildings(timestamp="2010-01-01")
+    nondense_buildings = OSM(nondense).get_buildings(timestamp="2010-01-01")
+    assert nondense_buildings is not None
+    assert len(nondense_buildings) == len(dense)
+    # Same geometry at the timestamp -> node versions newer than the timestamp
+    # were dropped (parse_nodes honours unix_time_filter), not just the latest.
+    import numpy as np
+
+    dense_geom = dense.sort_values("id").reset_index(drop=True)
+    nd_geom = nondense_buildings.sort_values("id").reset_index(drop=True)
+    assert (dense_geom["id"].tolist()) == (nd_geom["id"].tolist())
+    assert np.allclose(dense_geom.total_bounds, nd_geom.total_bounds, atol=1e-6)
+    assert (dense_geom.geometry.area.round(10) == nd_geom.geometry.area.round(10)).all()


### PR DESCRIPTION
Closes #274.

## Problem

`pbfreader.parse_nodes` (the non-dense PBF node parser) was broken; reading any non-dense PBF surfaced three bugs (see #274):

1. **Crash** — `_parse_osm_data` did `all_nodes += parse_nodes(...)`, appending the returned dict's *keys* (strings) instead of the dict, so every non-dense read died with `'str' object has no attribute 'keys'`.
2. **Missing columns** — `parse_nodes` didn't emit `tags` (non-dense node POIs lost their tags) or `visible` (an OSH history read with a timestamp crashed on the missing column).
3. **Ignored `unix_time_filter`** — historical reads could build geometry from node versions newer than the requested timestamp (future coordinates).

## Fix

- Wrap the result in a list at the call site (`+= [parse_nodes(...)]`), matching `parse_dense`.
- `parse_nodes` now returns the same schema as `parse_dense` — including `tags` (via `parse_tags`, threading the string table through) and `visible` — and applies `unix_time_filter` so node versions newer than the timestamp are dropped before `get_latest_version`.
- `.pxd` signature updated; both call sites (the main node loop and the #236 boundary-completion pass) updated.

## Tests

`pyosmium` added to all `ci/*-conda.yaml` envs. New tests in `tests/test_regressions.py` use osmium to write non-dense copies of the bundled PBFs and assert pyrosm parses them **identically** to the dense encoding:
- network edge count, building count + extent, **POIs** (column parity / tags), and a bbox parse (exercising the bbox + #236 id-filter branches);
- an **OSH history + timestamp** read compared at the geometry level (ids, total bounds, per-feature area) — this is the assertion that catches bug #3.

The tests `importorskip("osmium")`, so they skip cleanly where pyosmium is unavailable.

Verified locally: the parsing suites pass and the non-dense reads match the dense ones. `black --check pyrosm` clean.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.