### PR TITLE
Accept pathlib.Path filepaths in OSM constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Accept `pathlib.Path` (and any `os.PathLike`) filepaths in the `OSM` constructor, not just strings (#145)
 - CHANGED: Replace the [Pyrobuf](https://github.com/appnexus/pyrobuf) PBF backend with [Google's Protobuf](https://protobuf.dev/) (its fast C `upb` backend) for parsing the protocol-buffer messages. Pyrobuf is unmaintained and its source build fails with modern `setuptools` (breaking `pip install pyrosm`); Google's Protobuf is actively maintained and ships wheels and conda-forge packages for Python 3.10–3.14. Parsing speed is unchanged — see `benchmarks/README.md`. v0.7.0 was the last release using Pyrobuf. (#276)
 
 v0.7.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Accept ``pathlib.Path`` (and any ``os.PathLike``) filepaths in the ``OSM`` constructor, not just strings (#145)
 - CHANGED: Replace the `Pyrobuf <https://github.com/appnexus/pyrobuf>`_ PBF backend with `Google's Protobuf <https://protobuf.dev/>`_ (its fast C ``upb`` backend) for parsing the protocol-buffer messages. Pyrobuf is unmaintained and its source build fails with modern ``setuptools`` (breaking ``pip install pyrosm``); Google's Protobuf is actively maintained and ships wheels and conda-forge packages for Python 3.10–3.14. Parsing speed is unchanged — see the `backend benchmark <https://github.com/pyrosm/pyrosm/blob/master/benchmarks/README.md>`_. v0.7.0 was the last release using Pyrobuf. (#276)
 
 v0.7.0 (Jun 7, 2026)

--- a/pyrosm/utils/__init__.py
+++ b/pyrosm/utils/__init__.py
@@ -136,8 +136,10 @@ def validate_bounding_box(geom):
 
 
 def validate_input_file(filepath):
+    if isinstance(filepath, os.PathLike):
+        filepath = os.fspath(filepath)
     if not isinstance(filepath, str):
-        raise ValueError("'filepath' should be a string.")
+        raise ValueError("'filepath' should be a string or os.PathLike object.")
     if not filepath.endswith(".pbf"):
         raise ValueError(
             f"Input data should be in Protobuf format (*.osm.pbf). "

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -77,6 +77,17 @@ def test_boundaries(helsinki_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
 
+def test_passing_pathlib_path(test_pbf):
+    from pathlib import Path
+    from pyrosm import OSM
+    from geopandas import GeoDataFrame
+
+    osm = OSM(Path(test_pbf))
+    assert isinstance(osm.filepath, str)
+    gdf = osm.get_network()
+    assert isinstance(gdf, GeoDataFrame)
+
+
 def test_passing_incorrect_filepath():
     from pyrosm import OSM
 


### PR DESCRIPTION
Closes #145.

## Summary

The `OSM` constructor now accepts `pathlib.Path` (and any `os.PathLike`) filepaths, not just plain strings.

## Changes

- `pyrosm/utils/__init__.py`: `validate_input_file` converts an `os.PathLike` input via `os.fspath()` before the existing `.pbf`-extension and existence checks, and returns a `str`. The type-error message now states that a string or `os.PathLike` object is accepted. Returning a string keeps all downstream code unchanged — the `.osh.pbf` history-file detection (`self.filepath.lower()`) and the Cython `parse_osm_data` / `open(...)` calls continue to receive a string.
- `tests/test_main.py`: add `test_passing_pathlib_path`, which constructs `OSM(Path(test_pbf))`, asserts `osm.filepath` is a `str`, and that `get_network()` returns a `GeoDataFrame` (path usable end-to-end). The existing `test_passing_incorrect_filepath` (rejects `OSM(11)`) and `test_passing_wrong_file_format` (rejects `OSM("test.osm")`) still pass.
- Changelog entries added under `Unreleased` in `CHANGELOG.md` and `docs/changelog.rst`.

## Verification

- `pytest tests/test_main.py tests/test_utils.py` — 17 pass, including the new test.
- `black --check pyrosm` and `flake8 pyrosm` — clean.
- Codex code review (working-tree scope) returned no high-, medium-, or low-severity issues.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
