### PR TITLE
Add out-of-core reading engine with buildings reader

### DIFF
--- a/ci/310-conda.yaml
+++ b/ci/310-conda.yaml
@@ -16,6 +16,7 @@ dependencies:
   - pandana
   - pandarm
   - python-igraph
+  - pyarrow
   # testing
   - osmnx
   - pyosmium

--- a/ci/311-conda.yaml
+++ b/ci/311-conda.yaml
@@ -16,6 +16,7 @@ dependencies:
   - pandana
   - pandarm
   - python-igraph
+  - pyarrow
   # testing
   - osmnx
   - pyosmium

--- a/ci/312-conda.yaml
+++ b/ci/312-conda.yaml
@@ -16,6 +16,7 @@ dependencies:
   - pandana
   - pandarm
   - python-igraph
+  - pyarrow
   # testing
   - osmnx
   - pyosmium

--- a/ci/313-conda.yaml
+++ b/ci/313-conda.yaml
@@ -18,6 +18,7 @@ dependencies:
   # pandarm (the maintained fork) does build on 3.13 and is exercised instead.
   - pandarm
   - python-igraph
+  - pyarrow
   # testing
   - osmnx
   - pyosmium

--- a/ci/314-conda.yaml
+++ b/ci/314-conda.yaml
@@ -18,6 +18,7 @@ dependencies:
   # pandarm (the maintained fork) does build on 3.13/3.14 and is exercised instead.
   - pandarm
   - python-igraph
+  - pyarrow
   # testing
   - osmnx
   - pyosmium

--- a/pyrosm/_arrays.pyx
+++ b/pyrosm/_arrays.pyx
@@ -135,6 +135,16 @@ cpdef concatenate_dicts_of_arrays(dict_list_of_arrays):
 
     return result_arrays
 
+cpdef way_records_to_arrays(records, tags_to_separate_as_arrays):
+    """Convert way/relation records (dicts whose tags have been exploded onto the record)
+    into the harmonized dict-of-arrays used to build a GeoDataFrame -- splitting the OSM
+    keys in ``tags_to_separate_as_arrays`` into their own columns and the rest into the
+    JSON ``tags`` column. Python entry point reusing the same conversion the in-memory
+    reader uses, so an alternative reader can produce byte-identical columns."""
+    return convert_to_arrays_and_drop_empty(
+        convert_way_records_to_lists(records, tags_to_separate_as_arrays)
+    )
+
 cdef char** to_cstring_array(list str_list):
     """
     Converts Python byte-string list to an "array" of c-strings. 

--- a/pyrosm/engine/__init__.py
+++ b/pyrosm/engine/__init__.py
@@ -1,0 +1,16 @@
+"""Out-of-core PBF reading engine (the ``engine="out_of_core"`` backend).
+
+The file is read in one pass: data blobs are decoded in parallel with the raw Cython
+``primitive_block_decoder`` (protobuf is used only for the small ``BlobHeader`` / ``Blob``
+framing), each worker spills the node coordinates and the features it finds to a
+per-worker shard on disk, and the main process then gathers only the coordinates the kept
+features reference and assembles the geometries. Peak memory is bounded by the working
+set rather than the whole file.
+
+The public ``get_*`` readers re-exported here mirror the in-memory reader's output
+column-for-column.
+"""
+
+from pyrosm.engine.readers import get_buildings
+
+__all__ = ["get_buildings"]

--- a/pyrosm/engine/assemble.py
+++ b/pyrosm/engine/assemble.py
@@ -1,0 +1,41 @@
+"""Assemble collected way/relation records into a GeoDataFrame through pyrosm's own tag
+and geometry pipeline, so the output matches the in-memory reader column-for-column."""
+
+from pyrosm.engine.collect import _ways_arrays, _collect_buildings
+
+
+def _assemble_chunk(
+    node_coordinates, way_records, relations, relation_ways, keep_metadata
+):
+    """Build one GeoDataFrame from way and/or relation elements using pyrosm's own tag +
+    geometry pipeline (full columns, missing-node handling, polygon/linestring typing,
+    ring assembly, dropna, orientation), so the result matches the in-memory reader
+    exactly."""
+    from pyrosm.config import Conf
+    from pyrosm.frames import prepare_geodataframe
+
+    ways = _ways_arrays(way_records, keep_metadata) if way_records else None
+    gdf = prepare_geodataframe(
+        None,
+        node_coordinates,
+        ways,
+        relations,
+        relation_ways,
+        list(Conf.tags.building),
+        None,
+        keep_metadata=keep_metadata,
+    )
+    if gdf is not None and "nodes" in gdf.columns:
+        gdf = gdf.drop(columns=["nodes"])
+    return gdf
+
+
+def _assemble_buildings(shard_paths, keep_metadata):
+    """Assemble all building ways and relations into a single in-memory GeoDataFrame."""
+    collected = _collect_buildings(shard_paths)
+    if collected is None:
+        return None
+    kept, relations, relation_ways, node_coordinates = collected
+    return _assemble_chunk(
+        node_coordinates, kept, relations, relation_ways, keep_metadata
+    )

--- a/pyrosm/engine/blobs.py
+++ b/pyrosm/engine/blobs.py
@@ -1,0 +1,41 @@
+"""Blob framing: index a PBF file's blobs and read/decompress one ``PrimitiveBlock``."""
+
+import os
+import struct
+import zlib
+
+from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
+
+
+def _index_blobs(filepath):
+    """One cheap sequential pass: ``(type, data_offset, data_size)`` per blob, reading
+    only the ``BlobHeader``s and skipping the payloads (no decompression)."""
+    blobs = []
+    with open(filepath, "rb") as f:
+        while True:
+            header_len_bytes = f.read(4)
+            if len(header_len_bytes) < 4:
+                break
+            (header_len,) = struct.unpack("!L", header_len_bytes)
+            header = BlobHeader()
+            header.ParseFromString(f.read(header_len))
+            offset = f.tell()
+            blobs.append((header.type, offset, header.datasize))
+            f.seek(header.datasize, os.SEEK_CUR)
+    return blobs
+
+
+def _read_block(f, offset, size):
+    """Read and decompress one ``Blob`` payload into the raw ``PrimitiveBlock`` bytes."""
+    f.seek(offset)
+    blob = Blob()
+    blob.ParseFromString(f.read(size))
+    if blob.HasField("zlib_data"):
+        return zlib.decompress(blob.zlib_data)
+    if blob.HasField("raw"):
+        return blob.raw
+    if blob.HasField("lzma_data"):
+        import lzma
+
+        return lzma.decompress(blob.lzma_data)
+    raise ValueError("Unsupported Blob compression in '%s'." % f.name)

--- a/pyrosm/engine/collect.py
+++ b/pyrosm/engine/collect.py
@@ -1,0 +1,207 @@
+"""Main-process collection.
+
+Read the spilled shards back into the building way and relation records, their member
+ways and the referenced node coordinates -- pulling only what the kept features need off
+disk, so peak memory stays bounded by the working set.
+"""
+
+import numpy as np
+
+from pyrosm._arrays import way_records_to_arrays
+from pyrosm.tagparser import explode_way_tags
+from pyrosm.engine.decode import _object_array
+
+# Relation.MemberType -> the byte labels pyrosm's relation assembly expects.
+_MEMBER_TYPE = {0: b"node", 1: b"way", 2: b"relation"}
+# Only way members carry ring geometry. Member ids are matched against the way store, but
+# OSM ids are unique only per element type, so a node/relation member id can collide with a
+# building way id -- mixing types in the lookup would attach or drop the wrong way.
+_WAY_MEMBER = 1
+
+
+def _collect_building_ways(shard_paths):
+    """Read the spilled building ways back as pyrosm-shaped way records (``id``,
+    ``version``, ``timestamp``, ``visible``, ``nodes``, ``tags``)."""
+    records = []
+    for path in shard_paths:
+        z = np.load(path, allow_pickle=True)
+        wid = z["way_id"]
+        if len(wid) == 0:
+            continue
+        off, refs, tags = z["refs_off"], z["refs"], z["way_tags"]
+        ver, ts, vis = z["way_version"], z["way_timestamp"], z["way_visible"]
+        for i in range(len(wid)):
+            records.append(
+                {
+                    "id": int(wid[i]),
+                    "version": int(ver[i]),
+                    "timestamp": int(ts[i]),
+                    "visible": bool(vis[i]),
+                    "nodes": refs[off[i] : off[i + 1]].tolist(),
+                    "tags": tags[i],
+                }
+            )
+    return records
+
+
+def _node_lookup(shard_paths, needed):
+    """Gather only the coordinates of ``needed`` node ids from the shards (bounded
+    memory) and wrap them in a ``NodeLocations`` for geometry assembly."""
+    import pandas as pd
+
+    from pyrosm.node_lookup import NodeLocations
+
+    lon = np.full(len(needed), np.nan)
+    lat = np.full(len(needed), np.nan)
+    for path in shard_paths:
+        z = np.load(path, allow_pickle=True)
+        nid = z["node_id"]
+        if len(nid) == 0:
+            continue
+        pos = np.clip(np.searchsorted(needed, nid), 0, len(needed) - 1)
+        hit = needed[pos] == nid
+        lon[pos[hit]] = z["node_lon"][hit]
+        lat[pos[hit]] = z["node_lat"][hit]
+    present = ~np.isnan(lon)
+    coords = pd.DataFrame(
+        {"id": needed[present], "lon": lon[present], "lat": lat[present]}
+    )
+    return NodeLocations(coords)
+
+
+def _collect_kept_ways(shard_paths, exclude_ids):
+    """The standalone building way records to output, after dropping the ones that are
+    members of a building relation (pyrosm assigns those to the relation, so they are not
+    standalone way rows)."""
+    records = _collect_building_ways(shard_paths)
+    if not records:
+        return None
+    if len(exclude_ids):
+        exclude = set(exclude_ids.tolist())
+        records = [r for r in records if r["id"] not in exclude]
+        if not records:
+            return None
+    return records
+
+
+def _load_building_relations(shard_paths):
+    """Reassemble the building relations spilled across shards into the ``relations``
+    struct pyrosm's assembly expects (``id`` / ``members`` / ``tags``), and return it
+    together with the unique set of all their member ids. ``(None, empty)`` if there are
+    no building relations."""
+    ids, members, tags, meta, way_member_ids = [], [], [], [], []
+    for path in shard_paths:
+        z = np.load(path, allow_pickle=True)
+        rid = z["rel_id"]
+        if len(rid) == 0:
+            continue
+        memid, memoff, memtype, memrole, rtags = (
+            z["rel_memid"],
+            z["rel_memoff"],
+            z["rel_memtype"],
+            z["rel_memrole"],
+            z["rel_tags"],
+        )
+        for k in range(len(rid)):
+            s, e = memoff[k], memoff[k + 1]
+            mids, mtypes = memid[s:e], memtype[s:e]
+            members.append(
+                {
+                    "member_id": mids,
+                    "member_type": np.array(
+                        [_MEMBER_TYPE[int(t)] for t in mtypes], dtype=object
+                    ),
+                    "member_role": memrole[s:e],
+                }
+            )
+            way_member_ids.append(mids[mtypes == _WAY_MEMBER])
+            tags.append(rtags[k])
+        ids.append(rid)
+        meta.append(z["rel_meta"])
+    if not ids:
+        return None, np.empty(0, np.int64)
+    meta = np.concatenate(meta)
+    relations = {
+        "id": np.concatenate(ids),
+        "members": _object_array(members),
+        "tags": _object_array(tags),
+        "version": meta[:, 0],
+        "timestamp": meta[:, 1],
+        "changeset": meta[:, 2],
+    }
+    member_ids = (
+        np.unique(np.concatenate(way_member_ids))
+        if way_member_ids
+        else np.empty(0, np.int64)
+    )
+    return relations, member_ids
+
+
+def _collect_relation_ways(shard_paths, member_ids):
+    """Look up the member ways (id -> node refs) of the building relations from the
+    spilled all-ways store. Returned as a ``{id, nodes}`` dict sorted by id ascending --
+    pyrosm aligns member roles to the sorted member ids, so the ways must match that
+    order. ``None`` if there are no way members, or none of them are present."""
+    if len(member_ids) == 0:
+        return None
+    found = {}
+    for path in shard_paths:
+        z = np.load(path, allow_pickle=True)
+        wid, off, refs = z["all_id"], z["all_refs_off"], z["all_refs"]
+        if len(wid) == 0:
+            continue
+        pos = np.clip(np.searchsorted(member_ids, wid), 0, len(member_ids) - 1)
+        for k in np.nonzero(member_ids[pos] == wid)[0]:
+            found[int(wid[k])] = refs[off[k] : off[k + 1]]
+    if not found:
+        return None
+    ids = np.array(sorted(found), dtype=np.int64)
+    nodes = np.empty(len(ids), dtype=object)
+    nodes[:] = [found[int(i)] for i in ids]
+    return {"id": ids, "nodes": nodes}
+
+
+def _ways_arrays(records, keep_metadata):
+    """Convert way records into the ``way_elements`` dict (all occurring tag columns + the
+    JSON ``tags`` column + metadata) pyrosm's assembly expects, reusing pyrosm's own
+    tag-explosion so the columns match the in-memory reader. Consumes (explodes) the
+    records. The augmentation mirrors ``get_osm_ways_and_relations``."""
+    from pyrosm.config import Conf
+
+    tags_as_columns = list(Conf.tags.building) + ["id", "nodes"]
+    if keep_metadata:
+        tags_as_columns += ["timestamp", "version"]
+    return way_records_to_arrays(explode_way_tags(records), tags_as_columns)
+
+
+def _needed_node_ids(kept, relation_ways):
+    """The unique node ids referenced by the kept standalone ways and the relation
+    member ways -- the only coordinates the gather has to pull off disk."""
+    refs = []
+    if kept is not None:
+        refs.extend(r["nodes"] for r in kept)
+    if relation_ways is not None:
+        refs.extend(relation_ways["nodes"])
+    if not refs:
+        return np.empty(0, np.int64)
+    return np.unique(np.concatenate(refs))
+
+
+def _collect_buildings(shard_paths):
+    """Shared collection for both output modes: standalone building ways, building
+    relations, their member ways and the node coordinates all of them reference. ``None``
+    if there is nothing to assemble."""
+    relations, member_ids = _load_building_relations(shard_paths)
+    relation_ways = (
+        _collect_relation_ways(shard_paths, member_ids)
+        if relations is not None
+        else None
+    )
+    # No member way is present (all outside the data) -> the relation cannot be assembled.
+    if relation_ways is None:
+        relations = None
+    kept = _collect_kept_ways(shard_paths, member_ids)
+    if kept is None and relations is None:
+        return None
+    node_coordinates = _node_lookup(shard_paths, _needed_node_ids(kept, relation_ways))
+    return kept, relations, relation_ways, node_coordinates

--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -1,0 +1,206 @@
+"""Worker-side decode and spill.
+
+A worker decodes a contiguous run of blobs and writes one shard holding the node
+coordinates, the matching building ways (refs + resolved tags + metadata), *every* way
+(id + refs, for relation-member lookup) and the building relations.
+"""
+
+import os
+
+import numpy as np
+
+from pyrosm.primitive_block_decoder import decode_primitive_block
+from pyrosm.engine.blobs import _read_block
+
+_BUILDING = b"building"
+
+# Per-worker globals, set by the pool initializer (or directly for the in-process path).
+_FILEPATH = None
+_SHARD_DIR = None
+
+
+def _init_worker(filepath, shard_dir):
+    global _FILEPATH, _SHARD_DIR
+    _FILEPATH = filepath
+    _SHARD_DIR = shard_dir
+
+
+def _resolve_tags(string_table, keys, vals, start, end):
+    """The ``{key: value}`` tag dict for one element, resolved through the string table
+    (decoded to str, as pyrosm's protobuf path produces)."""
+    return {
+        string_table[keys[p]]
+        .decode("utf-8", "replace"): string_table[vals[p]]
+        .decode("utf-8", "replace")
+        for p in range(start, end)
+    }
+
+
+def _building_ways(string_table, ways):
+    """Select the ways tagged ``building=*`` and return, per matching way, its node-ref
+    slice, full (resolved) tag dict and ``version``/``timestamp``/``visible`` metadata --
+    everything pyrosm's way record carries. Returns a dict of parallel arrays/lists, or
+    ``None``."""
+    if ways is None or _BUILDING not in string_table:
+        return None
+    building_idx = string_table.index(_BUILDING)
+    keys, vals, tags_off = ways["keys"], ways["vals"], ways["tags_off"]
+    key_positions = np.nonzero(keys == building_idx)[0]
+    if len(key_positions) == 0:
+        return None
+    # A tag key belongs to the way whose [tags_off[i], tags_off[i+1]) slice contains it.
+    way_index = np.searchsorted(tags_off, key_positions, side="right") - 1
+    refs, refs_off = ways["refs"], ways["refs_off"]
+    return {
+        "id": ways["id"][way_index],
+        "refs": [refs[refs_off[i] : refs_off[i + 1]] for i in way_index],
+        "tags": [
+            _resolve_tags(string_table, keys, vals, tags_off[i], tags_off[i + 1])
+            for i in way_index
+        ],
+        "version": ways["version"][way_index],
+        "timestamp": ways["timestamp"][way_index],
+        "visible": ways["visible"][way_index],
+    }
+
+
+def _building_relations(string_table, relations):
+    """The ``building=*`` relations in this block. Yields, per relation, its id, member
+    id/type/role arrays, full tag dict and ``version``/``timestamp``/``changeset``
+    metadata -- everything pyrosm needs to assemble the multipolygon and its columns.
+    Member roles and tags are resolved through the block's string table."""
+    if relations is None or _BUILDING not in string_table:
+        return
+    building_idx = string_table.index(_BUILDING)
+    key_positions = np.nonzero(relations["keys"] == building_idx)[0]
+    if len(key_positions) == 0:
+        return
+    tags_off = relations["tags_off"]
+    rel_index = np.unique(np.searchsorted(tags_off, key_positions, side="right") - 1)
+    ids, keys, vals = relations["id"], relations["keys"], relations["vals"]
+    version, timestamp, changeset = (
+        relations["version"],
+        relations["timestamp"],
+        relations["changeset"],
+    )
+    memids, types, roles, moff = (
+        relations["memids"],
+        relations["types"],
+        relations["roles"],
+        relations["members_off"],
+    )
+    for i in rel_index:
+        s, e = moff[i], moff[i + 1]
+        member_role = np.array(
+            [string_table[r].decode("utf-8", "replace") for r in roles[s:e]],
+            dtype=object,
+        )
+        tags = _resolve_tags(string_table, keys, vals, tags_off[i], tags_off[i + 1])
+        yield {
+            "id": ids[i],
+            "memid": memids[s:e],
+            "memtype": types[s:e],
+            "memrole": member_role,
+            "tags": tags,
+            "version": version[i],
+            "timestamp": timestamp[i],
+            "changeset": changeset[i],
+        }
+
+
+def _offsets_from_lengths(lengths):
+    """CSR offsets array for variable-length rows: ``[0, l0, l0+l1, ...]``."""
+    off = np.zeros(len(lengths) + 1, dtype=np.int64)
+    if lengths:
+        np.cumsum(lengths, out=off[1:])
+    return off
+
+
+def _object_array(items):
+    """1-D object array of ``items`` (dicts/arrays), avoiding numpy's 2-D coercion."""
+    arr = np.empty(len(items), dtype=object)
+    arr[:] = items
+    return arr
+
+
+def _decode_batch(task):
+    """Worker: decode a contiguous run of blobs and spill one shard with the node
+    coordinates, the matching building ways (refs + resolved tags + metadata), *all* ways
+    (id + refs, for relation-member lookup) and the building relations, then return the
+    shard path."""
+    worker_id, blobs = task
+    node_id, node_lon, node_lat = [], [], []
+    bld_id, bld_refs, bld_tags = [], [], []
+    bld_version, bld_timestamp, bld_visible = [], [], []
+    all_id, all_refs, all_count = [], [], []
+    rel = {k: [] for k in ("id", "memid", "memtype", "memrole", "tags", "meta")}
+    with open(_FILEPATH, "rb") as f:
+        for offset, size in blobs:
+            data = _read_block(f, offset, size)
+            string_table, header, nodes, ways, relations = decode_primitive_block(data)
+            if nodes is not None:
+                gran = header["granularity"]
+                node_id.append(nodes["id"])
+                node_lat.append((nodes["lat"] * gran + header["lat_offset"]) / 1e9)
+                node_lon.append((nodes["lon"] * gran + header["lon_offset"]) / 1e9)
+            if ways is not None:
+                all_id.append(ways["id"])
+                all_refs.append(ways["refs"])
+                all_count.append(np.diff(ways["refs_off"]))
+                found = _building_ways(string_table, ways)
+                if found is not None:
+                    bld_id.append(found["id"])
+                    bld_refs.extend(found["refs"])
+                    bld_tags.extend(found["tags"])
+                    bld_version.append(found["version"])
+                    bld_timestamp.append(found["timestamp"])
+                    bld_visible.append(found["visible"])
+            for r in _building_relations(string_table, relations):
+                rel["id"].append(r["id"])
+                rel["memid"].append(r["memid"])
+                rel["memtype"].append(r["memtype"])
+                rel["memrole"].append(r["memrole"])
+                rel["tags"].append(r["tags"])
+                rel["meta"].append((r["version"], r["timestamp"], r["changeset"]))
+
+    path = os.path.join(_SHARD_DIR, "shard_%d.npz" % worker_id)
+    np.savez(
+        path,
+        node_id=np.concatenate(node_id) if node_id else np.empty(0, np.int64),
+        node_lon=np.concatenate(node_lon) if node_lon else np.empty(0),
+        node_lat=np.concatenate(node_lat) if node_lat else np.empty(0),
+        way_id=np.concatenate(bld_id) if bld_id else np.empty(0, np.int64),
+        refs=np.concatenate(bld_refs) if bld_refs else np.empty(0, np.int64),
+        refs_off=_offsets_from_lengths([len(r) for r in bld_refs]),
+        way_tags=_object_array(bld_tags),
+        way_version=(
+            np.concatenate(bld_version) if bld_version else np.empty(0, np.int64)
+        ),
+        way_timestamp=(
+            np.concatenate(bld_timestamp) if bld_timestamp else np.empty(0, np.int64)
+        ),
+        way_visible=(
+            np.concatenate(bld_visible) if bld_visible else np.empty(0, np.int64)
+        ),
+        all_id=np.concatenate(all_id) if all_id else np.empty(0, np.int64),
+        all_refs=np.concatenate(all_refs) if all_refs else np.empty(0, np.int64),
+        all_refs_off=_offsets_from_lengths(
+            np.concatenate(all_count).tolist() if all_count else []
+        ),
+        rel_id=np.array(rel["id"], dtype=np.int64),
+        rel_memid=(
+            np.concatenate(rel["memid"]) if rel["memid"] else np.empty(0, np.int64)
+        ),
+        rel_memoff=_offsets_from_lengths([len(m) for m in rel["memid"]]),
+        rel_memtype=(
+            np.concatenate(rel["memtype"]) if rel["memtype"] else np.empty(0, np.int64)
+        ),
+        rel_memrole=(
+            np.concatenate(rel["memrole"])
+            if rel["memrole"]
+            else np.empty(0, dtype=object)
+        ),
+        rel_tags=_object_array(rel["tags"]),
+        rel_meta=np.array(rel["meta"], dtype=np.int64).reshape(-1, 3),
+    )
+    return path

--- a/pyrosm/engine/geoparquet.py
+++ b/pyrosm/engine/geoparquet.py
@@ -1,0 +1,108 @@
+"""Stream a layer to a GeoParquet file without materialising the whole output frame.
+
+Each chunk is assembled and written to its own temporary parquet file, so only one chunk
+is in memory at a time. Because pyrosm builds a tag column only when that tag occurs in a
+chunk, different chunks carry different columns; the temporary files are then combined
+under one schema that is the union (by name) of every chunk's columns, so a tag column
+that first appears in a later chunk is not dropped. Needs the optional pyarrow dependency.
+"""
+
+import os
+import shutil
+import tempfile
+
+from pyrosm.engine.collect import _collect_buildings
+from pyrosm.engine.assemble import _assemble_chunk
+
+# Assemble and write this many ways per chunk, so the output frame is never fully
+# materialised.
+_OUTPUT_CHUNK_SIZE = 250_000
+
+
+def _align_table(table, schema):
+    """Reorder ``table`` to ``schema``'s field order, adding any columns it lacks as typed
+    nulls -- so a chunk that materialised only a subset of the union's columns is widened
+    to the full schema (rather than its extra-or-missing columns being dropped)."""
+    import pyarrow as pa
+
+    arrays = [
+        (
+            table.column(i)
+            if (i := table.schema.get_field_index(field.name)) >= 0
+            else pa.nulls(table.num_rows, type=field.type)
+        )
+        for field in schema
+    ]
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def _unify_schemas(schemas):
+    """One arrow schema holding the union (by name) of these schemas' fields, with the
+    GeoParquet ``geo`` metadata preserved -- so the per-chunk parquet files, which can
+    each carry a different subset of the tag columns, combine without dropping any."""
+    import pyarrow as pa
+
+    unified = pa.unify_schemas(schemas, promote_options="permissive")
+    for schema in schemas:
+        if schema.metadata and b"geo" in schema.metadata:
+            return unified.with_metadata(schema.metadata)
+    return unified
+
+
+def _stream_buildings_to_parquet(shard_paths, output, chunk_size, keep_metadata):
+    """Stream the buildings (ways in chunks, then relations) to a GeoParquet at ``output``,
+    spilling each chunk to its own temporary parquet file and then combining the files
+    under the union of their schemas. Returns the path, or ``None`` if there were no
+    buildings to write."""
+    import pyarrow.parquet as pq
+    from geopandas.io.arrow import _geopandas_to_arrow
+
+    collected = _collect_buildings(shard_paths)
+    if collected is None:
+        return None
+    kept, relations, relation_ways, node_coordinates = collected
+
+    def to_table(gdf):
+        return _geopandas_to_arrow(gdf, index=False, geometry_encoding="WKB")
+
+    def chunk_tables():
+        if kept is not None:
+            for start in range(0, len(kept), chunk_size):
+                gdf = _assemble_chunk(
+                    node_coordinates,
+                    kept[start : start + chunk_size],
+                    None,
+                    None,
+                    keep_metadata,
+                )
+                if gdf is not None and len(gdf) > 0:
+                    yield to_table(gdf)
+        if relations is not None:
+            rgdf = _assemble_chunk(
+                node_coordinates, None, relations, relation_ways, keep_metadata
+            )
+            if rgdf is not None and len(rgdf) > 0:
+                yield to_table(rgdf)
+
+    part_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_parquet_")
+    try:
+        # Spill each chunk to its own parquet file (heterogeneous columns allowed).
+        part_paths = []
+        for table in chunk_tables():
+            part_path = os.path.join(part_dir, "part_%d.parquet" % len(part_paths))
+            pq.write_table(table, part_path)
+            part_paths.append(part_path)
+        if not part_paths:
+            return None
+        # Combine the parts into the single output under the union of their schemas, one
+        # part in memory at a time so the full frame is never materialised.
+        schema = _unify_schemas([pq.read_schema(p) for p in part_paths])
+        writer = pq.ParquetWriter(output, schema)
+        try:
+            for part_path in part_paths:
+                writer.write_table(_align_table(pq.read_table(part_path), schema))
+        finally:
+            writer.close()
+        return output
+    finally:
+        shutil.rmtree(part_dir, ignore_errors=True)

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -1,0 +1,37 @@
+"""Worker-count policy and ``multiprocessing.Pool`` orchestration for decoding blobs."""
+
+import os
+from multiprocessing import Pool
+
+from pyrosm.engine.decode import _init_worker, _decode_batch
+
+# Parallelising the decode only pays off above this file size; smaller files decode in a
+# single process, where the process-spawn overhead would otherwise dominate.
+_PARALLEL_MIN_FILE_BYTES = 70_000_000  # ~70 MB
+
+
+def _auto_workers(filepath, n_blobs):
+    """Pick a worker count for ``filepath``: single-core below the size threshold (where
+    the process-spawn overhead dominates), otherwise a worker per CPU, capped at the blob
+    count."""
+    if os.path.getsize(filepath) < _PARALLEL_MIN_FILE_BYTES:
+        return 1
+    return max(1, min(os.cpu_count() or 1, n_blobs))
+
+
+def _decode_all(filepath, blobs, workers, shard_dir):
+    """Decode every data blob into per-worker shards; return the shard paths."""
+    n = len(blobs)
+    per = (n + workers - 1) // workers
+    tasks = [
+        (i, blobs[i * per : (i + 1) * per])
+        for i in range(workers)
+        if blobs[i * per : (i + 1) * per]
+    ]
+    if workers == 1:
+        _init_worker(filepath, shard_dir)
+        return [_decode_batch(tasks[0])] if tasks else []
+    with Pool(
+        workers, initializer=_init_worker, initargs=(filepath, shard_dir)
+    ) as pool:
+        return pool.map(_decode_batch, tasks)

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -1,0 +1,50 @@
+"""Public out-of-core readers (one per layer). Each indexes the file's blobs, decodes
+them into per-worker shards, then collects and assembles (or streams to GeoParquet) the
+requested layer."""
+
+import tempfile
+import shutil
+
+from pyrosm.utils._compat import require_pyarrow
+from pyrosm.engine.blobs import _index_blobs
+from pyrosm.engine.pool import _auto_workers, _decode_all
+from pyrosm.engine.assemble import _assemble_buildings
+from pyrosm.engine import geoparquet
+
+
+def get_buildings(filepath, workers=None, output=None, keep_metadata=True):
+    """Read building geometries from ``filepath`` with the out-of-core engine.
+
+    Returns the building ways and relations with the same columns as the in-memory reader:
+    every occurring ``Conf.tags.building`` tag as its own column, the remaining tags as a
+    JSON ``tags`` column, and -- when ``keep_metadata`` -- the ``version`` / ``timestamp``
+    / ``changeset`` / ``visible`` element metadata.
+
+    With ``output=None`` (the default) returns an in-memory GeoDataFrame. With ``output``
+    set to a path, the buildings are streamed to a GeoParquet file in chunks (never fully
+    materialised) and the path is returned; this needs the optional ``pyarrow`` dependency.
+
+    ``workers`` defaults to one for small files (no multiprocessing overhead) and
+    otherwise to a worker per CPU, bounded by the blob count.
+    """
+    if output is not None:
+        require_pyarrow()
+
+    data_blobs = [
+        (offset, size)
+        for (blob_type, offset, size) in _index_blobs(filepath)
+        if blob_type == "OSMData"
+    ]
+    if workers is None:
+        workers = _auto_workers(filepath, len(data_blobs))
+
+    shard_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_")
+    try:
+        shard_paths = _decode_all(filepath, data_blobs, workers, shard_dir)
+        if output is None:
+            return _assemble_buildings(shard_paths, keep_metadata)
+        return geoparquet._stream_buildings_to_parquet(
+            shard_paths, output, geoparquet._OUTPUT_CHUNK_SIZE, keep_metadata
+        )
+    finally:
+        shutil.rmtree(shard_dir, ignore_errors=True)

--- a/pyrosm/utils/_compat.py
+++ b/pyrosm/utils/_compat.py
@@ -31,3 +31,21 @@ try:
     HAS_PANDARM = True
 except ImportError:
     HAS_PANDARM = False
+
+# pyarrow is an optional dependency, needed only to write GeoParquet via output=
+try:
+    import pyarrow.parquet  # noqa: F401
+
+    HAS_PYARROW = True
+except ImportError:
+    HAS_PYARROW = False
+
+
+def require_pyarrow():
+    """Raise an actionable ImportError when an output= GeoParquet write is requested
+    without the optional pyarrow dependency installed."""
+    if not HAS_PYARROW:
+        raise ImportError(
+            "Writing to GeoParquet (output=...) requires the optional 'pyarrow' "
+            "dependency. Install it with `pip install pyarrow`."
+        )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -241,3 +241,218 @@ def test_read_block_decodes_lzma_and_rejects_unsupported(tmp_path):
     with open(bad_fp, "rb") as f:
         with pytest.raises(ValueError, match="Unsupported"):
             _read_block(f, 0, len(bad))
+
+
+def _write_shard(path, **overrides):
+    """Write a per-worker shard in the layout decode._decode_batch produces; every array
+    is empty by default so a test can fill in only the ones it needs."""
+    arrays = dict(
+        node_id=np.empty(0, np.int64),
+        node_lon=np.empty(0),
+        node_lat=np.empty(0),
+        way_id=np.empty(0, np.int64),
+        refs=np.empty(0, np.int64),
+        refs_off=np.array([0], np.int64),
+        way_tags=np.empty(0, object),
+        way_version=np.empty(0, np.int64),
+        way_timestamp=np.empty(0, np.int64),
+        way_visible=np.empty(0, np.int64),
+        all_id=np.empty(0, np.int64),
+        all_refs=np.empty(0, np.int64),
+        all_refs_off=np.array([0], np.int64),
+        rel_id=np.empty(0, np.int64),
+        rel_memid=np.empty(0, np.int64),
+        rel_memoff=np.array([0], np.int64),
+        rel_memtype=np.empty(0, np.int64),
+        rel_memrole=np.empty(0, object),
+        rel_tags=np.empty(0, object),
+        rel_meta=np.empty((0, 3), np.int64),
+    )
+    arrays.update(overrides)
+    np.savez(path, **arrays)
+
+
+def _write_pbf_no_buildings(path):
+    """Write a minimal one-blob PBF whose only way is untagged, so the engine reads it
+    with ways present but no buildings found."""
+    from pyrosm.proto.osmformat_pb2 import PrimitiveBlock
+
+    pb = PrimitiveBlock()
+    pb.stringtable.s.append(b"")
+    way = pb.primitivegroup.add().ways.add()
+    way.id = 100
+    way.refs.extend([1, 1])
+    blob = Blob()
+    blob.raw = pb.SerializeToString()
+    blob_bytes = blob.SerializeToString()
+    bh = BlobHeader()
+    bh.type = "OSMData"
+    bh.datasize = len(blob_bytes)
+    bh_bytes = bh.SerializeToString()
+    with open(path, "wb") as f:
+        f.write(pack("!L", len(bh_bytes)))
+        f.write(bh_bytes)
+        f.write(blob_bytes)
+
+
+def test_engine_get_buildings_no_buildings_returns_none(tmp_path):
+    # A PBF with ways but no buildings yields None from both the in-memory and output paths.
+    fp = str(tmp_path / "no_buildings.osm.pbf")
+    _write_pbf_no_buildings(fp)
+    assert get_buildings(fp) is None
+    pytest.importorskip("pyarrow")
+    assert get_buildings(fp, output=str(tmp_path / "x.parquet")) is None
+
+
+def test_engine_building_ways_early_returns():
+    from pyrosm.engine.decode import _building_ways
+
+    ways = {
+        "id": np.array([7], np.int64),
+        "keys": np.array([0], np.int64),
+        "vals": np.array([0], np.int64),
+        "tags_off": np.array([0, 1], np.int64),
+        "refs": np.array([1, 2], np.int64),
+        "refs_off": np.array([0, 2], np.int64),
+        "version": np.array([1], np.int64),
+        "timestamp": np.array([1], np.int64),
+        "visible": np.array([1], np.int64),
+    }
+    assert _building_ways([b"highway"], None) is None  # ways is None guard
+    assert _building_ways([b"highway"], ways) is None  # 'building' not in string table
+    # 'building' is in the table but no way carries it as a key.
+    assert _building_ways([b"highway", b"building"], ways) is None
+
+
+def test_engine_collect_empty_and_edge_shards(tmp_path):
+    from pyrosm.engine.collect import (
+        _collect_building_ways,
+        _collect_kept_ways,
+        _node_lookup,
+        _collect_relation_ways,
+        _needed_node_ids,
+        _collect_buildings,
+    )
+
+    empty = str(tmp_path / "empty.npz")
+    _write_shard(empty)
+    assert _collect_building_ways([empty]) == []
+    assert _collect_kept_ways([empty], np.empty(0, np.int64)) is None
+    assert _node_lookup([empty], np.array([1, 2], np.int64)) is not None
+    assert _collect_buildings([empty]) is None
+    assert len(_needed_node_ids(None, None)) == 0
+
+    bld = str(tmp_path / "bld.npz")
+    _write_shard(
+        bld,
+        way_id=np.array([1], np.int64),
+        refs=np.array([10, 11], np.int64),
+        refs_off=np.array([0, 2], np.int64),
+        way_tags=np.array([{"building": "yes"}], dtype=object),
+        way_version=np.array([1], np.int64),
+        way_timestamp=np.array([100], np.int64),
+        way_visible=np.array([1], np.int64),
+    )
+    # Excluding the only building way (it is a relation member) leaves nothing standalone.
+    assert _collect_kept_ways([bld], np.array([1], np.int64)) is None
+
+    ways_only = str(tmp_path / "ways.npz")
+    _write_shard(
+        ways_only,
+        all_id=np.array([5], np.int64),
+        all_refs=np.array([10, 11], np.int64),
+        all_refs_off=np.array([0, 2], np.int64),
+    )
+    # Member ids that match no stored way -> no relation ways.
+    assert _collect_relation_ways([ways_only], np.array([999], np.int64)) is None
+
+
+def test_engine_geoparquet_schema_helpers():
+    pa = pytest.importorskip("pyarrow")
+    from pyrosm.engine.geoparquet import _unify_schemas, _align_table
+
+    s1 = pa.schema([pa.field("a", pa.int64())])
+    s2 = pa.schema([pa.field("b", pa.string())])
+    unified = _unify_schemas([s1, s2])  # neither carries GeoParquet 'geo' metadata
+    assert set(unified.names) == {"a", "b"}
+    # A table missing column 'b' is widened with typed nulls rather than dropping columns.
+    aligned = _align_table(pa.table({"a": [1, 2]}), unified)
+    assert aligned.schema.names == ["a", "b"]
+    assert aligned.column("b").null_count == 2
+
+
+def test_engine_stream_parquet_chunk_table_branches(
+    helsinki_pbf, tmp_path, monkeypatch
+):
+    # Drive the chunked writer through its relations-only, ways-only and empty-chunk
+    # branches by feeding it crafted variants of the real collected building data.
+    pytest.importorskip("pyarrow")
+    import tempfile
+    import shutil
+    from pyrosm.engine import geoparquet
+    from pyrosm.engine.blobs import _index_blobs
+    from pyrosm.engine.pool import _decode_all
+    from pyrosm.engine.collect import _collect_buildings
+
+    data_blobs = [(o, s) for (t, o, s) in _index_blobs(helsinki_pbf) if t == "OSMData"]
+    shard_dir = tempfile.mkdtemp()
+    try:
+        shards = _decode_all(helsinki_pbf, data_blobs, 1, shard_dir)
+        kept, relations, relation_ways, nc = _collect_buildings(shards)
+        assert kept is not None and relations is not None  # helsinki has both
+
+        def write(collected):
+            monkeypatch.setattr(
+                geoparquet, "_collect_buildings", lambda paths: collected
+            )
+            return geoparquet._stream_buildings_to_parquet(
+                shards, str(tmp_path / "o.parquet"), 250_000, True
+            )
+
+        # relations only (no standalone ways): way loop skipped, relation chunk written.
+        assert write((None, relations, relation_ways, nc)) is not None
+        # ways only (no relations): relation branch skipped.
+        assert write((kept, None, None, nc)) is not None
+        # a way referencing an absent node assembles empty -> no parts -> None.
+        absent = [
+            {
+                "id": -1,
+                "version": 1,
+                "timestamp": 1,
+                "visible": True,
+                "nodes": [10**18],
+                "tags": {"building": "yes"},
+            }
+        ]
+        assert write((absent, None, None, nc)) is None
+        # a relation whose member ways are all absent assembles empty -> chunk skipped.
+        empty_ways = {"id": np.empty(0, np.int64), "nodes": np.empty(0, dtype=object)}
+        assert write((None, relations, empty_ways, nc)) is None
+    finally:
+        shutil.rmtree(shard_dir, ignore_errors=True)
+
+
+def test_compat_has_pyarrow_false_when_unavailable(monkeypatch):
+    # The optional-dependency flag falls back to False (and require_pyarrow then raises)
+    # when pyarrow cannot be imported.
+    import builtins
+    import importlib
+    from pyrosm.utils import _compat
+
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name == "pyarrow" or name.startswith("pyarrow."):
+            raise ImportError("pyarrow blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    try:
+        importlib.reload(_compat)
+        assert _compat.HAS_PYARROW is False
+        with pytest.raises(ImportError, match="pyarrow"):
+            _compat.require_pyarrow()
+    finally:
+        monkeypatch.undo()
+        importlib.reload(_compat)  # restore the real, pyarrow-present state
+    assert _compat.HAS_PYARROW is True

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -215,3 +215,29 @@ def test_auto_workers_decides_on_file_size_not_blob_count(tmp_path):
     cpus = os.cpu_count() or 1
     assert pool._auto_workers(str(big), 10_000) == cpus
     assert pool._auto_workers(str(big), 2) == min(cpus, 2)
+
+
+def test_read_block_decodes_lzma_and_rejects_unsupported(tmp_path):
+    # _read_block must decode an lzma-compressed Blob and raise on a Blob that carries no
+    # recognised compression field.
+    import lzma
+    from pyrosm.engine.blobs import _read_block
+
+    payload = b"raw primitive block bytes"
+
+    blob = Blob()
+    blob.lzma_data = lzma.compress(payload)
+    encoded = blob.SerializeToString()
+    lzma_fp = tmp_path / "lzma_blob.bin"
+    lzma_fp.write_bytes(encoded)
+    with open(lzma_fp, "rb") as f:
+        assert _read_block(f, 0, len(encoded)) == payload
+
+    unsupported = Blob()
+    unsupported.raw_size = len(payload)  # a field is set, but no payload field is
+    bad = unsupported.SerializeToString()
+    bad_fp = tmp_path / "bad_blob.bin"
+    bad_fp.write_bytes(bad)
+    with open(bad_fp, "rb") as f:
+        with pytest.raises(ValueError, match="Unsupported"):
+            _read_block(f, 0, len(bad))

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,217 @@
+"""Out-of-core engine buildings reader: parity vs the in-memory OSM(fp).get_buildings()
+way and relation rows, plus the output= GeoParquet path and the worker-count policy."""
+
+import zlib
+from struct import pack, unpack
+
+import geopandas as gpd
+import numpy as np
+import pytest
+import shapely
+
+from pyrosm import OSM, get_data
+from pyrosm.engine import get_buildings
+from pyrosm.engine import pool, geoparquet
+from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
+
+
+@pytest.fixture
+def test_pbf():
+    return get_data("test_pbf")
+
+
+@pytest.fixture
+def helsinki_pbf():
+    return get_data("helsinki_pbf")
+
+
+def _rewrite_pbf_raw(src, dst):
+    """Re-encode every blob of ``src`` with an uncompressed ``raw`` payload. Bundled
+    extracts are all zlib, so this synthesises a file that exercises the engine's ``raw``
+    decompression branch."""
+    with open(src, "rb") as f, open(dst, "wb") as out:
+        while True:
+            head = f.read(4)
+            if len(head) < 4:
+                break
+            (n,) = unpack("!L", head)
+            bh = BlobHeader()
+            bh.ParseFromString(f.read(n))
+            blob = Blob()
+            blob.ParseFromString(f.read(bh.datasize))
+            raw = (
+                zlib.decompress(blob.zlib_data)
+                if blob.HasField("zlib_data")
+                else blob.raw
+            )
+            new_blob = Blob()
+            new_blob.raw = raw
+            blob_bytes = new_blob.SerializeToString()
+            bh.datasize = len(blob_bytes)
+            header_bytes = bh.SerializeToString()
+            out.write(pack("!L", len(header_bytes)))
+            out.write(header_bytes)
+            out.write(blob_bytes)
+
+
+def _in_memory_buildings(fp):
+    # Way and relation building rows from the in-memory reader (the out-of-core engine
+    # must reproduce both). osm_type makes the comparison key unambiguous since a way and
+    # a relation can share an id number.
+    gdf = OSM(fp).get_buildings()
+    return gdf.sort_values(["osm_type", "id"]).reset_index(drop=True)
+
+
+def _assert_matches(mine, ref):
+    a = mine.sort_values(["osm_type", "id"]).reset_index(drop=True)
+    b = ref.sort_values(["osm_type", "id"]).reset_index(drop=True)
+    # Same element kinds and ids.
+    np.testing.assert_array_equal(a["osm_type"].to_numpy(), b["osm_type"].to_numpy())
+    np.testing.assert_array_equal(a["id"].to_numpy(), b["id"].to_numpy())
+    # Same geometries, exact coordinates (order-canonical via normalize).
+    na = gpd.GeoSeries(shapely.normalize(a.geometry.values))
+    nb = gpd.GeoSeries(shapely.normalize(b.geometry.values))
+    assert na.geom_equals_exact(nb, tolerance=0).all()
+
+
+def _assert_full_parity(mine, ref):
+    import pandas as pd
+
+    a = mine.sort_values(["osm_type", "id"]).reset_index(drop=True)
+    b = ref.sort_values(["osm_type", "id"]).reset_index(drop=True)
+    assert set(a.columns) == set(b.columns), set(a.columns).symmetric_difference(
+        b.columns
+    )
+    a = a[b.columns]
+    na = gpd.GeoSeries(shapely.normalize(a.geometry.values))
+    nb = gpd.GeoSeries(shapely.normalize(b.geometry.values))
+    assert na.geom_equals_exact(nb, tolerance=0).all()
+    for col in b.columns:
+        if col == "geometry":
+            continue
+        pd.testing.assert_series_equal(
+            a[col], b[col], check_dtype=False, check_names=False
+        )
+
+
+@pytest.mark.parametrize("fixture", ["test_pbf", "helsinki_pbf"])
+def test_engine_buildings_match_in_memory(fixture, request):
+    fp = request.getfixturevalue(fixture)
+    mine = get_buildings(fp)
+    ref = _in_memory_buildings(fp)
+    assert mine is not None and len(mine) == len(ref) > 0
+    _assert_matches(mine, ref)
+
+
+@pytest.mark.parametrize("fixture", ["test_pbf", "helsinki_pbf"])
+def test_engine_buildings_full_column_parity(fixture, request):
+    # Every tag column, the JSON 'tags' column and the metadata columns must match
+    # OSM().get_buildings() column-for-column and value-for-value.
+    fp = request.getfixturevalue(fixture)
+    mine = get_buildings(fp)
+    ref = OSM(fp).get_buildings()
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_buildings_keep_metadata_false_parity(helsinki_pbf):
+    # keep_metadata=False must drop the element-metadata columns exactly as the in-memory
+    # reader does (whatever its handling) -- full column + value parity either way.
+    mine = get_buildings(helsinki_pbf, keep_metadata=False)
+    ref = OSM(helsinki_pbf, keep_metadata=False).get_buildings()
+    assert "changeset" not in mine.columns
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_building_relations_match(helsinki_pbf):
+    # The bundled Helsinki extract has building relations (multipolygons); they must
+    # match the in-memory reader's relation rows exactly.
+    mine = get_buildings(helsinki_pbf)
+    ref = OSM(helsinki_pbf).get_buildings()
+    n_rel = int((ref["osm_type"] == "relation").sum())
+    assert n_rel > 0
+    assert int((mine["osm_type"] == "relation").sum()) == n_rel
+    _assert_matches(
+        mine[mine["osm_type"] == "relation"], ref[ref["osm_type"] == "relation"]
+    )
+
+
+def test_engine_buildings_parallel_matches_single(helsinki_pbf):
+    # The multiprocessing path must produce the same result as the in-process path.
+    single = get_buildings(helsinki_pbf, workers=1)
+    parallel = get_buildings(helsinki_pbf, workers=3)
+    _assert_matches(parallel, single.sort_values("id").reset_index(drop=True))
+
+
+def test_engine_buildings_raw_blob_matches(helsinki_pbf, tmp_path):
+    # Uncompressed `raw` blobs must decode to the same result as the zlib originals.
+    raw_fp = str(tmp_path / "helsinki_raw.osm.pbf")
+    _rewrite_pbf_raw(helsinki_pbf, raw_fp)
+    zlib_buildings = get_buildings(helsinki_pbf)
+    raw_buildings = get_buildings(raw_fp)
+    _assert_matches(
+        raw_buildings, zlib_buildings.sort_values("id").reset_index(drop=True)
+    )
+
+
+def test_engine_buildings_output_parquet_matches(helsinki_pbf, tmp_path):
+    # The streamed GeoParquet must reload equal to the in-memory frame.
+    pytest.importorskip("pyarrow")
+    out = str(tmp_path / "buildings.parquet")
+    in_memory = get_buildings(helsinki_pbf)
+    returned = get_buildings(helsinki_pbf, output=out)
+    assert returned == out
+    reloaded = gpd.read_parquet(out)
+    assert isinstance(reloaded, gpd.GeoDataFrame)
+    assert reloaded.crs == in_memory.crs
+    _assert_matches(reloaded, in_memory.sort_values("id").reset_index(drop=True))
+
+
+def test_engine_buildings_output_is_chunked(helsinki_pbf, tmp_path, monkeypatch):
+    # Tiny chunks must stream multiple row groups AND still carry every column: a tag
+    # column that first occurs only in a later chunk must not be dropped from the output.
+    pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    in_memory = get_buildings(helsinki_pbf)
+    full_out = str(tmp_path / "buildings_full.parquet")
+    get_buildings(helsinki_pbf, output=full_out)
+    full_reload = gpd.read_parquet(full_out)
+
+    monkeypatch.setattr(geoparquet, "_OUTPUT_CHUNK_SIZE", 20)
+    chunked_out = str(tmp_path / "buildings_chunked.parquet")
+    get_buildings(helsinki_pbf, output=chunked_out)
+    assert pq.ParquetFile(chunked_out).metadata.num_row_groups > 1
+    chunked_reload = gpd.read_parquet(chunked_out)
+
+    # No column dropped: the chunked output carries exactly the in-memory reader's columns,
+    # and is identical value-for-value to the single-chunk output.
+    assert set(chunked_reload.columns) == set(in_memory.columns)
+    _assert_full_parity(chunked_reload, full_reload)
+
+
+def test_engine_output_requires_pyarrow(helsinki_pbf, tmp_path, monkeypatch):
+    # Without pyarrow, output= must fail fast with an actionable error (and not decode).
+    from pyrosm.utils import _compat
+
+    monkeypatch.setattr(_compat, "HAS_PYARROW", False)
+    with pytest.raises(ImportError, match="pyarrow"):
+        get_buildings(helsinki_pbf, output=str(tmp_path / "x.parquet"))
+
+
+def test_auto_workers_decides_on_file_size_not_blob_count(tmp_path):
+    # The default worker count is chosen by file size: parallelising only pays off above
+    # ~70 MB, and blob count must not force a pool for a small file (sparse files give a
+    # size without occupying disk).
+    import os
+
+    small = tmp_path / "small.osm.pbf"
+    small.touch()
+    os.truncate(small, pool._PARALLEL_MIN_FILE_BYTES - 1)
+    assert pool._auto_workers(str(small), 10_000) == 1
+
+    big = tmp_path / "big.osm.pbf"
+    big.touch()
+    os.truncate(big, pool._PARALLEL_MIN_FILE_BYTES + 1)
+    cpus = os.cpu_count() or 1
+    assert pool._auto_workers(str(big), 10_000) == cpus
+    assert pool._auto_workers(str(big), 2) == min(cpus, 2)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1255,3 +1255,20 @@ def test_get_data_dispatch_and_lazy_attrs(monkeypatch):
     assert callable(data.get_data_by_geocoding)
     with pytest.raises(AttributeError):
         data.this_attr_does_not_exist
+
+
+def test_engine_collect_relation_ways_handles_no_way_members(tmp_path):
+    """A building relation whose members are all non-way (node/relation) leaves the
+    way-member id set empty; the out-of-core way lookup must short-circuit to None
+    (relation dropped) instead of indexing the empty id array."""
+    import numpy as np
+    from pyrosm.engine.collect import _collect_relation_ways
+
+    shard = str(tmp_path / "shard_0.npz")
+    np.savez(
+        shard,
+        all_id=np.array([1, 2, 3], dtype=np.int64),
+        all_refs=np.array([10, 11, 12], dtype=np.int64),
+        all_refs_off=np.array([0, 1, 2, 3], dtype=np.int64),
+    )
+    assert _collect_relation_ways([shard], np.empty(0, np.int64)) is None


### PR DESCRIPTION
Adds `pyrosm/engine/`, an opt-in out-of-core PBF reading backend, with a buildings reader exposed as `pyrosm.engine.get_buildings`. The file is read in a single pass: data blobs are decoded in parallel with the raw Cython `primitive_block_decoder` (protobuf is used only for the small `BlobHeader` / `Blob` framing), each worker spills the node coordinates and the building features it finds to a per-worker shard on disk, and the main process then gathers only the coordinates the kept features reference and assembles the geometries. Peak memory is bounded by the working set rather than the whole file. The backend is not yet reachable from the `OSM` class; it is used directly through `pyrosm.engine.get_buildings`.

Modules:
- `blobs` — index a file's blobs and read/decompress a single `PrimitiveBlock`.
- `decode` — worker-side decode and per-shard spill of node coordinates, building ways and building relations.
- `pool` — worker-count policy (a single process below ~70 MB, otherwise a worker per CPU bounded by the blob count) and the `multiprocessing.Pool` orchestration.
- `collect` — read the spilled building ways, relations, their member ways and the referenced node coordinates back from the shards, pulling only what the kept features need.
- `assemble` — build the GeoDataFrame through pyrosm's own tag-explosion and geometry pipeline.
- `geoparquet` — the `output=` path: stream the buildings to a GeoParquet file, writing each chunk to its own temporary parquet and then combining them under one schema that is the union (by name) of every chunk's columns.
- `readers` — the public `get_buildings(filepath, workers=, output=, keep_metadata=)`.

Supporting changes:
- `pyrosm/_arrays.pyx`: a `way_records_to_arrays` cpdef wrapper exposing the way/relation record → column conversion to Python callers, so the backend produces the same columns as the in-memory reader.
- `pyrosm/utils/_compat.py`: a `HAS_PYARROW` flag and `require_pyarrow()` helper beside the existing optional-dependency flags; pyarrow is needed only for the `output=` GeoParquet path.

`get_buildings` reproduces the in-memory `OSM(...).get_buildings()` output column-for-column and value-for-value: building ways and relations, every occurring tag as its own column, the remaining tags in the JSON `tags` column, and the element metadata, with `keep_metadata` honoured.

How it is verified: `tests/test_engine.py` asserts parity against the in-memory reader on the bundled `test_pbf` and `helsinki_pbf` extracts (full column + value parity, building relations, `keep_metadata=False`), the parallel-vs-single-process paths, uncompressed `raw` blobs, the `output=` GeoParquet path (including a small chunk size that exercises a tag column first occurring in a later chunk, which must not be dropped), the `require_pyarrow()` guard, and the file-size worker-count policy. A regression test in `tests/test_regressions.py` covers a building relation whose members are all non-way.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
