### PR TITLE
Add PyPI release automation (#287)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,107 @@
+name: release
+
+# Build the binary wheels + sdist and publish them to PyPI when a version tag
+# (vX.Y.Z, incl. pre-releases) is pushed. workflow_dispatch builds the same
+# artifacts without publishing, as a dry run.
+#
+# Publishing uses PyPI Trusted Publishing (OIDC) — no API token is stored. The
+# PyPI project must have a pending/active publisher configured for: owner
+# `pyrosm`, repository `pyrosm`, workflow `release.yaml`, environment `pypi`.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: Tests
+    uses: ./.github/workflows/tests.yaml
+    secrets: inherit
+
+  check-version:
+    name: Verify tag matches package version
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.check.outputs.prerelease }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --quiet packaging
+      - id: check
+        run: python ci/check_version.py "${{ github.ref_name }}"
+
+  build-wheels:
+    name: Build wheels (${{ matrix.os }})
+    needs: [tests]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos-13 builds x86_64, macos-14 builds arm64 (each native).
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pypa/cibuildwheel@v4.0
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build-sdist:
+    name: Build sdist
+    needs: [tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pipx run build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [check-version, build-wheels, build-sdist]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyrosm
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+  github-release:
+    name: Create GitHub release
+    needs: [check-version, publish]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          prerelease: ${{ needs.check-version.outputs.prerelease == 'true' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Automate PyPI releases — a GitHub Actions `release` workflow builds binary wheels (cibuildwheel; Linux/macOS/Windows × CPython 3.10–3.14) and an sdist, then publishes them to PyPI via Trusted Publishing and creates a GitHub release when a `vX.Y.Z` tag is pushed (#287)
 - FIXED: Decode node coordinates at full float64 precision (exact OSM 7-decimal values, matching GDAL/osmium); they were truncated to float32, introducing a ~0.1 m error, false extra precision, and visible distortion of straight geometry edges (#245, #225)
 - FIXED: Normalize polygon/multipolygon ring orientation to the OGC/GeoJSON right-hand rule (exterior counter-clockwise, holes clockwise), matching osmium and QGIS; previously rings inherited the OSM way node order and were inconsistently wound (#230)
 - NEW: Expose relation members under the `members` key of the JSON `tags` column (each `{member_id, member_type, member_role}`), so relations carry their members in the returned GeoDataFrame (#216)

--- a/ci/check_version.py
+++ b/ci/check_version.py
@@ -1,0 +1,47 @@
+"""Guard a release tag against the packaged version.
+
+Used by the release workflow: given the pushed tag (e.g. ``v0.7.0``), confirm
+its version matches ``setup.py`` and refuse to publish on a mismatch (which
+would otherwise upload the wrong version under the tag). Also reports whether
+the version is a PEP 440 pre-release so the GitHub release can be flagged.
+"""
+
+import os
+import re
+import sys
+
+from packaging.version import Version
+
+
+def packaged_version():
+    with open("setup.py", encoding="utf-8") as fh:
+        source = fh.read()
+    match = re.search(r'\bversion\s*=\s*"([^"]+)"', source)
+    if match is None:
+        sys.exit("::error::could not find version= in setup.py")
+    return match.group(1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: check_version.py <tag>")
+    tag = sys.argv[1]
+    tag_version = tag[1:] if tag.startswith("v") else tag
+    pkg_version = packaged_version()
+
+    if tag_version != pkg_version:
+        sys.exit(
+            f"::error::tag {tag} (version {tag_version}) does not match "
+            f"setup.py version {pkg_version}"
+        )
+
+    prerelease = Version(tag_version).is_prerelease
+    output = os.environ.get("GITHUB_OUTPUT")
+    if output:
+        with open(output, "a", encoding="utf-8") as fh:
+            fh.write(f"prerelease={'true' if prerelease else 'false'}\n")
+    print(f"OK: releasing {pkg_version} (prerelease={prerelease})")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/smoke_test.py
+++ b/ci/smoke_test.py
@@ -1,0 +1,21 @@
+"""Post-build smoke test run by cibuildwheel against each built wheel.
+
+Imports the installed wheel (cibuildwheel runs this from outside the source
+tree, so ``import pyrosm`` resolves to the wheel, not the repo) and parses the
+bundled ``test_pbf`` extract end to end, exercising the compiled Cython
+pipeline. Kept dependency-light and network-free so it works in every wheel's
+isolated test environment.
+"""
+
+from pyrosm import OSM, get_data
+
+
+def main():
+    osm = OSM(get_data("test_pbf"))
+    network = osm.get_network()
+    assert network is not None and len(network) > 0, "empty network from test_pbf"
+    print(f"smoke test OK: parsed {len(network)} network edges")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+- NEW: Automate PyPI releases — a GitHub Actions ``release`` workflow builds binary wheels (cibuildwheel; Linux/macOS/Windows × CPython 3.10–3.14) and an sdist, then publishes them to PyPI via Trusted Publishing and creates a GitHub release when a ``vX.Y.Z`` tag is pushed (#287)
 - FIXED: Decode node coordinates at full float64 precision (exact OSM 7-decimal values, matching GDAL/osmium); they were truncated to float32, introducing a ~0.1 m error, false extra precision, and visible distortion of straight geometry edges (#245, #225)
 - FIXED: Normalize polygon/multipolygon ring orientation to the OGC/GeoJSON right-hand rule (exterior counter-clockwise, holes clockwise), matching osmium and QGIS; previously rings inherited the OSM way node order and were inconsistently wound (#230)
 - NEW: Expose relation members under the ``members`` key of the JSON ``tags`` column (each ``{member_id, member_type, member_role}``), so relations carry their members in the returned GeoDataFrame (#216)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,12 @@ requires = ["setuptools", "wheel", "Cython", "cykhash>=2"]
 
 [tool.black]
 force-exclude = '.*_pb2\.py$'
+
+[tool.cibuildwheel]
+# CPython 3.10–3.14, matching python_requires and the test matrix. PyPy is
+# excluded (the build targets CPython); musllinux, 32-bit and win32 are skipped.
+build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
+skip = "*-musllinux_* *_i686 *-win32"
+build-frontend = "build"
+# Import the freshly built wheel and parse the bundled extract end to end.
+test-command = "python {project}/ci/smoke_test.py"


### PR DESCRIPTION
Closes #287.

Adds a tag-triggered GitHub Actions workflow that builds release artifacts and publishes pyrosm to PyPI.

## What it does

- `.github/workflows/release.yaml`, triggered on `v*` tags (and `workflow_dispatch` for an artifact-only dry run):
  - `tests` — reuses the existing `tests.yaml` via `workflow_call` as a release gate.
  - `check-version` — fails the run if the tag version does not match the version in `setup.py`; outputs whether the version is a PEP 440 pre-release.
  - `build-wheels` — builds binary wheels with cibuildwheel across `ubuntu-latest`, `windows-latest`, `macos-13` (x86_64) and `macos-14` (arm64), for CPython 3.10–3.14; each wheel is import- and parse-tested via `ci/smoke_test.py`.
  - `build-sdist` — builds the source distribution.
  - `publish` — uploads wheels + sdist to PyPI with `pypa/gh-action-pypi-publish` using Trusted Publishing (OIDC; `id-token: write`, `environment: pypi`, `skip-existing: true`).
  - `github-release` — creates the GitHub release with the artifacts attached, marked pre-release when the tag is a PEP 440 pre-release.

  Top-level permissions are `contents: read`; jobs elevate only as needed.
- `pyproject.toml` — `[tool.cibuildwheel]`: build cp310–cp314; skip musllinux, i686, win32; smoke-test each wheel.
- `ci/check_version.py`, `ci/smoke_test.py` — the version guard and the wheel smoke test.
- `CHANGELOG.md`, `docs/changelog.rst` — Unreleased entry.

Trusted Publishing authenticates without a stored token; it requires a PyPI publisher configured for project `pyrosm`, repository `pyrosm/pyrosm`, workflow `release.yaml`, environment `pypi`. The published version comes from `setup.py`; `check-version` enforces that the tag equals it.

## Verification

- Built the wheel and sdist locally: both include the compiled extension, the vendored `pyrosm/proto/*_pb2.py` modules and the bundled `.pbf` data.
- `ci/smoke_test.py` parses the bundled `test_pbf` (238 network edges).
- `ci/check_version.py`: matching tag passes and emits the prerelease flag; mismatched tag exits non-zero; PEP 440 prerelease detection verified.
- `release.yaml` parses as YAML; `pyproject.toml` parses as TOML; `ci/*.py` pass `black` and `flake8`.
- Codex code review (working-tree) returned no findings.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
