### PR TITLE
Expose relation members in the output (tags column)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Expose relation members under the `members` key of the JSON `tags` column (each `{member_id, member_type, member_role}`), so relations carry their members in the returned GeoDataFrame (#216)
 - NEW: Raise a clear `InvalidOSMFileError` when the input `.pbf` is not a valid OSM PBF file, instead of a cryptic zlib/protobuf error (#160)
 - FIXED: `get_bounding_box` now reads the header bounding box correctly; it returned `None` for every file after the protobuf backend migration (#160)
 - NEW: Accept `pathlib.Path` (and any `os.PathLike`) filepaths in the `OSM` constructor, not just strings (#145)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Expose relation members under the ``members`` key of the JSON ``tags`` column (each ``{member_id, member_type, member_role}``), so relations carry their members in the returned GeoDataFrame (#216)
 - NEW: Raise a clear ``InvalidOSMFileError`` when the input ``.pbf`` is not a valid OSM PBF file, instead of a cryptic zlib/protobuf error (#160)
 - FIXED: ``get_bounding_box`` now reads the header bounding box correctly; it returned ``None`` for every file after the protobuf backend migration (#160)
 - NEW: Accept ``pathlib.Path`` (and any ``os.PathLike``) filepaths in the ``OSM`` constructor, not just strings (#145)

--- a/pyrosm/relations.pyx
+++ b/pyrosm/relations.pyx
@@ -6,6 +6,33 @@ from shapely.predicates import is_valid
 import numpy as np
 import geopandas as gpd
 
+
+cdef members_to_list(members):
+    """Convert a relation's members (a dict of arrays) into a list of
+    ``{member_id, member_type, member_role}`` dicts, decoding the bytes
+    member_type to str. Stored under the 'members' key of the relation's JSON
+    ``tags`` column rather than as a separate column (it only concerns
+    relations, so a full-length column would be mostly null)."""
+    member_ids = members["member_id"]
+    member_types = members["member_type"]
+    member_roles = members["member_role"]
+    parsed = []
+    for j in range(len(member_ids)):
+        mtype = member_types[j]
+        if isinstance(mtype, bytes):
+            mtype = mtype.decode("utf-8")
+        mrole = member_roles[j]
+        if isinstance(mrole, bytes):
+            mrole = mrole.decode("utf-8")
+        parsed.append(
+            {
+                "member_id": int(member_ids[j]),
+                "member_type": mtype,
+                "member_role": mrole,
+            }
+        )
+    return parsed
+
 cpdef _get_ways_for_relation(member_ids, member_roles, building_relation_ways):
     return get_ways_for_relation(member_ids, member_roles, building_relation_ways)
 
@@ -149,6 +176,11 @@ cdef get_relations(relations, relation_ways, node_coordinates):
         # Add tags
         for k, v in rel["tags"][0].items():
             relation[k] = v
+
+        # Add the relation members. Not listed in tags_to_keep, so it is folded
+        # into the JSON 'tags' column. Set after the tag loop so a stray tag
+        # named 'members' cannot shadow the structural member list.
+        relation["members"] = members_to_list(rel["members"][0])
 
         prepared_relations.append(relation)
 

--- a/tests/test_boundary_parsing.py
+++ b/tests/test_boundary_parsing.py
@@ -152,3 +152,26 @@ def test_reading_all_boundaries(helsinki_region_pbf):
 
         gdf = osm.get_boundaries(boundary_type=boundary_type)
         assert len(gdf) >= cnt, f"Got incorrect number of rows with {boundary_type}"
+
+
+def test_relation_members_in_tags(helsinki_pbf):
+    """#216 — a relation's members are exposed under the 'members' key of the
+    JSON 'tags' column (not a separate full-length column)."""
+    import json
+    from pyrosm import OSM
+
+    osm = OSM(helsinki_pbf)
+    gdf = osm.get_boundaries()
+
+    # Folded into the tags JSON, not a standalone column.
+    assert "members" not in gdf.columns
+
+    tags = json.loads(gdf["tags"].iloc[0])
+    assert "members" in tags
+    members = tags["members"]
+    assert isinstance(members, list) and len(members) > 0
+    for member in members:
+        assert set(member) == {"member_id", "member_type", "member_role"}
+        assert isinstance(member["member_id"], int)
+        assert member["member_type"] in ("node", "way", "relation")
+        assert isinstance(member["member_role"], str)


### PR DESCRIPTION
Closes #216.

## Summary

Relation members (member_id / member_type / member_role) were parsed but never reached the returned GeoDataFrame — they were only accessible via the internal `osm._relations`. This change exposes them so relations carry their members in the output of `get_data_by_custom_criteria`, `get_boundaries`, and the other relation-returning methods.

## Design

Members are exposed **under the `members` key of the existing JSON `tags` column**, not as a separate top-level column. A separate column would be full-length — one entry per row, null for every node/way row — which is wasteful when a dataset has many ways/nodes but only a handful of relations. Folding members into the per-relation `tags` JSON keeps the data only where it is relevant, with no extra column and no added memory footprint for non-relation rows.

Access pattern:

```python
import json
members = json.loads(row["tags"])["members"]
# [{"member_id": 38153442, "member_type": "way", "member_role": "outer"}, ...]
```

## Changes

- `pyrosm/relations.pyx`: add `members_to_list(members)`, converting the relation's members dict-of-arrays into a list of `{member_id, member_type, member_role}` dicts (decoding the bytes `member_type` `b"node"`/`b"way"`/`b"relation"` to str, casting `member_id` to `int`). In `get_relations`, set `relation["members"]` after the tag loop (so a stray OSM tag literally named `members` cannot shadow the structural list). `members` is intentionally left out of `tags_to_keep`, so `convert_way_records_to_lists` routes it into the JSON `tags` column via `rapidjson.dumps`; the list nests natively (not double-encoded). The full member list is used, so e.g. turn-restriction from/via/to members are preserved.

## Tests

- `tests/test_boundary_parsing.py::test_relation_members_in_tags`: `get_boundaries()` on the bundled Helsinki PBF; asserts `members` is NOT a standalone column, that the parsed `tags` JSON contains a `members` list, and that each member has exactly `{member_id (int), member_type in {node,way,relation}, member_role (str)}`. Existing relation shape/column tests are unaffected because the column count does not change.

## Verification

- `pytest` over the relation-touching suites (boundary / custom_filter / building / poi / landuse / natural / main) — all pass, including the new test; no shape regressions.
- `black --check pyrosm` and `flake8 pyrosm` — clean.
- Codex code review (working-tree scope) returned no high-, medium-, or low-severity issues.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
