### PR TITLE
Build macOS wheels by cross-compiling on arm64 (drop retired macos-13)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-13 builds x86_64, macos-14 builds arm64 (each native).
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        # macos-14 (arm64) builds both arm64 and cross-compiled x86_64 wheels
+        # (see [tool.cibuildwheel.macos]); Intel macos-13 runners are retired.
+        os: [ubuntu-latest, windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v5
       - uses: pypa/cibuildwheel@v4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ skip = "*-musllinux_* *_i686 *-win32"
 build-frontend = "build"
 # Import the freshly built wheel and parse the bundled extract end to end.
 test-command = "python {project}/ci/smoke_test.py"
+
+[tool.cibuildwheel.macos]
+# Intel (macos-13) runners are retired, so build both macOS architectures on the
+# arm64 runner: arm64 natively, x86_64 cross-compiled. cibuildwheel runs the
+# test-command only on the native (arm64) slice and skips it for x86_64.
+archs = ["x86_64", "arm64"]


### PR DESCRIPTION
Fixes the macOS leg of the release workflow. The Intel `macos-13` runner is retired, so `Build wheels (macos-13)` queues indefinitely with no runner (observed on the v0.8.0 release dry run).

## What it does

- `.github/workflows/release.yaml` — drop `macos-13` from the build-wheels matrix; macOS wheels now build on `macos-14` (arm64) only.
- `pyproject.toml` — `[tool.cibuildwheel.macos] archs = ["x86_64", "arm64"]`, so `macos-14` builds both arm64 (native) and x86_64 (cross-compiled) wheels. cibuildwheel runs the smoke test on the native arm64 slice and skips it for the cross-compiled x86_64 slice.

Intel-Mac users continue to get wheels (cp310–cp314 × {x86_64, arm64}); the Linux and Windows legs are unchanged.

## Verification

- `pyproject.toml` and `release.yaml` parse; the build-wheels matrix is `[ubuntu-latest, windows-latest, macos-14]`.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
