### PR TITLE
Disambiguate dataset names shared by multiple regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="resources/img/pyrosm_logo_2.png" alt="Pyrosm" width="660">
 </p>
 
-# Pyrosm –- Python’s Rapid OSM Parser
+# Pyrosm – Python’s Rapid OSM Parser
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/pyrosm.svg)](https://anaconda.org/conda-forge/pyrosm)
 [![PyPI version](https://badge.fury.io/py/pyrosm.svg)](https://badge.fury.io/py/pyrosm)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyrosm.svg?logo=python&logoColor=%23fff)](https://pypi.org/project/pyrosm)

--- a/pyrosm/data/__init__.py
+++ b/pyrosm/data/__init__.py
@@ -155,20 +155,61 @@ def retrieve(data, update, directory):
     )
 
 
-def search_source(name):
+def _find_sources(name):
+    """Return every ``(region_key, source_dict)`` whose region lists ``name``.
+
+    Mirrors the lookup ``search_source`` does, but collects all matches so a name
+    that exists in more than one region (e.g. the country 'georgia' and the US
+    state 'georgia') can be detected instead of silently taking the first (#162).
+    """
+    found = []
     for source, available in sources.available.items():
         # Cities are kept as CamelCase, so need to make lower
         if source == "cities":
-            available = [src.lower() for src in available]
-        if isinstance(available, list):
+            if name in [src.lower() for src in available]:
+                found.append((source, sources.__dict__[source].__dict__[name]))
+        elif isinstance(available, list):
             if name in available:
-                return sources.__dict__[source].__dict__[name]
+                found.append((source, sources.__dict__[source].__dict__[name]))
         elif isinstance(available, dict):
             # Sub-regions should be looked one level further down
             for subregion, available2 in available.items():
                 if name in available2:
-                    return sources.subregions.__dict__[subregion].__dict__[name]
-    raise ValueError(f"Could not retrieve url for '{name}'.")
+                    found.append(
+                        (
+                            subregion,
+                            sources.subregions.__dict__[subregion].__dict__[name],
+                        )
+                    )
+    return found
+
+
+def search_source(name):
+    # A region-qualified name ("europe/georgia", "usa/georgia") picks one of the
+    # regions that share a name (#162).
+    if "/" in name:
+        qualifier, base = name.split("/", 1)
+        for region, source in _find_sources(base):
+            if region == qualifier:
+                return source
+        raise ValueError(f"Could not retrieve url for '{name}'.")
+
+    found = _find_sources(name)
+    if not found:
+        raise ValueError(f"Could not retrieve url for '{name}'.")
+
+    # The same name in different regions pointing at different files (the country
+    # 'georgia' vs the US state 'georgia') is ambiguous -- do not silently pick
+    # one; ask the caller to qualify it (#162). Names that resolve to the same
+    # file (a UK county reachable via both 'great_britain' and 'united_kingdom')
+    # are not ambiguous.
+    if len({source["url"] for _, source in found}) > 1:
+        options = " or ".join(f"'{region}/{name}'" for region, _ in found)
+        raise ValueError(
+            f"The dataset name '{name}' is ambiguous -- it exists in multiple "
+            f"regions. Use a region-qualified name, e.g. {options}."
+        )
+    return found[0][1]
 
 
 def get_data(dataset, update=False, directory=None):
@@ -208,6 +249,11 @@ def get_data(dataset, update=False, directory=None):
 
     elif dataset == "ulanbator_test_pbf":
         return retrieve(_ulanbator_test_pbf, update, directory)
+
+    # A region-qualified name ("usa/georgia") disambiguates a name shared by
+    # multiple regions; route it straight to the resolver (#162).
+    elif "/" in dataset:
+        return retrieve(search_source(dataset), update, directory)
 
     elif dataset in sources._all_sources:
         return retrieve(search_source(dataset), update, directory)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1145,3 +1145,113 @@ def test_incomplete_boundaries_dropped_not_force_closed():
     from pyrosm import OSM, get_data
 
     assert OSM(get_data("helsinki_pbf")).get_boundaries() is None
+
+
+def test_get_data_disambiguates_ambiguous_region_name(monkeypatch):
+    """#162 — 'georgia' is both a country (europe) and a US state
+    (north-america/us), which resolve to different Geofabrik files. The bare name
+    used to silently return the country. It is now rejected as ambiguous, and a
+    region-qualified name resolves each one; get_data routes a qualified name to
+    the correct file."""
+    import pyrosm.data as data
+    from pyrosm.data import search_source
+
+    # The two regions resolve to different files.
+    state = search_source("usa/georgia")["url"]
+    country = search_source("europe/georgia")["url"]
+    assert state.endswith("north-america/us/georgia-latest.osm.pbf")
+    assert country.endswith("europe/georgia-latest.osm.pbf")
+    assert state != country
+
+    # The bare, ambiguous name raises with guidance (search_source and get_data).
+    with pytest.raises(ValueError, match="ambiguous"):
+        search_source("georgia")
+    with pytest.raises(ValueError, match="ambiguous"):
+        data.get_data("georgia")
+
+    # A benign collision (same file reachable via two groupings) is not ambiguous.
+    assert search_source("oxfordshire")["url"].endswith(
+        "england/oxfordshire-latest.osm.pbf"
+    )
+
+    # An unknown region qualifier is rejected.
+    with pytest.raises(ValueError, match="Could not retrieve"):
+        search_source("nowhere/georgia")
+
+    # get_data routes a region-qualified name to the resolved file (download stubbed).
+    captured = {}
+
+    def fake_retrieve(d, update, directory):
+        captured["url"] = d["url"]
+        return "/fake/path"
+
+    monkeypatch.setattr(data, "retrieve", fake_retrieve)
+    data.get_data("usa/georgia")
+    assert captured["url"].endswith("north-america/us/georgia-latest.osm.pbf")
+
+    # A source-registry entry that is neither a region list nor a subregion dict is
+    # skipped rather than crashing the lookup.
+    monkeypatch.setattr(
+        data.sources, "available", {**data.sources.available, "_stray": 42}
+    )
+    assert data._find_sources("finland")
+
+
+def test_get_data_dispatch_and_lazy_attrs(monkeypatch):
+    """Exercise get_data's dispatch table -- bundled files, gist-hosted test data,
+    the name-normalisation variants (spaces, underscores, dashes) and the
+    not-available error -- plus the deprecated get_path alias and the lazy
+    pyrosm.data attribute loader."""
+    import os
+    import pyrosm.data as data
+
+    # Non-string input is rejected up front.
+    with pytest.raises(ValueError, match="should be text"):
+        data.get_data(123)
+
+    # An unknown name reports that it is not available.
+    with pytest.raises(ValueError, match="is not available"):
+        data.get_data("not_a_real_place_xyz")
+
+    # Bundled data is returned as a local path, no download.
+    assert os.path.exists(data.get_data("test_pbf"))
+
+    # Stub the network so the retrieve-backed branches (and retrieve itself) run
+    # offline; capture the resolved filename for each.
+    seen = []
+
+    def fake_download(url, filename, update, target_dir):
+        seen.append(filename)
+        return "/fake/" + filename
+
+    monkeypatch.setattr(data, "download", fake_download)
+
+    # Gist-hosted test datasets dispatch to retrieve directly.
+    for name in (
+        "helsinki_region_pbf",
+        "helsinki_history_pbf",
+        "helsinki_test_history_pbf",
+        "ulanbator_test_pbf",
+    ):
+        data.get_data(name)
+
+    # A plain region name resolves through search_source.
+    data.get_data("finland")
+
+    # Name-normalisation variants: spaces removed (a city), space->underscore and
+    # dash->underscore (a region).
+    data.get_data("Brandenburg Havel")
+    data.get_data("new zealand")
+    data.get_data("new-zealand")
+    assert seen  # everything above went through the stubbed download
+
+    # get_path is the deprecated alias for get_data.
+    with pytest.warns(DeprecationWarning, match="get_path"):
+        assert os.path.exists(data.get_path("test_pbf"))
+
+    # The optional geo helpers are exposed lazily via module __getattr__.
+    assert callable(data.get_data_by_bbox)
+    assert callable(data.geocode)
+    assert callable(data.get_data_by_geocoding)
+    with pytest.raises(AttributeError):
+        data.this_attr_does_not_exist


### PR DESCRIPTION
`get_data("georgia")` returned the country of Georgia (europe) instead of the US state. The name resolver returned the first region that listed the name, and europe is iterated before the US subregions. The country and the US state map to different Geofabrik files, so silently picking one is wrong.

- `search_source` now collects every region that lists a name. When a bare name maps to more than one region with different download URLs, it raises a `ValueError` naming the region-qualified alternatives instead of silently returning one. Names that resolve to the same file (e.g. a UK county reachable via both `great_britain` and `united_kingdom`) are not treated as ambiguous and still resolve.
- Region-qualified names are now accepted: `get_data("europe/georgia")` fetches the country and `get_data("usa/georgia")` fetches the US state. `get_data` routes any `"region/name"` straight to the resolver.

Verification: added regression tests in `tests/test_regressions.py` covering qualified resolution, the ambiguity error (raised by both `search_source` and `get_data`), benign same-file collisions, unknown qualifiers, and the `get_data` dispatch and name-normalisation paths.

Closes #162

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
