### PR TITLE
Bump version to 0.8.0 for final release

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-v0.8.0 (Jun 9, 2026)
---------------------
+v0.8.0 (Jun 10, 2026)
+---------------------
 
 This is a major release that changes the PBF parsing backend.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ copyright = f"2020-{current_year}, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.8.0rc1"
+version = release = "0.8.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ if _linetrace:
 
 setup(
     name="pyrosm",
-    version="0.8.0rc1",
+    version="0.8.0",
     license="MIT",
     description="A Python tool to parse OSM data from Protobuf format into GeoDataFrame.",
     long_description=read_long_description(),


### PR DESCRIPTION
Finalizes the v0.8.0 release after the `0.8.0rc1` pre-release was validated (built across the matrix, published to PyPI, and installed/tested via `pip install --pre`).

## What it does

- Drops the pre-release suffix: version `0.8.0rc1` → `0.8.0` in `setup.py` and `docs/conf.py`.
- Dates the `v0.8.0` changelog heading in `docs/changelog.rst` (Jun 10, 2026).

The `v0.8.0` changelog content itself is already on master (PR #289) and is unchanged here.

## Verification

- `ci/check_version.py v0.8.0` passes and reports `prerelease=False`, so tagging `v0.8.0` clears the release workflow's version guard and cuts a normal (non-pre) release.
- The version reads `0.8.0` in both `setup.py` and `docs/conf.py`.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
