### PR TITLE
Update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Pyrosm 
-[![Conda version](https://anaconda.org/conda-forge/pyrosm/badges/version.svg)](https://anaconda.org/conda-forge/pyrosm/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyrosm.svg)](https://anaconda.org/conda-forge/pyrosm)
 [![PyPI version](https://badge.fury.io/py/pyrosm.svg)](https://badge.fury.io/py/pyrosm)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyrosm.svg?logo=python&logoColor=%23fff)](https://pypi.org/project/pyrosm)
 [![Documentation Status](https://readthedocs.org/projects/pyrosm/badge/?version=latest)](https://pyrosm.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://codecov.io/gh/pyrosm/pyrosm/branch/master/graph/badge.svg)](https://codecov.io/gh/pyrosm/pyrosm) 
+[![CodeFactor](https://www.codefactor.io/repository/github/pyrosm/pyrosm/badge)](https://www.codefactor.io/repository/github/pyrosm/pyrosm)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/pyrosm?color=yellow&label=Downloads)](https://pypistats.org/packages/pyrosm)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3755057.svg)](https://doi.org/10.5281/zenodo.3755057)
 [![License](https://anaconda.org/conda-forge/pyrosm/badges/license.svg)](https://anaconda.org/conda-forge/pyrosm/)


### PR DESCRIPTION
Updates the badge block at the top of the README:

- **Conda version** badge switched to the `img.shields.io/conda/vn/conda-forge/pyrosm` format.
- **PyPI - Python Version** badge added, linking to the PyPI project page and showing supported Python versions.
- **CodeFactor** badge added, linking to the CodeFactor repository page.

All three are Markdown-format badges consistent with the rest of the badge block.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
