### PR TITLE
Use certifi CA bundle for downloads (fix Windows SSL cert-store error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a major release that changes the PBF parsing backend.
 - FIXED: Decode node coordinates at full float64 precision (exact OSM 7-decimal values, matching GDAL/osmium); they were truncated to float32, introducing a ~0.1 m error, false extra precision, and visible distortion of straight geometry edges (#283, #245, #225)
 - FIXED: Normalize polygon/multipolygon ring orientation to the OGC/GeoJSON right-hand rule (exterior counter-clockwise, holes clockwise), matching osmium and QGIS; previously rings inherited the OSM way node order and were inconsistently wound (#282, #230)
 - FIXED: `get_bounding_box` now reads the header bounding box correctly; it returned `None` for every file after the protobuf backend migration (#280, #160)
+- FIXED: Download data over HTTPS using certifi's CA bundle instead of the OS trust store, so fetching datasets no longer fails on Windows with `ssl.SSLError [ASN1: NOT_ENOUGH_DATA]` (a CPython bug triggered by a malformed entry in the Windows certificate store)
 - Refresh the README badges (#278)
 
 v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This is a major release that changes the PBF parsing backend.
 - FIXED: Decode node coordinates at full float64 precision (exact OSM 7-decimal values, matching GDAL/osmium); they were truncated to float32, introducing a ~0.1 m error, false extra precision, and visible distortion of straight geometry edges (#283, #245, #225)
 - FIXED: Normalize polygon/multipolygon ring orientation to the OGC/GeoJSON right-hand rule (exterior counter-clockwise, holes clockwise), matching osmium and QGIS; previously rings inherited the OSM way node order and were inconsistently wound (#282, #230)
 - FIXED: `get_bounding_box` now reads the header bounding box correctly; it returned `None` for every file after the protobuf backend migration (#280, #160)
-- FIXED: Download data over HTTPS using certifi's CA bundle instead of the OS trust store, so fetching datasets no longer fails on Windows with `ssl.SSLError [ASN1: NOT_ENOUGH_DATA]` (a CPython bug triggered by a malformed entry in the Windows certificate store)
+- FIXED: Download data over HTTPS using certifi's CA bundle instead of the OS trust store, so fetching datasets no longer fails on Windows with `ssl.SSLError [ASN1: NOT_ENOUGH_DATA]` (a CPython bug triggered by a malformed entry in the Windows certificate store) (#294)
 - Refresh the README badges (#278)
 
 v0.7.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,7 +14,7 @@ This is a major release that changes the PBF parsing backend.
 - FIXED: Decode node coordinates at full float64 precision (exact OSM 7-decimal values, matching GDAL/osmium); they were truncated to float32, introducing a ~0.1 m error, false extra precision, and visible distortion of straight geometry edges (#283, #245, #225)
 - FIXED: Normalize polygon/multipolygon ring orientation to the OGC/GeoJSON right-hand rule (exterior counter-clockwise, holes clockwise), matching osmium and QGIS; previously rings inherited the OSM way node order and were inconsistently wound (#282, #230)
 - FIXED: ``get_bounding_box`` now reads the header bounding box correctly; it returned ``None`` for every file after the protobuf backend migration (#280, #160)
-- FIXED: Download data over HTTPS using certifi's CA bundle instead of the OS trust store, so fetching datasets no longer fails on Windows with ``ssl.SSLError [ASN1: NOT_ENOUGH_DATA]`` (a CPython bug triggered by a malformed entry in the Windows certificate store)
+- FIXED: Download data over HTTPS using certifi's CA bundle instead of the OS trust store, so fetching datasets no longer fails on Windows with ``ssl.SSLError [ASN1: NOT_ENOUGH_DATA]`` (a CPython bug triggered by a malformed entry in the Windows certificate store) (#294)
 - Refresh the README badges (#278)
 
 v0.7.0 (Jun 7, 2026)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ This is a major release that changes the PBF parsing backend.
 - FIXED: Decode node coordinates at full float64 precision (exact OSM 7-decimal values, matching GDAL/osmium); they were truncated to float32, introducing a ~0.1 m error, false extra precision, and visible distortion of straight geometry edges (#283, #245, #225)
 - FIXED: Normalize polygon/multipolygon ring orientation to the OGC/GeoJSON right-hand rule (exterior counter-clockwise, holes clockwise), matching osmium and QGIS; previously rings inherited the OSM way node order and were inconsistently wound (#282, #230)
 - FIXED: ``get_bounding_box`` now reads the header bounding box correctly; it returned ``None`` for every file after the protobuf backend migration (#280, #160)
+- FIXED: Download data over HTTPS using certifi's CA bundle instead of the OS trust store, so fetching datasets no longer fails on Windows with ``ssl.SSLError [ASN1: NOT_ENOUGH_DATA]`` (a CPython bug triggered by a malformed entry in the Windows certificate store)
 - Refresh the README badges (#278)
 
 v0.7.0 (Jun 7, 2026)

--- a/pyrosm/utils/download.py
+++ b/pyrosm/utils/download.py
@@ -1,8 +1,12 @@
-import urllib
+import urllib.request
 import tempfile
 import os
 import enum
+import shutil
+import ssl
 from urllib.error import HTTPError
+
+import certifi
 
 
 class UNIT(enum.Enum):
@@ -52,7 +56,16 @@ def download(url, filename, update, target_dir):
     # Download data to temp if it does not exist or if update is requested
     if update or file_exists is False:
         try:
-            filepath, msg = urllib.request.urlretrieve(url, filepath)
+            # Build the HTTPS context from certifi's CA bundle instead of the OS
+            # trust store. On Windows, loading the system certificate store can
+            # raise ssl.SSLError [ASN1: NOT_ENOUGH_DATA] (a CPython bug triggered
+            # by a malformed entry in the store); certifi avoids it and works the
+            # same across platforms.
+            context = ssl.create_default_context(cafile=certifi.where())
+            with urllib.request.urlopen(url, context=context) as response, open(
+                filepath, "wb"
+            ) as out_file:
+                shutil.copyfileobj(response, out_file)
         except HTTPError:
             raise ValueError(
                 f"PBF-file '{url}' is temporarily unavailable. " f"Try again later."

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requirements = [
     "shapely>=2.1",
     "cykhash",
     "protobuf>=6.33.5",
+    "certifi",
 ]
 
 # Optional line-trace build for measuring Cython (.pyx) test coverage. Enabled

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -825,3 +825,43 @@ def test_node_coordinates_decoded_at_full_precision(tmp_path):
     assert gdf["lon"].dtype == np.float64
     assert gdf["lat"].dtype == np.float64
     assert gdf.loc[gdf["id"] == 1, "lon"].iloc[0] == -80.4410082
+
+
+def test_download_builds_ssl_context_from_certifi(tmp_path, monkeypatch):
+    """Downloads must build the HTTPS context from certifi's CA bundle, not the
+    OS trust store: on Windows, loading the system certificate store can raise
+    ssl.SSLError [ASN1: NOT_ENOUGH_DATA] (a CPython bug on a malformed store
+    entry), which aborted every download-backed test on the windows runners."""
+    import io
+    import os
+    import ssl
+
+    import certifi
+
+    from pyrosm.utils import download as dl
+
+    captured = {}
+    real_create = ssl.create_default_context
+
+    def fake_create(*args, **kwargs):
+        captured["cafile"] = kwargs.get("cafile")
+        return real_create()
+
+    def fake_urlopen(url, context=None):
+        captured["context"] = context
+        return io.BytesIO(b"x" * 50000)
+
+    monkeypatch.setattr(dl.ssl, "create_default_context", fake_create)
+    monkeypatch.setattr(dl.urllib.request, "urlopen", fake_urlopen)
+
+    out = dl.download(
+        "https://example.invalid/data.osm.pbf",
+        "data.osm.pbf",
+        True,
+        str(tmp_path),
+    )
+
+    # The CA bundle came from certifi, and that context was handed to urlopen.
+    assert captured["cafile"] == certifi.where()
+    assert isinstance(captured["context"], ssl.SSLContext)
+    assert os.path.exists(out)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -841,11 +841,12 @@ def test_download_builds_ssl_context_from_certifi(tmp_path, monkeypatch):
     from pyrosm.utils import download as dl
 
     captured = {}
-    real_create = ssl.create_default_context
 
     def fake_create(*args, **kwargs):
         captured["cafile"] = kwargs.get("cafile")
-        return real_create()
+        # Return a bare context; do NOT load the OS trust store (that is the very
+        # Windows ssl bug under test). fake_urlopen ignores the context anyway.
+        return ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
     def fake_urlopen(url, context=None):
         captured["context"] = context


### PR DESCRIPTION
Fixes the Windows CI failure that blocks the v0.8.0 release, so this is folded into v0.8.0 (the version is unchanged).

## Problem

On the Windows runners every download-backed test errors at TLS setup with `ssl.SSLError: [ASN1: NOT_ENOUGH_DATA] not enough data`. The crash is in CPython's stdlib, not pyrosm: `urllib.request.urlretrieve` builds the default HTTPS context, which calls `ssl.load_default_certs()` → `_load_windows_store_certs()` → `load_verify_locations(cadata=certs)`, and a malformed entry in the Windows certificate store breaks ASN.1 parsing. It aborts `pyrosm.data.get_data(...)` and thus the graph-export / OSH tests that fetch `ulanbator_test_pbf`.

## Fix

- `pyrosm/utils/download.py`: build the HTTPS context from **certifi**'s CA bundle (`ssl.create_default_context(cafile=certifi.where())`) and stream the response to disk with `urllib.request.urlopen(url, context=...)` + `shutil.copyfileobj`, instead of `urllib.request.urlretrieve`. This never touches the OS trust store, so the Windows ASN.1 bug cannot occur, and it behaves identically across platforms. Existing behaviour is preserved: `HTTPError` → friendly `ValueError`, other exceptions re-raised, the empty-file (0 MB) guard, the success print, and the returned filepath.
- `setup.py`: add `certifi` to `install_requires` (already present transitively in the conda test envs via `requests`).
- `tests/test_regressions.py`: `test_download_builds_ssl_context_from_certifi` — a network-free test that monkeypatches `ssl.create_default_context` and `urllib.request.urlopen` to assert the download builds the context from `certifi.where()`, passes that `SSLContext` to `urlopen`, and writes the file.
- `CHANGELOG.md` / `docs/changelog.rst`: a `FIXED` entry under v0.8.0.

## Verification

- The new regression test passes; `black`/`flake8` clean over `pyrosm/`.
- Codex code review (working-tree) returned no findings.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
