### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,55 @@
 Changelog
 =========
 
+v0.7.0
+------
+
+- NEW: Add `pandarm` graph-export backend (the maintained, NumPy 2-compatible fork of pandana); deprecate `graph_type="pandana"` (#271)
+- NEW: Make cycling networks directed and honour `oneway:bicycle` (#255)
+- NEW: Add `custom_filter` to `get_network` so custom-filtered networks also return graph nodes (#264)
+- NEW: Add `street_count` node attribute to the NetworkX export (compatible with OSMnx `basic_stats`) (#265)
+- NEW: Support combining `custom_filter` `True` with explicit tag values (#251)
+- Support Python 3.10–3.14 (drop 3.9) and fix OSH parsing under pandas 3.0 (#248)
+
+- Return complete (uncut) geometries for ways/edges that straddle a bounding-box edge (#268)
+- Keep bounding-box network `nodes` consistent with the kept `edges` so graph export works without manual cleanup (#269)
+- Fix non-dense PBF node parsing (`parse_nodes`) (#275)
+- Handle bounding boxes that select no nodes instead of raising `KeyError` (#267)
+- Fix `custom_filter` with `highway` turning closed-way polygons into lines (#266)
+- Fix network exclude/keep filters leaking on multi-key filters (#263)
+- Fix duplicate "phantom" nodes in the NetworkX export (#259)
+- Correct relation ids and surface a colliding `id` tag as `id_tag` (#234, #249)
+- Stop `get_*` methods from mutating the shared default-tag config (#252)
+- Fix spurious pandas chained-assignment warnings from the Cython frame builders (#256)
+- Fix Geofabrik UK sub-region downloads (moved under `united-kingdom`) (#258)
+- Fix reading PBF produced by `osmconvert` (#238)
+- Fix documentation URL (#223)
+
+- Measure Cython (`.pyx`) coverage and raise overall test coverage (#273)
+- Document the `pandarm` graph backend and the `pandana` deprecation, and reading OSM history files (`.osh.pbf`) (#257)
+- Fix the Read the Docs build; run live download tests on a single CI runner; bump GitHub Actions to Node 24 (#250, #254, #260)
+
+Thanks for all the contributors who helped to improve the library either via PRs or reporting bugs:
+
+- AnBowell (#233, #234)
+- eracle (#238)
+- meeuw (#174, #178)
+- mattijsdp (#224, #226)
+- Jontata (#237)
+- anatrk (#112)
+- Eph97 (#117)
+- gregoriiv (#144)
+- chourmo (#170)
+- arredond (#176)
+- lenkahas (#181)
+- rohanaras (#199)
+- AdrianKriger (#236)
+- my4ng (#239)
+- skull3r7 (#241)
+- wood-chris (#243)
+- llebocq (#247)
+
+
 v0.6.2
 ------
 

--- a/docs/basics.ipynb
+++ b/docs/basics.ipynb
@@ -2199,13 +2199,13 @@
    "source": [
     "## Export street networks to graph\n",
     "\n",
-    "If you want to analyze the street networks using your favourite network analysis library, you can export the street network from Pyrosm into a graph (new in version 0.6.0). Supported graphs are `iGraph`, `NetworkX` (compatible with `OSMnx`) and `Pandana`. Those libraries provide numerous possibilities to analyze different properties of the graph (e.g. centrality) or conduct e.g. shortest path analysis to find the fastest (or shortest) route from a location to another. Notice that the numerous algorithms provided by these libraries are **not** going to be integrated into Pyrosm, but you can easily export the graphs to these libraries and continue working with them.\n",
+    "If you want to analyze the street networks using your favourite network analysis library, you can export the street network from Pyrosm into a graph (new in version 0.6.0). Supported graphs are `iGraph`, `NetworkX` (compatible with `OSMnx`), `Pandarm` and `Pandana`. Those libraries provide numerous possibilities to analyze different properties of the graph (e.g. centrality) or conduct e.g. shortest path analysis to find the fastest (or shortest) route from a location to another. Notice that the numerous algorithms provided by these libraries are **not** going to be integrated into Pyrosm, but you can easily export the graphs to these libraries and continue working with them.\n",
     "\n",
     "Exporting the network into a graph can be done as follows:\n",
     "\n",
     " 1. Retrieve the graph elements (nodes and edges) from a given OSM network by specifying `nodes=True` in the `osm.get_network()` function.\n",
     " 2. Use `osm.to_graph()` function to convert the nodes and edges into a graph. \n",
-    "    - The output graph type can be specified with `graph_type` parameter. Available types are: `\"igraph\"` (default), `\"networkx\"` and `\"pandana\"`.\n",
+    "    - The output graph type can be specified with `graph_type` parameter. Available types are: `\"igraph\"` (default), `\"networkx\"`, `\"pandarm\"` and `\"pandana\"` (deprecated; use `\"pandarm\"`).\n",
     "    \n",
     "Following sections show how to do this in practice.\n",
     "\n",
@@ -2625,11 +2625,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Export to Pandana\n",
+    "### Export to Pandarm\n",
     "\n",
-    "[Pandana](http://udst.github.io/pandana/) is a Python library for conducting accessibility/reachability analysis using contraction hierarchies algorithm. It has useful functionalities to conduct more specific queries such as \"find me all restaurants that are within 500 meters from given locations (e.g. buildings)\".\n",
+    "[Pandarm](https://github.com/oturns/pandarm) (the maintained, NumPy 2-compatible fork of [Pandana](http://udst.github.io/pandana/)) is a Python library for conducting accessibility/reachability analysis using the contraction hierarchies algorithm. It has useful functionalities to conduct more specific queries such as \"find me all restaurants that are within 500 meters from given locations (e.g. buildings)\".\n",
     "\n",
-    "Exporting the OSM street network to Pandana works in a similar manner as with the previous ones. By specifying graph_type=\"pandana\" for the to_graph() function, the output will be a pandana graph. In addition, you can specify with `pandana_weights` -parameter which columns in your `edges` data is used as *edge weights* in the pandana graph. By default `length` column is used but you can add any other numerical column as an edge weight (you can use multiple weights in the same graph):"
+    "Exporting the OSM street network to Pandarm works in a similar manner as with the previous ones. By specifying `graph_type=\"pandarm\"` for the `to_graph()` function, the output will be a pandarm graph. In addition, you can specify with `pandana_weights` -parameter which columns in your `edges` data is used as *edge weights* in the graph. By default `length` column is used but you can add any other numerical column as an edge weight (you can use multiple weights in the same graph):\n",
+    "\n",
+    "```{note}\n",
+    "\n",
+    "`graph_type=\"pandana\"` is still accepted for backwards compatibility, but **pandana is deprecated** (unmaintained and incompatible with NumPy 2 on Windows) and will be removed in a future release. Use `\"pandarm\"` instead.\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -2640,7 +2646,7 @@
     {
      "data": {
       "text/plain": [
-       "<pandana.network.Network at 0x7f7904c5c820>"
+       "<pandarm.network.Network at 0x7f7904c5c820>"
       ]
      },
      "execution_count": 47,
@@ -2653,8 +2659,8 @@
     "osm = OSM(get_data(\"test_pbf\"))\n",
     "nodes, edges = osm.get_network(nodes=True, network_type=\"driving\")\n",
     "\n",
-    "# Export the nodes and edges to Pandana graph\n",
-    "G = osm.to_graph(nodes, edges, graph_type=\"pandana\", pandana_weights=[\"length\"])\n",
+    "# Export the nodes and edges to Pandarm graph\n",
+    "G = osm.to_graph(nodes, edges, graph_type=\"pandarm\", pandana_weights=[\"length\"])\n",
     "G"
    ]
   },
@@ -2662,7 +2668,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As an output, you get a directed pandana `Network` object that can be used for further analysis using pandana.\n",
+    "As an output, you get a directed pandarm `Network` object that can be used for further analysis using pandarm.\n",
     "\n",
     "See all available parameters of `to_graph()` [from here](#to-graph-parameters-explained) and usage examples from [working with graphs](graphs.ipynb).\n"
    ]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,55 @@
 Changelog
 =========
 
+v0.7.0 (Jun 7, 2026)
+--------------------
+
+- NEW: Add ``pandarm`` graph-export backend (the maintained, NumPy 2-compatible fork of pandana); deprecate ``graph_type="pandana"`` (#271)
+- NEW: Make cycling networks directed and honour ``oneway:bicycle`` (#255)
+- NEW: Add ``custom_filter`` to ``get_network`` so custom-filtered networks also return graph nodes (#264)
+- NEW: Add ``street_count`` node attribute to the NetworkX export (compatible with OSMnx ``basic_stats``) (#265)
+- NEW: Support combining ``custom_filter`` ``True`` with explicit tag values (#251)
+- Support Python 3.10–3.14 (drop 3.9) and fix OSH parsing under pandas 3.0 (#248)
+
+- Return complete (uncut) geometries for ways/edges that straddle a bounding-box edge (#268)
+- Keep bounding-box network ``nodes`` consistent with the kept ``edges`` so graph export works without manual cleanup (#269)
+- Fix non-dense PBF node parsing (``parse_nodes``) (#275)
+- Handle bounding boxes that select no nodes instead of raising ``KeyError`` (#267)
+- Fix ``custom_filter`` with ``highway`` turning closed-way polygons into lines (#266)
+- Fix network exclude/keep filters leaking on multi-key filters (#263)
+- Fix duplicate "phantom" nodes in the NetworkX export (#259)
+- Correct relation ids and surface a colliding ``id`` tag as ``id_tag`` (#234, #249)
+- Stop ``get_*`` methods from mutating the shared default-tag config (#252)
+- Fix spurious pandas chained-assignment warnings from the Cython frame builders (#256)
+- Fix Geofabrik UK sub-region downloads (moved under ``united-kingdom``) (#258)
+- Fix reading PBF produced by ``osmconvert`` (#238)
+- Fix documentation URL (#223)
+
+- Measure Cython (``.pyx``) coverage and raise overall test coverage (#273)
+- Document the ``pandarm`` graph backend and the ``pandana`` deprecation, and reading OSM history files (``.osh.pbf``) (#257)
+- Fix the Read the Docs build; run live download tests on a single CI runner; bump GitHub Actions to Node 24 (#250, #254, #260)
+
+Thanks for all the contributors who helped to improve the library either via PRs or reporting bugs:
+
+- AnBowell (#233, #234)
+- eracle (#238)
+- meeuw (#174, #178)
+- mattijsdp (#224, #226)
+- Jontata (#237)
+- anatrk (#112)
+- Eph97 (#117)
+- gregoriiv (#144)
+- chourmo (#170)
+- arredond (#176)
+- lenkahas (#181)
+- rohanaras (#199)
+- AdrianKriger (#236)
+- my4ng (#239)
+- skull3r7 (#241)
+- wood-chris (#243)
+- llebocq (#247)
+
+
 v0.6.2 (Oct 26, 2023)
 ---------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,13 +19,16 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
+from datetime import datetime
+
+current_year = datetime.now().year
 
 project = "pyrosm"
-copyright = "2020, Henrikki Tenkanen + pyrosm contributors"
+copyright = f"2020-{current_year}, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.6.2"
+version = release = "0.7.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/graphs.ipynb
+++ b/docs/graphs.ipynb
@@ -877,9 +877,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Calculate the job accessibility in Helsinki Region with pyrosm + pandana\n",
+    "## Calculate the job accessibility in Helsinki Region with pyrosm + pandarm\n",
     "\n",
-    "[Pandana](https://github.com/UDST/pandana/) is a third Python network analysis library supported by `pyrosm` export functionality at the time of writing. Pandana operates using a fast [contraction hierarchies](https://en.wikipedia.org/wiki/Contraction_hierarchies) -algorithm and includes various useful functions. In this tutorial, we will see 1) how to calculate distance to nearest 5 restaurants for each network node in the Helsinki Region, and 2) how to calculate a simple job accessibility index for the region based on number of restaurant employees (simulated). "
+    "[Pandarm](https://github.com/oturns/pandarm) (the maintained, NumPy 2-compatible fork of [pandana](https://github.com/UDST/pandana/)) is a Python network analysis library supported by `pyrosm` export functionality. Pandarm operates using a fast [contraction hierarchies](https://en.wikipedia.org/wiki/Contraction_hierarchies) -algorithm and includes various useful functions. In this tutorial, we will see 1) how to calculate distance to nearest 5 restaurants for each network node in the Helsinki Region, and 2) how to calculate a simple job accessibility index for the region based on number of restaurant employees (simulated).\n",
+    "\n",
+    "```{note}\n",
+    "\n",
+    "`pyrosm` also still accepts `graph_type=\"pandana\"`, but **pandana is deprecated** because it is unmaintained and incompatible with NumPy 2 on Windows. Use `\"pandarm\"` (a drop-in replacement with the same API) instead.\n",
+    "\n",
+    "```"
    ]
   },
   {
@@ -902,7 +908,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G = osm.to_graph(nodes, edges, graph_type=\"pandana\")"
+    "G = osm.to_graph(nodes, edges, graph_type=\"pandarm\")"
    ]
   },
   {
@@ -933,7 +939,7 @@
    "source": [
     "### Find nearest X number of POIs for each network node\n",
     "\n",
-    "After we have done precalculations with pandana, it allows conducting performant queries, such as querying distances to X number of nearest restaurants for all network nodes.\n",
+    "After we have done precalculations with pandarm, it allows conducting performant queries, such as querying distances to X number of nearest restaurants for all network nodes.\n",
     "\n",
     "- The following example shows how to find the 5 closest restaurants from each network node (up to 2000 meter distance threshold):"
    ]
@@ -1105,7 +1111,7 @@
    "source": [
     "### Calculate the job accessibility\n",
     "\n",
-    "Next we will use a useful pandana function called `aggregate` that allows to calculate accessibility index based on a given numeric variable, such as employee count. Here, we won't be using any real employee information, but assign a random number of employees for each restaurant (between 1-10). Then we will calculate a specific job accessibility index based on cumulative number of restaurant employees within 500 meters (from each network node). This kind of index can provide a nice overview of the (restaurant) job accessibility in a city. "
+    "Next we will use a useful pandarm function called `aggregate` that allows to calculate accessibility index based on a given numeric variable, such as employee count. Here, we won't be using any real employee information, but assign a random number of employees for each restaurant (between 1-10). Then we will calculate a specific job accessibility index based on cumulative number of restaurant employees within 500 meters (from each network node). This kind of index can provide a nice overview of the (restaurant) job accessibility in a city. "
    ]
   },
   {

--- a/pyrosm/__init__.py
+++ b/pyrosm/__init__.py
@@ -1,2 +1,9 @@
+from importlib.metadata import version, PackageNotFoundError
+
 from pyrosm.data import get_data, get_path  # drop get_path in the future
 from pyrosm.pyrosm import OSM
+
+try:
+    __version__ = version("pyrosm")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if _linetrace:
 
 setup(
     name="pyrosm",
-    version="0.6.2",
+    version="0.7.0",
     license="MIT",
     description="A Python tool to parse OSM data from Protobuf format into GeoDataFrame.",
     long_description=read_long_description(),
@@ -93,7 +93,7 @@ setup(
     ],
     project_urls={
         "Documentation": "https://pyrosm.readthedocs.org/",
-        "Issue Tracker": "https://github.com/htenkanen/pyrosm/issues",
+        "Issue Tracker": "https://github.com/pyrosm/pyrosm/issues",
     },
     keywords=[
         "OpenStreetMap",

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -816,3 +816,26 @@ def test_parse_nodes_non_dense_osh_history_with_timestamp(tmp_path):
     assert (dense_geom["id"].tolist()) == (nd_geom["id"].tolist())
     assert np.allclose(dense_geom.total_bounds, nd_geom.total_bounds, atol=1e-6)
     assert (dense_geom.geometry.area.round(10) == nd_geom.geometry.area.round(10)).all()
+
+
+def test_version_attribute_and_unknown_fallback(monkeypatch):
+    """#277 — pyrosm exposes __version__ from the installed distribution
+    metadata, falling back to 'unknown' when pyrosm is not installed as a
+    distribution (e.g. imported straight from a source tree)."""
+    import importlib
+    import importlib.metadata
+
+    import pyrosm
+
+    assert isinstance(pyrosm.__version__, str) and pyrosm.__version__
+
+    def _raise(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", _raise)
+    try:
+        importlib.reload(pyrosm)
+        assert pyrosm.__version__ == "unknown"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(pyrosm)


### PR DESCRIPTION
Prepares the **v0.7.0** release. The diff here is release packaging only; the substantive work is the PRs merged to `master` since v0.6.2, listed below.

## Key changes

**New**
- `pandarm` graph-export backend (maintained, NumPy-2-compatible fork of pandana); `graph_type="pandana"` deprecated (#271)
- Directed cycling networks honouring `oneway:bicycle` (#255)
- `custom_filter` on `get_network` so custom-filtered networks return graph nodes (#264); combine `custom_filter` `True` with explicit values (#251)
- `street_count` node attribute in the NetworkX export (OSMnx `basic_stats`-compatible) (#265)
- Python 3.10–3.14 (drop 3.9); OSH parsing under pandas 3.0 (#248)

**Fixes**
- Complete bbox-straddling geometries (#268); bbox node/edge consistency (#269); empty-bbox `KeyError` (#267)
- Non-dense PBF node parsing (#275); closed-way polygon typing under `custom_filter` (#266); multi-key filter leak (#263)
- Phantom nodes in NetworkX export (#259); relation ids + `id_tag` (#234, #249); shared tag-config mutation (#252)
- Chained-assignment warnings (#256); Geofabrik UK sub-regions (#258); `osmconvert` PBF (#238); doc URL (#223)

**Docs / CI**
- Cython coverage measurement (#273); pandarm + OSH-history docs (#257); RTD build, single-runner downloads, Node 24 actions (#250, #254, #260)

## Packaging in this PR
- Version → 0.7.0 (`setup.py`, `docs/conf.py`); v0.7.0 changelog entries (`CHANGELOG.md`, `docs/changelog.rst`)
- `pyrosm.__version__` now exposed (read from installed metadata)
- pandarm documented as the recommended graph backend in the tutorials; copyright year fixed in `docs/conf.py`

Full list and contributor credits are in the changelog.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
