### PR TITLE
Prepare v0.9.0rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 Changelog
 =========
 
-Unreleased
-----------
+v0.9.0rc1
+---------
+
+First release candidate for v0.9.0. This release lowers the read path's memory use and speeds it up, adds fetching data by bounding box and by place name, and writes OSM data back to PBF (editing attributes/tags and cropping).
 
 - NEW: Add a `tags_to_keep` parameter to the feature methods (`get_network`, `get_buildings`, `get_pois`, `get_landuse`, `get_natural`, `get_boundaries`). When given, only those OSM tag keys are kept as columns (replacing the default tag-column set), reducing memory; structural columns, filtering and `extra_attributes` are unaffected and the default behaviour is unchanged (#87)
 - NEW: Add a `keep_metadata` parameter to `OSM(...)` (default `True`). Set `keep_metadata=False` to drop the element metadata columns (`timestamp`, `version`, `changeset`) from the returned GeoDataFrames and skip decoding the per-node metadata while parsing, lowering memory use and parse time on node-heavy files; the default behaviour is unchanged and history (`.osh.pbf`) files keep the metadata they require (#87, #150)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,10 @@
 Changelog
 =========
 
-Unreleased
-----------
+v0.9.0rc1 (Jun 16, 2026)
+------------------------
+
+First release candidate for v0.9.0. This release lowers the read path's memory use and speeds it up, adds fetching data by bounding box and by place name, and writes OSM data back to PBF (editing attributes/tags and cropping).
 
 - NEW: Add a ``tags_to_keep`` parameter to the feature methods (``get_network``, ``get_buildings``, ``get_pois``, ``get_landuse``, ``get_natural``, ``get_boundaries``). When given, only those OSM tag keys are kept as columns (replacing the default tag-column set), reducing memory; structural columns, filtering and ``extra_attributes`` are unaffected and the default behaviour is unchanged (#87)
 - NEW: Add a ``keep_metadata`` parameter to ``OSM(...)`` (default ``True``). Set ``keep_metadata=False`` to drop the element metadata columns (``timestamp``, ``version``, ``changeset``) from the returned GeoDataFrames and skip decoding the per-node metadata while parsing, lowering memory use and parse time on node-heavy files; the default behaviour is unchanged and history (``.osh.pbf``) files keep the metadata they require (#87, #150)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ copyright = f"2020-{current_year}, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.8.0"
+version = release = "0.9.0rc1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if _linetrace:
 
 setup(
     name="pyrosm",
-    version="0.8.0",
+    version="0.9.0rc1",
     license="MIT",
     description="A Python tool to parse OSM data from Protobuf format into GeoDataFrame.",
     long_description=read_long_description(),


### PR DESCRIPTION
Prepares the first release candidate for v0.9.0. Documentation/metadata only — no code changes.

## Changes
- Bump `version` to `0.9.0rc1` in `setup.py` and `version = release` to `0.9.0rc1` in `docs/conf.py`.
- Rename the changelog `Unreleased` section to the release heading: `v0.9.0rc1` in `CHANGELOG.md` and `v0.9.0rc1 (Jun 16, 2026)` in `docs/changelog.rst` (the rst changelog carries dates, the markdown one does not, matching existing style), each with a one-line summary lead-in. The existing entries are unchanged.

## Changelog coverage
Every feature PR merged since v0.8.0 is already represented in the entries: read-path memory/speed work (#53, #87, #150), `to_pbf` crop with `compact`/`repack` and lazy import (#6, #284), `write_pbf` (#285, #286), and `get_data_by_bbox` / `geocode` / `get_data_by_geocoding` (#165, #197). Internal-only changes (tests, refactors, CI) have no entry.

## Verification
- `ci/check_version.py v0.9.0rc1` prints `OK: releasing 0.9.0rc1 (prerelease=True)`, and it exits non-zero on a mismatched tag, so the release workflow's version gate passes and the GitHub release is flagged as a pre-release.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
