### PR TITLE
Raise a meaningful error for non-OSM-PBF input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Raise a clear `InvalidOSMFileError` when the input `.pbf` is not a valid OSM PBF file, instead of a cryptic zlib/protobuf error (#160)
+- FIXED: `get_bounding_box` now reads the header bounding box correctly; it returned `None` for every file after the protobuf backend migration (#160)
 - NEW: Accept `pathlib.Path` (and any `os.PathLike`) filepaths in the `OSM` constructor, not just strings (#145)
 - CHANGED: Replace the [Pyrobuf](https://github.com/appnexus/pyrobuf) PBF backend with [Google's Protobuf](https://protobuf.dev/) (its fast C `upb` backend) for parsing the protocol-buffer messages. Pyrobuf is unmaintained and its source build fails with modern `setuptools` (breaking `pip install pyrosm`); Google's Protobuf is actively maintained and ships wheels and conda-forge packages for Python 3.10–3.14. Parsing speed is unchanged — see `benchmarks/README.md`. v0.7.0 was the last release using Pyrobuf. (#276)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Raise a clear ``InvalidOSMFileError`` when the input ``.pbf`` is not a valid OSM PBF file, instead of a cryptic zlib/protobuf error (#160)
+- FIXED: ``get_bounding_box`` now reads the header bounding box correctly; it returned ``None`` for every file after the protobuf backend migration (#160)
 - NEW: Accept ``pathlib.Path`` (and any ``os.PathLike``) filepaths in the ``OSM`` constructor, not just strings (#145)
 - CHANGED: Replace the `Pyrobuf <https://github.com/appnexus/pyrobuf>`_ PBF backend with `Google's Protobuf <https://protobuf.dev/>`_ (its fast C ``upb`` backend) for parsing the protocol-buffer messages. Pyrobuf is unmaintained and its source build fails with modern ``setuptools`` (breaking ``pip install pyrosm``); Google's Protobuf is actively maintained and ships wheels and conda-forge packages for Python 3.10–3.14. Parsing speed is unchanged — see the `backend benchmark <https://github.com/pyrosm/pyrosm/blob/master/benchmarks/README.md>`_. v0.7.0 was the last release using Pyrobuf. (#276)
 

--- a/pyrosm/exceptions/__init__.py
+++ b/pyrosm/exceptions/__init__.py
@@ -4,3 +4,7 @@ class PBFException(Exception):
 
 class PBFNotImplemented(PBFException):
     pass
+
+
+class InvalidOSMFileError(PBFException):
+    pass

--- a/pyrosm/utils/__init__.py
+++ b/pyrosm/utils/__init__.py
@@ -2,7 +2,8 @@ from shapely import ops
 from shapely.geometry import MultiLineString, Polygon, MultiPolygon, box
 from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
 from pyrosm.proto.osmformat_pb2 import HeaderBlock
-from pyrosm.exceptions import PBFNotImplemented
+from pyrosm.exceptions import PBFNotImplemented, InvalidOSMFileError
+from google.protobuf.message import DecodeError
 import zlib
 from struct import unpack
 import os
@@ -188,38 +189,67 @@ def valid_header_block(header_block):
     return True
 
 
+# The OSM PBF spec caps a BlobHeader at 64 KiB; a larger declared size is a
+# strong signal the file is not an OSM PBF (matches osmium's check).
+_MAX_BLOB_HEADER_SIZE = 64 * 1024
+
+
 def get_bounding_box(filepath):
+    invalid = (
+        f"'{filepath}' is not a valid OSM PBF file. Pyrosm reads OpenStreetMap "
+        f"data in the OSM PBF format "
+        f"(https://wiki.openstreetmap.org/wiki/PBF_Format); this file does not "
+        f"follow the OSM PBF schema"
+    )
     with open(filepath, "rb") as f:
-        # Check that the data stream is valid OSM
-        # =======================================
-
+        # The first fileblock of an OSM PBF is an 'OSMHeader' BlobHeader.
         buf = f.read(4)
+        if len(buf) < 4:
+            raise InvalidOSMFileError(
+                invalid + " (file is too short to contain a header)."
+            )
         msg_len = unpack("!L", buf)[0]
-        msg = BlobHeader()
-        msg.ParseFromString(f.read(msg_len))
-        blob_header = msg
+        if msg_len > _MAX_BLOB_HEADER_SIZE:
+            raise InvalidOSMFileError(
+                invalid + f" (declared BlobHeader size {msg_len} exceeds the "
+                f"{_MAX_BLOB_HEADER_SIZE}-byte maximum)."
+            )
+        blob_header = BlobHeader()
+        try:
+            blob_header.ParseFromString(f.read(msg_len))
+        except DecodeError:
+            raise InvalidOSMFileError(
+                invalid + " (the BlobHeader could not be parsed)."
+            ) from None
+        if blob_header.type != "OSMHeader":
+            raise InvalidOSMFileError(
+                invalid
+                + f" (first block is '{blob_header.type}', expected 'OSMHeader')."
+            )
 
-        msg = Blob()
-        msg.ParseFromString(f.read(blob_header.datasize))
-        blob_data = zlib.decompress(msg.zlib_data)
-        header_block = HeaderBlock()
-        header_block.ParseFromString(blob_data)
+        blob = Blob()
+        try:
+            blob.ParseFromString(f.read(blob_header.datasize))
+            blob_data = zlib.decompress(blob.zlib_data)
+            header_block = HeaderBlock()
+            header_block.ParseFromString(blob_data)
+        except (DecodeError, zlib.error) as e:
+            raise InvalidOSMFileError(invalid + f" ({e}).") from None
 
-        # Validate header
-        if valid_header_block(header_block):
-            # Parse bounding box
-            try:
-                bb = header_block.bbox.SerializeToDict()
-                div = 1000000000
-                bbox = box(
-                    bb["left"] / div,
-                    bb["bottom"] / div,
-                    bb["right"] / div,
-                    bb["top"] / div,
-                )
-            except Exception:
-                bbox = None
-            return bbox
+        # Validate required features (raises PBFNotImplemented on unknown ones).
+        valid_header_block(header_block)
+
+        # Parse the optional data bounding box (in nano-degrees).
+        if not header_block.HasField("bbox"):
+            return None
+        bb = header_block.bbox
+        div = 1000000000
+        return box(
+            bb.left / div,
+            bb.bottom / div,
+            bb.right / div,
+            bb.top / div,
+        )
 
 
 def datetime_to_unix_time(dt):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,3 +108,39 @@ def test_passing_wrong_file_format():
         pass
     except Exception as e:
         raise e
+
+
+def test_invalid_osm_pbf_raises_meaningful_error(tmp_path):
+    """A '.pbf' that is not a valid OSM PBF should raise InvalidOSMFileError."""
+    import struct
+    from pyrosm import OSM
+    from pyrosm.exceptions import InvalidOSMFileError
+    from pyrosm.proto.fileformat_pb2 import BlobHeader
+
+    # 1) Too short to contain a header.
+    short = tmp_path / "short.pbf"
+    short.write_bytes(b"\x00\x00")
+    with pytest.raises(InvalidOSMFileError):
+        OSM(short)
+
+    # 2) Declared BlobHeader size beyond the 64 KiB maximum.
+    oversized = tmp_path / "oversized.pbf"
+    oversized.write_bytes(struct.pack("!L", 5_000_000) + b"garbage" * 100)
+    with pytest.raises(InvalidOSMFileError):
+        OSM(oversized)
+
+    # 3) A parseable BlobHeader whose first block is not an 'OSMHeader'
+    #    (e.g. a non-OSM PBF such as a vector-tile PBF).
+    header = BlobHeader(type="NotOSMHeader", datasize=5).SerializeToString()
+    wrong_type = tmp_path / "wrong_type.pbf"
+    wrong_type.write_bytes(struct.pack("!L", len(header)) + header + b"\x00" * 5)
+    with pytest.raises(InvalidOSMFileError):
+        OSM(wrong_type)
+
+    # 4) Correct 'OSMHeader' type but a payload that is not zlib-compressed
+    #    (reproduces the cryptic "Error -5 while decompressing data" from #156).
+    header = BlobHeader(type="OSMHeader", datasize=20).SerializeToString()
+    bad_zlib = tmp_path / "bad_zlib.pbf"
+    bad_zlib.write_bytes(struct.pack("!L", len(header)) + header + b"notzlibdata000000000")
+    with pytest.raises(InvalidOSMFileError):
+        OSM(bad_zlib)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -144,3 +144,9 @@ def test_invalid_osm_pbf_raises_meaningful_error(tmp_path):
     bad_zlib.write_bytes(struct.pack("!L", len(header)) + header + b"notzlibdata000000000")
     with pytest.raises(InvalidOSMFileError):
         OSM(bad_zlib)
+
+    # 5) A BlobHeader whose bytes are not valid protobuf (truncated varint).
+    malformed = tmp_path / "malformed_header.pbf"
+    malformed.write_bytes(struct.pack("!L", 1) + b"\x08")
+    with pytest.raises(InvalidOSMFileError):
+        OSM(malformed)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -839,3 +839,19 @@ def test_version_attribute_and_unknown_fallback(monkeypatch):
     finally:
         monkeypatch.undo()
         importlib.reload(pyrosm)
+
+
+def test_get_bounding_box_returns_polygon_for_valid_pbf():
+    """#160 — get_bounding_box must read the header bbox via protobuf field
+    access, not the pyrobuf-only SerializeToDict() that the backend migration
+    left behind (which silently returned None for every file)."""
+    from shapely.geometry import Polygon
+    from pyrosm import get_data
+    from pyrosm.utils import get_bounding_box
+
+    bbox = get_bounding_box(get_data("helsinki_pbf"))
+    assert isinstance(bbox, Polygon)
+    minx, miny, maxx, maxy = bbox.bounds
+    # Helsinki sits around lon ~25, lat ~60.
+    assert 24 < minx < maxx < 26
+    assert 60 < miny < maxy < 61

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -855,3 +855,22 @@ def test_get_bounding_box_returns_polygon_for_valid_pbf():
     # Helsinki sits around lon ~25, lat ~60.
     assert 24 < minx < maxx < 26
     assert 60 < miny < maxy < 61
+
+
+def test_get_bounding_box_returns_none_without_header_bbox(tmp_path):
+    """#160 — a valid OSM PBF whose header carries no bbox yields None, not an
+    error and not a degenerate Polygon."""
+    import struct
+    import zlib
+    from pyrosm.utils import get_bounding_box
+    from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
+    from pyrosm.proto.osmformat_pb2 import HeaderBlock
+
+    header = HeaderBlock()
+    header.required_features.append("OsmSchema-V0.6")
+    blob_bytes = Blob(zlib_data=zlib.compress(header.SerializeToString())).SerializeToString()
+    blob_header = BlobHeader(type="OSMHeader", datasize=len(blob_bytes)).SerializeToString()
+    pbf = tmp_path / "no_bbox.pbf"
+    pbf.write_bytes(struct.pack("!L", len(blob_header)) + blob_header + blob_bytes)
+
+    assert get_bounding_box(pbf) is None


### PR DESCRIPTION
Closes #160 (see also #156).

## Summary

When the input `.pbf` is not a valid OSM PBF file (e.g. a vector-tile / TileMapService PBF, or a truncated/corrupt file), pyrosm now raises a clear `InvalidOSMFileError` at `OSM(...)` construction instead of a cryptic low-level error such as `zlib.error: Error -5 while decompressing data: incomplete or truncated stream` (#156) or a protobuf `DecodeError`.

## Changes

- `pyrosm/exceptions/__init__.py`: add `InvalidOSMFileError(PBFException)`.
- `pyrosm/utils/__init__.py`: rewrite `get_bounding_box` (the eager header read called from the `OSM` constructor) to validate the OSM PBF header and raise `InvalidOSMFileError` with a clear, actionable message for each failure mode:
  - file too short to contain the 4-byte length prefix;
  - declared BlobHeader size above the 64 KiB OSM PBF maximum (a strong non-OSM signal; matches osmium);
  - BlobHeader that fails to parse (`DecodeError`);
  - first block whose `type` is not `"OSMHeader"` (the OSM PBF spec requires it);
  - Blob/HeaderBlock that fail to parse or whose payload is not zlib-compressed (`DecodeError` / `zlib.error` — the #156 case).
  The message names the file, states it is not a valid OSM PBF, links the OSM PBF format, and includes the specific reason; `from None` suppresses the cryptic chained traceback.
- Same function: fix a backend-migration regression — `header_block.bbox.SerializeToDict()` is a pyrobuf-only method that does not exist on Google's protobuf, so the call always raised `AttributeError`, was swallowed by a bare `except`, and made `get_bounding_box` return `None` for every file. It now reads the bbox via direct protobuf field access (`bbox.left/bottom/right/top`, guarded by `HasField("bbox")`) and returns a real `Polygon`.

## Tests

- `tests/test_main.py::test_invalid_osm_pbf_raises_meaningful_error` — asserts `InvalidOSMFileError` for four crafted bad `.pbf` files (too short; oversized BlobHeader; parseable BlobHeader with a non-`OSMHeader` type; correct `OSMHeader` type but non-zlib payload reproducing #156), built with `tmp_path` and the real `BlobHeader` proto class so the actual code path runs. Existing input-validation tests still pass.
- `tests/test_regressions.py::test_get_bounding_box_returns_polygon_for_valid_pbf` — guards the `SerializeToDict` regression: the bundled Helsinki PBF yields a `Polygon` with bounds around Helsinki, not `None`.

## Verification

- `pytest tests/test_main.py tests/test_regressions.py tests/test_utils.py` — 55 pass, including the new tests.
- `black --check pyrosm` and `flake8 pyrosm` — clean.
- Codex code review (working-tree scope) returned no high-, medium-, or low-severity issues.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
