### PR TITLE
Prepare v0.8.0rc1 pre-release; recommend mamba/micromamba for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ which is also used by OpenStreetMap contributors to distribute the OSM data in P
 
 Pyrosm is distributed via PyPI and conda-forge.
 
-The recommended way to install pyrosm is from conda-forge with [mamba](https://mamba.readthedocs.io/) (or its standalone variant [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)), a fast drop-in replacement for `conda`:
+The recommended way to install pyrosm is from conda-forge with [mamba](https://mamba.readthedocs.io/) (or its standalone variant [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)), a fast drop-in replacement for `conda`. If you don't have it yet, download and install mamba via Miniforge from the [conda-forge download page](https://conda-forge.org/download/) — it ships mamba preconfigured with the conda-forge channel. Then install pyrosm with:
 
 `$ mamba install -c conda-forge pyrosm`
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,17 @@ which is also used by OpenStreetMap contributors to distribute the OSM data in P
  
 ## Install
 
-Pyrosm is distributed via PyPi and conda-forge. 
+Pyrosm is distributed via PyPI and conda-forge.
 
-The recommended way to install pyrosm is using `conda` package manager:
+The recommended way to install pyrosm is from conda-forge with [mamba](https://mamba.readthedocs.io/) (or its standalone variant [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)), a fast drop-in replacement for `conda`:
 
-`$ conda install -c conda-forge pyrosm`
+`$ mamba install -c conda-forge pyrosm`
 
-You can also install the package with pip:
+or, with micromamba:
+
+`$ micromamba install -c conda-forge pyrosm`
+
+(the same command works with `conda` if you have it). You can also install the package with pip:
 
 `$ pip install pyrosm`
 
@@ -86,17 +90,17 @@ please check the [contribution guidelines](https://pyrosm.readthedocs.io/en/late
 
 ## Development
 
-You can install a local development version of the tool by 1) installing necessary packages with conda and 2) building pyrosm from source:
+You can install a local development version of the tool by 1) creating an environment with the necessary packages using mamba/micromamba and 2) building pyrosm from source:
 
- 1. install a conda-environment for one of the supported Python versions (3.10–3.14) by:
+ 1. create an environment for one of the supported Python versions (3.10–3.14) by:
  
-    - e.g. Python 3.14 (you might want to modify the env-name which is `test` by default): `$ conda env create -f ci/314-conda.yaml`
+    - e.g. Python 3.14 (you might want to modify the env-name which is `test` by default): `$ mamba env create -f ci/314-conda.yaml` (or `$ micromamba create -f ci/314-conda.yaml`)
     - environment files for other versions are available under `ci/` (e.g. `ci/312-conda.yaml`)
     
  2. build pyrosm development version from master (activate the environment first):
  
     - `pip install -e . --no-build-isolation`
-    - (`--no-build-isolation` builds the Cython extensions against the conda-provided build dependencies, i.e. Cython and `cykhash`, instead of refetching and recompiling them in an isolated build environment)
+    - (`--no-build-isolation` builds the Cython extensions against the build dependencies provided by the environment, i.e. Cython and `cykhash`, instead of refetching and recompiling them in an isolated build environment)
 
 You can run tests with `pytest` by executing:
  

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ copyright = f"2020-{current_year}, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.8.0"
+version = release = "0.8.0rc1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if _linetrace:
 
 setup(
     name="pyrosm",
-    version="0.8.0",
+    version="0.8.0rc1",
     license="MIT",
     description="A Python tool to parse OSM data from Protobuf format into GeoDataFrame.",
     long_description=read_long_description(),


### PR DESCRIPTION
Prepares the `v0.8.0rc1` pre-release and refreshes the install instructions.

## What it does

- Sets the version to `0.8.0rc1` in `setup.py` and `docs/conf.py`. The release workflow's `check-version` job requires the tag to equal the packaged version exactly, so the pre-release version has to live in `setup.py`; with this, tagging `v0.8.0rc1` passes the gate and the version is detected as a PEP 440 pre-release (the GitHub release is marked pre-release, and on PyPI it is a pre-release that `pip install pyrosm` will not pick up without `--pre`).
- README install instructions now recommend **mamba** (or **micromamba**) from conda-forge instead of `conda`, in both the user-install and the development-setup sections. The same conda-forge command still works with `conda`; pip install is unchanged.

## Verification

- `ci/check_version.py v0.8.0rc1` passes and reports `prerelease=True`.
- The version reads `0.8.0rc1` in both `setup.py` and `docs/conf.py`.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
