### PR TITLE
Fix get_boundaries(): drop incomplete boundaries instead of force-closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- FIXED: `get_boundaries()` no longer force-closes incomplete administrative boundaries into polygons. A boundary relation whose member ways run off the PBF extent cannot form a closed ring, and was previously closed with a spurious straight edge bridging the gap (the stray lines crossing boundary plots); such incomplete boundaries are now dropped, matching how osmium and GDAL skip areas they cannot assemble ([#154](https://github.com/pyrosm/pyrosm/issues/154))
+
 v0.9.0
 ------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- FIXED: ``get_boundaries()`` no longer force-closes incomplete administrative boundaries into polygons. A boundary relation whose member ways run off the PBF extent cannot form a closed ring, and was previously closed with a spurious straight edge bridging the gap (the stray lines crossing boundary plots); such incomplete boundaries are now dropped, matching how osmium and GDAL skip areas they cannot assemble (`#154 <https://github.com/pyrosm/pyrosm/issues/154>`__)
+
 v0.9.0 (Jun 16, 2026)
 ---------------------
 

--- a/pyrosm/frames.pyx
+++ b/pyrosm/frames.pyx
@@ -123,9 +123,16 @@ cpdef prepare_relation_gdf(node_coordinates, relations, relation_ways, tags_as_c
                                       tags_as_columns,
                                       keep_metadata)
 
-        relation_gdf = gpd.GeoDataFrame(relations, crs="epsg:4326").assign(
-            osm_type="relation"
-        )
+        # prepare_relations returns an empty GeoDataFrame when no relation could
+        # be assembled into a geometry (e.g. every boundary relation is incomplete
+        # and was dropped). It then has no geometry column, so building a
+        # GeoDataFrame(..., crs=...) from it would raise -- return empty instead.
+        if "geometry" not in relations:
+            relation_gdf = gpd.GeoDataFrame()
+        else:
+            relation_gdf = gpd.GeoDataFrame(relations, crs="epsg:4326").assign(
+                osm_type="relation"
+            )
 
     else:
         relation_gdf = gpd.GeoDataFrame()

--- a/pyrosm/geometry.pxd
+++ b/pyrosm/geometry.pxd
@@ -4,7 +4,8 @@ cdef _create_way_geometries(node_coordinates, way_elements, parse_network, bint 
 cpdef create_way_geometries(node_coordinates, way_elements, parse_network, bint build_node_data=*)
 cdef create_relation_geometry(node_coordinates, ways,
                              member_roles, force_linestring,
-                             make_multipolygon)
+                             make_multipolygon,
+                             bint drop_if_open=*)
 cdef create_linear_ring(coordinates)
 cdef create_linestring_geometry(nodes, node_coordinates)
 cdef get_way_coordinates_for_polygon(node_coordinate_lookup, way_records)

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -144,9 +144,19 @@ cdef _create_point_geometries(xarray, yarray):
         else None for geom in geometries
     ]
 
+cdef bint _is_closed_ring(coords):
+    # A closed ring needs at least 4 positions and identical first/last points.
+    # OSM closed ways repeat the same node id at both ends, so their coordinates
+    # are exactly equal and a plain comparison is sufficient.
+    if coords.shape[0] < 4:
+        return False
+    return coords[0, 0] == coords[-1, 0] and coords[0, 1] == coords[-1, 1]
+
+
 cdef create_relation_geometry(node_coordinates, ways,
                               member_roles, force_linestring,
-                              make_multipolygon):
+                              make_multipolygon,
+                              bint drop_if_open=False):
     cdef int i, m_cnt
     cdef str role
     # Get coordinates for relation
@@ -225,10 +235,15 @@ cdef create_relation_geometry(node_coordinates, ways,
 
     if len(shell) > 1:
         if not make_multipolygon:
-            ring = create_linear_ring(
-                get_coordinates(
-                    line_merge(multilinestrings(shell))
-                ))
+            coords = get_coordinates(line_merge(multilinestrings(shell)))
+            # An administrative boundary whose member ways run off the PBF extent
+            # cannot form a closed ring. Rather than force-close it with a spurious
+            # straight edge across the map (#154), drop it -- matching how osmium
+            # and GDAL skip areas they cannot assemble. Scoped to boundaries
+            # (drop_if_open); other relations keep the existing behaviour.
+            if drop_if_open and not _is_closed_ring(coords):
+                return None
+            ring = create_linear_ring(coords)
             if ring is None:
                 return None
             geom = polygons(ring, holes)
@@ -251,7 +266,12 @@ cdef create_relation_geometry(node_coordinates, ways,
                 geom = polygons(rings, holes)
 
     else:
-        ring = create_linear_ring(get_coordinates(shell))
+        coords = get_coordinates(shell)
+        # A single, non-closed boundary member way cannot form a polygon; drop it
+        # rather than force-closing it into a ring with a spurious edge (#154).
+        if drop_if_open and not _is_closed_ring(coords):
+            return None
+        ring = create_linear_ring(coords)
         if ring is None:
             return None
 

--- a/pyrosm/relations.pyx
+++ b/pyrosm/relations.pyx
@@ -138,11 +138,14 @@ cdef get_relations(relations, relation_ways, node_coordinates, bint keep_metadat
         if ways is None:
             continue
 
+        # Boundaries are dropped when their outer ways do not close (#154); other
+        # relation types keep the existing geometry handling.
         geometry = create_relation_geometry(node_coordinates,
                                             ways,
                                             member_roles,
                                             force_linestring,
-                                            make_multipolygon
+                                            make_multipolygon,
+                                            "boundary" in tag_keys
                                             )
         if geometry is None:
             continue

--- a/tests/test_boundary_parsing.py
+++ b/tests/test_boundary_parsing.py
@@ -14,65 +14,56 @@ def helsinki_region_pbf():
     return pbf_path
 
 
-def test_reading_boundaries_with_defaults(helsinki_pbf):
+REQUIRED_COLUMNS = [
+    "name",
+    "admin_level",
+    "boundary",
+    "id",
+    "timestamp",
+    "version",
+    "changeset",
+    "geometry",
+    "tags",
+    "osm_type",
+]
+
+
+def test_reading_boundaries_with_defaults(helsinki_region_pbf):
+    # The small helsinki_pbf extract has only incomplete boundaries (all dropped,
+    # see test_regressions::test_incomplete_boundaries_dropped_not_force_closed),
+    # so the feature tests use the region extract, which contains complete ones.
     from pyrosm import OSM
 
-    osm = OSM(helsinki_pbf)
+    osm = OSM(helsinki_region_pbf)
     gdf = osm.get_boundaries()
 
-    # Test shape
-    assert gdf.shape == (8, 11)
-    required_columns = [
-        "name",
-        "admin_level",
-        "boundary",
-        "id",
-        "timestamp",
-        "version",
-        "changeset",
-        "geometry",
-        "tags",
-        "osm_type",
-    ]
-    for col in required_columns:
+    assert len(gdf) == 247
+    for col in REQUIRED_COLUMNS:
         assert col in gdf.columns
 
-    # osm_type should be 'relation'
-    assert gdf.osm_type.unique()[0] == "relation"
+    # Complete boundaries assemble into valid polygons; results are relations
+    # (with a few standalone boundary ways).
+    assert "relation" in set(gdf.osm_type.unique())
+    assert (gdf.geometry.geom_type == "Polygon").any()
+    assert gdf.geometry.is_valid.all()
 
 
-def test_reading_boundaries_with_name_search(helsinki_pbf):
+def test_reading_boundaries_with_name_search(helsinki_region_pbf):
     from pyrosm import OSM
 
-    osm = OSM(helsinki_pbf)
+    osm = OSM(helsinki_region_pbf)
 
-    # Full name and also partial name should work and produce data
-    # 'saari' is included in 'Siltasaari'
-    names = ["Punavuori", "saari"]
+    # Full name -> a single boundary polygon.
+    gdf = osm.get_boundaries(name="Punavuori")
+    assert len(gdf) == 1
+    for col in REQUIRED_COLUMNS:
+        assert col in gdf.columns
+    assert gdf.geometry.geom_type.iloc[0] == "Polygon"
 
-    for name in names:
-        gdf = osm.get_boundaries(name=name)
-
-        # Should now only contain one row
-        assert gdf.shape == (1, 11)
-
-        required_columns = [
-            "name",
-            "admin_level",
-            "boundary",
-            "id",
-            "timestamp",
-            "version",
-            "changeset",
-            "geometry",
-            "tags",
-            "osm_type",
-        ]
-        for col in required_columns:
-            assert col in gdf.columns
-
-        # osm_type should be 'relation'
-        assert gdf.osm_type.unique()[0] == "relation"
+    # Partial name -> one or more, every returned name contains the substring.
+    gdf = osm.get_boundaries(name="saari")
+    assert len(gdf) >= 1
+    assert gdf["name"].str.contains("saari").all()
 
 
 def test_passing_incorrect_parameters(helsinki_pbf):
@@ -80,7 +71,7 @@ def test_passing_incorrect_parameters(helsinki_pbf):
 
     osm = OSM(helsinki_pbf)
     try:
-        gdf = osm.get_boundaries(boundary_type="incorrect")
+        osm.get_boundaries(boundary_type="incorrect")
     except ValueError as e:
         if "should be one of the following" in str(e):
             pass
@@ -88,7 +79,7 @@ def test_passing_incorrect_parameters(helsinki_pbf):
         raise e
 
     try:
-        gdf = osm.get_boundaries(name=1)
+        osm.get_boundaries(name=1)
     except ValueError as e:
         if "should be text" in str(e):
             pass
@@ -96,11 +87,11 @@ def test_passing_incorrect_parameters(helsinki_pbf):
         raise e
 
 
-def test_adding_extra_attribute(helsinki_pbf):
+def test_adding_extra_attribute(helsinki_region_pbf):
     from pyrosm import OSM
     from geopandas import GeoDataFrame
 
-    osm = OSM(filepath=helsinki_pbf)
+    osm = OSM(filepath=helsinki_region_pbf)
     gdf = osm.get_boundaries()
     extra_col = "wikidata"
     extra = osm.get_boundaries(extra_attributes=[extra_col])
@@ -120,26 +111,8 @@ def test_reading_all_boundaries(helsinki_region_pbf):
     osm = OSM(helsinki_region_pbf)
     gdf = osm.get_boundaries(boundary_type="all")
 
-    # Test shape. This previously asserted 21 columns, but that count was
-    # inflated by a bug: test_adding_extra_attribute (above) leaked its extra
-    # column into the shared Conf.tags.boundary list, and it bled into this
-    # test. With the config-mutation fix the correct, isolated count is 20.
-    assert gdf.shape == (733, 20)
-
-    required_columns = [
-        "name",
-        "admin_level",
-        "boundary",
-        "id",
-        "timestamp",
-        "version",
-        "changeset",
-        "geometry",
-        "tags",
-        "osm_type",
-    ]
-
-    for col in required_columns:
+    assert len(gdf) == 699
+    for col in REQUIRED_COLUMNS:
         assert col in gdf.columns
 
     # Test filtering different types of boundaries
@@ -154,19 +127,20 @@ def test_reading_all_boundaries(helsinki_region_pbf):
         assert len(gdf) >= cnt, f"Got incorrect number of rows with {boundary_type}"
 
 
-def test_relation_members_in_tags(helsinki_pbf):
+def test_relation_members_in_tags(helsinki_region_pbf):
     """#216 — a relation's members are exposed under the 'members' key of the
     JSON 'tags' column (not a separate full-length column)."""
     import json
     from pyrosm import OSM
 
-    osm = OSM(helsinki_pbf)
+    osm = OSM(helsinki_region_pbf)
     gdf = osm.get_boundaries()
+    rel = gdf[gdf.osm_type == "relation"].iloc[0]
 
     # Folded into the tags JSON, not a standalone column.
     assert "members" not in gdf.columns
 
-    tags = json.loads(gdf["tags"].iloc[0])
+    tags = json.loads(rel["tags"])
     assert "members" in tags
     members = tags["members"]
     assert isinstance(members, list) and len(members) > 0

--- a/tests/test_branch_coverage.py
+++ b/tests/test_branch_coverage.py
@@ -20,6 +20,11 @@ def helsinki_pbf():
     return get_data("helsinki_pbf")
 
 
+@pytest.fixture
+def helsinki_region_pbf():
+    return get_data("helsinki_region_pbf")
+
+
 # --- natural.py ---------------------------------------------------------------
 
 
@@ -49,11 +54,12 @@ def test_get_boundaries_returns_none_for_empty_area(helsinki_pbf):
     assert gdf is None
 
 
-def test_get_boundaries_filter_by_name(helsinki_pbf):
+def test_get_boundaries_filter_by_name(helsinki_region_pbf):
     """Filtering boundaries by name returns only the matching boundary
     (boundary.py name-filter branch). Helsinki has named neighbourhood
-    boundaries (e.g. 'Kallio')."""
-    osm = OSM(helsinki_pbf)
+    boundaries (e.g. 'Kallio'). The region extract is used because helsinki_pbf's
+    boundaries are all incomplete and dropped (#154)."""
+    osm = OSM(helsinki_region_pbf)
     all_boundaries = osm.get_boundaries()
     assert "Kallio" in set(all_boundaries["name"].dropna())
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,12 @@ def helsinki_pbf():
     return pbf_path
 
 
+@pytest.fixture
+def helsinki_region_pbf():
+    pbf_path = get_data("helsinki_region_pbf")
+    return pbf_path
+
+
 def test_lazy_public_api():
     import pyrosm
 
@@ -80,11 +86,13 @@ def test_custom(test_pbf):
     assert isinstance(gdf, GeoDataFrame)
 
 
-def test_boundaries(helsinki_pbf):
+def test_boundaries(helsinki_region_pbf):
     from pyrosm import OSM
     from geopandas import GeoDataFrame
 
-    osm = OSM(helsinki_pbf)
+    # helsinki_pbf has only incomplete boundaries (all dropped, #154); the region
+    # extract contains complete ones.
+    osm = OSM(helsinki_region_pbf)
     gdf = osm.get_boundaries()
     assert isinstance(gdf, GeoDataFrame)
 
@@ -153,7 +161,9 @@ def test_invalid_osm_pbf_raises_meaningful_error(tmp_path):
     #    (reproduces the cryptic "Error -5 while decompressing data" from #156).
     header = BlobHeader(type="OSMHeader", datasize=20).SerializeToString()
     bad_zlib = tmp_path / "bad_zlib.pbf"
-    bad_zlib.write_bytes(struct.pack("!L", len(header)) + header + b"notzlibdata000000000")
+    bad_zlib.write_bytes(
+        struct.pack("!L", len(header)) + header + b"notzlibdata000000000"
+    )
     with pytest.raises(InvalidOSMFileError):
         OSM(bad_zlib)
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -970,7 +970,9 @@ def test_tags_to_keep_applies_to_all_feature_methods():
     are dropped, and rows/geometry are unchanged."""
     from pyrosm import OSM, get_data
 
-    osm = OSM(get_data("helsinki_pbf"))
+    # The region extract is used because the small helsinki_pbf has only
+    # incomplete boundaries (all dropped, #154), leaving get_boundaries empty.
+    osm = OSM(get_data("helsinki_region_pbf"))
     cases = [
         (osm.get_network, {}, "highway"),
         (osm.get_landuse, {}, "landuse"),
@@ -1130,3 +1132,16 @@ def test_way_tag_columns_built_only_when_nonempty():
                 assert (
                     gdf[c].notna().any()
                 ), f"{feature}: tag column {c!r} is entirely empty"
+
+
+def test_incomplete_boundaries_dropped_not_force_closed():
+    """#154 — administrative boundaries whose member ways run off the PBF extent
+    cannot form a closed ring. They are dropped (matching how osmium and GDAL skip
+    areas they cannot assemble), not force-closed into polygons with a spurious
+    straight edge bridging the gap (the stray lines that slashed across
+    get_boundaries() plots). Every boundary in the bundled Helsinki extract crosses
+    its edge, so none can be assembled and get_boundaries returns nothing; pre-fix
+    it returned 8 force-closed stray polygons."""
+    from pyrosm import OSM, get_data
+
+    assert OSM(get_data("helsinki_pbf")).get_boundaries() is None


### PR DESCRIPTION
Fixes the broken administrative boundaries reported in #154: `get_boundaries()` returned stray straight lines slashing across the map and self-intersecting polygons (reproduced on `get_data("oxfordshire")`).

## Root cause
For a boundary relation (`type=boundary`), `create_relation_geometry` line-merges the outer member ways and passes them to `shapely.linearrings()`, which **silently auto-closes** a non-closed coordinate sequence by joining the last point straight back to the first. When a boundary's member ways run off the PBF extent the merge stays open, so the auto-close drew a spurious closing edge — the stray lines. The force-closed polygon is still `is_valid`, so no validity guard caught it.

## Fix
- Only build a polygon when the merged outer ways actually form a closed ring (a new `_is_closed_ring` helper checks first point == last). When they do not, the boundary is incomplete and is **dropped** — matching how osmium and GDAL skip areas they cannot assemble. On `oxfordshire` this leaves exactly the 292 polygons osmium assembles, with no stray lines.
- The drop is **scoped to boundaries** via a `drop_if_open` flag set only for boundary relations (`"boundary" in tag_keys`), so `get_buildings` / `get_landuse` / `get_natural` and custom multipolygon reads keep their existing geometry handling unchanged.
- Guard the empty case: when every boundary in an extract is incomplete, `prepare_relation_gdf` previously crashed building a CRS'd GeoDataFrame from an empty relations set; it now returns an empty frame so `get_boundaries()` returns `None`.

## Verification
- `oxfordshire`: 292 valid polygons, no stray lines (was force-closed strays); the polygon set equals osmium's assembled boundary areas.
- Non-boundary features unchanged — `helsinki_pbf` buildings stay at 490.
- The boundary feature tests move to the region extract (the small `helsinki_pbf` has only incomplete boundaries, now dropped); a regression test is added. The full test suite passes except three pre-existing, environment-only failures (`r5py` routing and two `osmnx` subprocess tests).

Closes #154

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
