### PR TITLE
Add out-of-core readers for all area/point layers

### DIFF
--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -265,6 +265,12 @@ cdef record_should_be_kept(tag, osm_keys, data_filter, filter_type, bint keep_al
     return True
 
 
+cpdef element_should_be_kept(tag, osm_keys, data_filter, filter_type):
+    """Python entry point to the per-element keep/exclude decision, so an alternative
+    reader can refine its key-presence candidates by the exact value filter pyrosm uses."""
+    return record_should_be_kept(tag, osm_keys, data_filter, filter_type)
+
+
 cdef filter_relation_indices(relations, osm_keys, data_filter, filter_type, bint keep_all=False):
     cdef int i, n = len(relations.get("tags", []))
     indices = []

--- a/pyrosm/data_manager.pyx
+++ b/pyrosm/data_manager.pyx
@@ -43,6 +43,13 @@ cdef get_data_filter_and_osm_keys(custom_filter):
                          f"Got {custom_filter} with type {type(custom_filter)}.")
 
 
+cpdef parse_custom_filter(custom_filter):
+    """Python entry point: normalise a ``custom_filter`` dict into ``(data_filter,
+    osm_keys)`` exactly as the in-memory reader does, so an alternative reader filters with
+    identical semantics."""
+    return get_data_filter_and_osm_keys(custom_filter)
+
+
 cdef get_relation_arrays(relations, osm_keys, data_filter, filter_type, bint keep_all=False):
     # Get indices for MultiPolygons that also passes data_filter
     indices = filter_relation_indices(relations, osm_keys, data_filter, filter_type, keep_all)

--- a/pyrosm/engine/__init__.py
+++ b/pyrosm/engine/__init__.py
@@ -11,6 +11,20 @@ The public ``get_*`` readers re-exported here mirror the in-memory reader's outp
 column-for-column.
 """
 
-from pyrosm.engine.readers import get_buildings
+from pyrosm.engine.readers import (
+    get_buildings,
+    get_landuse,
+    get_natural,
+    get_pois,
+    get_boundaries,
+    get_data_by_custom_criteria,
+)
 
-__all__ = ["get_buildings"]
+__all__ = [
+    "get_buildings",
+    "get_landuse",
+    "get_natural",
+    "get_pois",
+    "get_boundaries",
+    "get_data_by_custom_criteria",
+]

--- a/pyrosm/engine/assemble.py
+++ b/pyrosm/engine/assemble.py
@@ -1,27 +1,37 @@
-"""Assemble collected way/relation records into a GeoDataFrame through pyrosm's own tag
-and geometry pipeline, so the output matches the in-memory reader column-for-column."""
+"""Assemble collected node/way/relation records into a GeoDataFrame through pyrosm's own
+tag and geometry pipeline, so the output matches the in-memory reader column-for-column.
+"""
 
-from pyrosm.engine.collect import _ways_arrays, _collect_buildings
+from pyrosm.engine.collect import _ways_arrays, _collect_layer
 
 
 def _assemble_chunk(
-    node_coordinates, way_records, relations, relation_ways, keep_metadata
+    node_coordinates,
+    way_records,
+    relations,
+    relation_ways,
+    tags_as_columns,
+    keep_metadata,
+    nodes=None,
 ):
-    """Build one GeoDataFrame from way and/or relation elements using pyrosm's own tag +
-    geometry pipeline (full columns, missing-node handling, polygon/linestring typing,
-    ring assembly, dropna, orientation), so the result matches the in-memory reader
-    exactly."""
-    from pyrosm.config import Conf
+    """Build one GeoDataFrame from node, way and/or relation elements using pyrosm's own
+    tag + geometry pipeline (full columns, missing-node handling, polygon/linestring
+    typing, ring assembly, dropna, orientation), so the result matches the in-memory
+    reader exactly."""
     from pyrosm.frames import prepare_geodataframe
 
-    ways = _ways_arrays(way_records, keep_metadata) if way_records else None
+    ways = (
+        _ways_arrays(way_records, tags_as_columns, keep_metadata)
+        if way_records
+        else None
+    )
     gdf = prepare_geodataframe(
-        None,
+        nodes,
         node_coordinates,
         ways,
         relations,
         relation_ways,
-        list(Conf.tags.building),
+        list(tags_as_columns),
         None,
         keep_metadata=keep_metadata,
     )
@@ -30,12 +40,27 @@ def _assemble_chunk(
     return gdf
 
 
-def _assemble_buildings(shard_paths, keep_metadata):
-    """Assemble all building ways and relations into a single in-memory GeoDataFrame."""
-    collected = _collect_buildings(shard_paths)
+def _assemble_layer(
+    shard_paths, tags_as_columns, keep_metadata, filter_spec, keep_ways, keep_relations
+):
+    """Assemble all matching nodes, ways and relations into one in-memory GeoDataFrame."""
+    collected = _collect_layer(
+        shard_paths,
+        tags_as_columns,
+        keep_metadata,
+        filter_spec,
+        keep_ways,
+        keep_relations,
+    )
     if collected is None:
         return None
-    kept, relations, relation_ways, node_coordinates = collected
+    node_features, kept, relations, relation_ways, node_coordinates = collected
     return _assemble_chunk(
-        node_coordinates, kept, relations, relation_ways, keep_metadata
+        node_coordinates,
+        kept,
+        relations,
+        relation_ways,
+        tags_as_columns,
+        keep_metadata,
+        nodes=node_features,
     )

--- a/pyrosm/engine/collect.py
+++ b/pyrosm/engine/collect.py
@@ -1,26 +1,28 @@
 """Main-process collection.
 
-Read the spilled shards back into the building way and relation records, their member
-ways and the referenced node coordinates -- pulling only what the kept features need off
-disk, so peak memory stays bounded by the working set.
+Read the spilled shards back into the layer's node, way and relation records, their
+member ways and the referenced node coordinates -- pulling only what the kept features
+need off disk, and refining the worker's key-presence candidates by pyrosm's exact value
+filter so peak memory stays bounded by the working set.
 """
 
 import numpy as np
 
 from pyrosm._arrays import way_records_to_arrays
-from pyrosm.tagparser import explode_way_tags
+from pyrosm.tagparser import explode_way_tags, explode_node_tag_array
+from pyrosm.data_filter import element_should_be_kept
 from pyrosm.engine.decode import _object_array
 
 # Relation.MemberType -> the byte labels pyrosm's relation assembly expects.
 _MEMBER_TYPE = {0: b"node", 1: b"way", 2: b"relation"}
 # Only way members carry ring geometry. Member ids are matched against the way store, but
 # OSM ids are unique only per element type, so a node/relation member id can collide with a
-# building way id -- mixing types in the lookup would attach or drop the wrong way.
+# way id -- mixing types in the lookup would attach or drop the wrong way.
 _WAY_MEMBER = 1
 
 
-def _collect_building_ways(shard_paths):
-    """Read the spilled building ways back as pyrosm-shaped way records (``id``,
+def _collect_matching_ways(shard_paths):
+    """Read the spilled matching ways back as pyrosm-shaped way records (``id``,
     ``version``, ``timestamp``, ``visible``, ``nodes``, ``tags``)."""
     records = []
     for path in shard_paths:
@@ -44,12 +46,61 @@ def _collect_building_ways(shard_paths):
     return records
 
 
+def _collect_node_features(shard_paths, tags_as_columns, keep_metadata, keep):
+    """Read the spilled node features back, refine them by the exact value filter ``keep``
+    and explode their tags into the same columns the in-memory reader builds (``id`` /
+    ``lon`` / ``lat`` / ``visible`` + metadata when ``keep_metadata``, plus the layer tag
+    columns and a JSON ``tags`` column). ``None`` if no node passes."""
+    ids, lon, lat, tags, meta = [], [], [], [], []
+    for path in shard_paths:
+        z = np.load(path, allow_pickle=True)
+        nid = z["nfeat_id"]
+        if len(nid) == 0:
+            continue
+        ids.append(nid)
+        lon.append(z["nfeat_lon"])
+        lat.append(z["nfeat_lat"])
+        tags.append(z["nfeat_tags"])
+        meta.append(z["nfeat_meta"])
+    if not ids:
+        return None
+    tag_array = np.concatenate(tags)
+    mask = np.fromiter((keep(t) for t in tag_array), dtype=bool, count=len(tag_array))
+    if not mask.any():
+        return None
+    meta = np.concatenate(meta)[mask]
+    node_arrays = {
+        "id": np.concatenate(ids)[mask],
+        "lon": np.concatenate(lon)[mask],
+        "lat": np.concatenate(lat)[mask],
+        "tags": tag_array[mask],
+        "visible": meta[:, 3].astype(bool),
+    }
+    if keep_metadata:
+        node_arrays["version"] = meta[:, 0]
+        node_arrays["timestamp"] = meta[:, 1]
+        node_arrays["changeset"] = meta[:, 2]
+    # Mirror get_osm_nodes: merge the exploded tag columns in (the original 'tags' dict
+    # array stays only when no node had leftover tags, exactly as the in-memory reader).
+    node_arrays.update(
+        explode_node_tag_array(node_arrays["tags"], list(tags_as_columns))
+    )
+    return node_arrays
+
+
 def _node_lookup(shard_paths, needed):
     """Gather only the coordinates of ``needed`` node ids from the shards (bounded
     memory) and wrap them in a ``NodeLocations`` for geometry assembly."""
     import pandas as pd
 
     from pyrosm.node_lookup import NodeLocations
+
+    if len(needed) == 0:
+        # Node-only result (the filter matched no ways/relations): no coordinates needed.
+        empty = np.empty(0, np.int64)
+        return NodeLocations(
+            pd.DataFrame({"id": empty, "lon": np.empty(0), "lat": np.empty(0)})
+        )
 
     lon = np.full(len(needed), np.nan)
     lat = np.full(len(needed), np.nan)
@@ -69,11 +120,11 @@ def _node_lookup(shard_paths, needed):
     return NodeLocations(coords)
 
 
-def _collect_kept_ways(shard_paths, exclude_ids):
-    """The standalone building way records to output, after dropping the ones that are
-    members of a building relation (pyrosm assigns those to the relation, so they are not
-    standalone way rows)."""
-    records = _collect_building_ways(shard_paths)
+def _collect_kept_ways(shard_paths, exclude_ids, keep):
+    """The standalone way records to output: the spilled candidates refined by the exact
+    value filter ``keep``, then with the relation member ways dropped (pyrosm assigns those
+    to the relation, so they are not standalone way rows)."""
+    records = [r for r in _collect_matching_ways(shard_paths) if keep(r["tags"])]
     if not records:
         return None
     if len(exclude_ids):
@@ -84,27 +135,31 @@ def _collect_kept_ways(shard_paths, exclude_ids):
     return records
 
 
-def _load_building_relations(shard_paths):
-    """Reassemble the building relations spilled across shards into the ``relations``
-    struct pyrosm's assembly expects (``id`` / ``members`` / ``tags``), and return it
-    together with the unique set of all their member ids. ``(None, empty)`` if there are
-    no building relations."""
+def _collect_relations(shard_paths, keep):
+    """Reassemble the spilled relations into the ``relations`` struct pyrosm's assembly
+    expects (``id`` / ``members`` / ``tags`` / metadata), refined by the exact value filter
+    ``keep``, and return it with the unique set of their way-member ids. ``(None, empty)``
+    when no relation passes."""
     ids, members, tags, meta, way_member_ids = [], [], [], [], []
     for path in shard_paths:
         z = np.load(path, allow_pickle=True)
         rid = z["rel_id"]
         if len(rid) == 0:
             continue
-        memid, memoff, memtype, memrole, rtags = (
+        memid, memoff, memtype, memrole, rtags, rmeta = (
             z["rel_memid"],
             z["rel_memoff"],
             z["rel_memtype"],
             z["rel_memrole"],
             z["rel_tags"],
+            z["rel_meta"],
         )
         for k in range(len(rid)):
+            if not keep(rtags[k]):
+                continue
             s, e = memoff[k], memoff[k + 1]
             mids, mtypes = memid[s:e], memtype[s:e]
+            ids.append(int(rid[k]))
             members.append(
                 {
                     "member_id": mids,
@@ -116,13 +171,12 @@ def _load_building_relations(shard_paths):
             )
             way_member_ids.append(mids[mtypes == _WAY_MEMBER])
             tags.append(rtags[k])
-        ids.append(rid)
-        meta.append(z["rel_meta"])
+            meta.append(rmeta[k])
     if not ids:
         return None, np.empty(0, np.int64)
-    meta = np.concatenate(meta)
+    meta = np.array(meta, dtype=np.int64).reshape(-1, 3)
     relations = {
-        "id": np.concatenate(ids),
+        "id": np.array(ids, dtype=np.int64),
         "members": _object_array(members),
         "tags": _object_array(tags),
         "version": meta[:, 0],
@@ -138,10 +192,10 @@ def _load_building_relations(shard_paths):
 
 
 def _collect_relation_ways(shard_paths, member_ids):
-    """Look up the member ways (id -> node refs) of the building relations from the
-    spilled all-ways store. Returned as a ``{id, nodes}`` dict sorted by id ascending --
-    pyrosm aligns member roles to the sorted member ids, so the ways must match that
-    order. ``None`` if there are no way members, or none of them are present."""
+    """Look up the member ways (id -> node refs) of the kept relations from the spilled
+    all-ways store. Returned as a ``{id, nodes}`` dict sorted by id ascending -- pyrosm
+    aligns member roles to the sorted member ids, so the ways must match that order.
+    ``None`` if there are no way members, or none of them are present."""
     if len(member_ids) == 0:
         return None
     found = {}
@@ -161,17 +215,15 @@ def _collect_relation_ways(shard_paths, member_ids):
     return {"id": ids, "nodes": nodes}
 
 
-def _ways_arrays(records, keep_metadata):
+def _ways_arrays(records, tags_as_columns, keep_metadata):
     """Convert way records into the ``way_elements`` dict (all occurring tag columns + the
     JSON ``tags`` column + metadata) pyrosm's assembly expects, reusing pyrosm's own
     tag-explosion so the columns match the in-memory reader. Consumes (explodes) the
     records. The augmentation mirrors ``get_osm_ways_and_relations``."""
-    from pyrosm.config import Conf
-
-    tags_as_columns = list(Conf.tags.building) + ["id", "nodes"]
+    augmented = list(tags_as_columns) + ["id", "nodes"]
     if keep_metadata:
-        tags_as_columns += ["timestamp", "version"]
-    return way_records_to_arrays(explode_way_tags(records), tags_as_columns)
+        augmented += ["timestamp", "version"]
+    return way_records_to_arrays(explode_way_tags(records), augmented)
 
 
 def _needed_node_ids(kept, relation_ways):
@@ -187,21 +239,44 @@ def _needed_node_ids(kept, relation_ways):
     return np.unique(np.concatenate(refs))
 
 
-def _collect_buildings(shard_paths):
-    """Shared collection for both output modes: standalone building ways, building
-    relations, their member ways and the node coordinates all of them reference. ``None``
-    if there is nothing to assemble."""
-    relations, member_ids = _load_building_relations(shard_paths)
-    relation_ways = (
-        _collect_relation_ways(shard_paths, member_ids)
-        if relations is not None
-        else None
+def _collect_layer(
+    shard_paths,
+    tags_as_columns,
+    keep_metadata,
+    filter_spec,
+    keep_ways=True,
+    keep_relations=True,
+):
+    """Shared collection for both output modes: node features, standalone ways, relations,
+    their member ways and the node coordinates the ways/relations reference. ``filter_spec``
+    is ``(osm_keys, data_filter, filter_type)``; the spilled key-presence candidates are
+    refined here by pyrosm's exact value filter. ``keep_ways`` / ``keep_relations`` drop
+    those element kinds from the output (``get_data_by_custom_criteria``). ``None`` if there
+    is nothing to assemble."""
+    osm_keys, data_filter, filter_type = filter_spec
+
+    def keep(tag):
+        return element_should_be_kept(tag, osm_keys, data_filter, filter_type)
+
+    if keep_relations:
+        relations, member_ids = _collect_relations(shard_paths, keep)
+        relation_ways = (
+            _collect_relation_ways(shard_paths, member_ids)
+            if relations is not None
+            else None
+        )
+        # No member way present (all outside the data) -> the relation can't be assembled.
+        if relation_ways is None:
+            relations = None
+    else:
+        # Without relations there is no member-way set, so matching ways that would have
+        # been members stay as standalone ways (matching get_data_by_custom_criteria).
+        relations, relation_ways, member_ids = None, None, np.empty(0, np.int64)
+    kept = _collect_kept_ways(shard_paths, member_ids, keep) if keep_ways else None
+    node_features = _collect_node_features(
+        shard_paths, tags_as_columns, keep_metadata, keep
     )
-    # No member way is present (all outside the data) -> the relation cannot be assembled.
-    if relation_ways is None:
-        relations = None
-    kept = _collect_kept_ways(shard_paths, member_ids)
-    if kept is None and relations is None:
+    if kept is None and relations is None and node_features is None:
         return None
     node_coordinates = _node_lookup(shard_paths, _needed_node_ids(kept, relation_ways))
-    return kept, relations, relation_ways, node_coordinates
+    return node_features, kept, relations, relation_ways, node_coordinates

--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -1,8 +1,8 @@
 """Worker-side decode and spill.
 
 A worker decodes a contiguous run of blobs and writes one shard holding the node
-coordinates, the matching building ways (refs + resolved tags + metadata), *every* way
-(id + refs, for relation-member lookup) and the building relations.
+coordinates, the matching layer features (ways, point nodes and relations -- selected by
+filter-key presence) and *every* way (id + refs, for relation-member lookup).
 """
 
 import os
@@ -12,17 +12,27 @@ import numpy as np
 from pyrosm.primitive_block_decoder import decode_primitive_block
 from pyrosm.engine.blobs import _read_block
 
-_BUILDING = b"building"
-
 # Per-worker globals, set by the pool initializer (or directly for the in-process path).
+# ``_OSM_KEYS`` holds the layer's filter keys (utf-8 bytes) used to pre-select elements;
+# ``_INCLUDE_NODES`` is False for layers that emit no node features (buildings, boundary).
 _FILEPATH = None
 _SHARD_DIR = None
+_OSM_KEYS = None
+_INCLUDE_NODES = True
 
 
-def _init_worker(filepath, shard_dir):
-    global _FILEPATH, _SHARD_DIR
+def _init_worker(filepath, shard_dir, osm_keys, include_nodes):
+    global _FILEPATH, _SHARD_DIR, _OSM_KEYS, _INCLUDE_NODES
     _FILEPATH = filepath
     _SHARD_DIR = shard_dir
+    _OSM_KEYS = osm_keys
+    _INCLUDE_NODES = include_nodes
+
+
+def _key_indices(string_table, osm_keys):
+    """Positions of the filter keys in this block's string table (skipping keys this block
+    never uses), so element selection is a fast integer ``isin`` on the key indices."""
+    return [string_table.index(k) for k in osm_keys if k in string_table]
 
 
 def _resolve_tags(string_table, keys, vals, start, end):
@@ -36,20 +46,23 @@ def _resolve_tags(string_table, keys, vals, start, end):
     }
 
 
-def _building_ways(string_table, ways):
-    """Select the ways tagged ``building=*`` and return, per matching way, its node-ref
-    slice, full (resolved) tag dict and ``version``/``timestamp``/``visible`` metadata --
-    everything pyrosm's way record carries. Returns a dict of parallel arrays/lists, or
-    ``None``."""
-    if ways is None or _BUILDING not in string_table:
+def _matching_ways(string_table, ways, osm_keys):
+    """Select the ways carrying any of ``osm_keys`` and return, per matching way, its
+    node-ref slice, full (resolved) tag dict and ``version``/``timestamp``/``visible``
+    metadata -- everything pyrosm's way record carries. Returns a dict of parallel
+    arrays/lists, or ``None``."""
+    if ways is None:
         return None
-    building_idx = string_table.index(_BUILDING)
+    key_indices = _key_indices(string_table, osm_keys)
+    if not key_indices:
+        return None
     keys, vals, tags_off = ways["keys"], ways["vals"], ways["tags_off"]
-    key_positions = np.nonzero(keys == building_idx)[0]
+    key_positions = np.nonzero(np.isin(keys, key_indices))[0]
     if len(key_positions) == 0:
         return None
-    # A tag key belongs to the way whose [tags_off[i], tags_off[i+1]) slice contains it.
-    way_index = np.searchsorted(tags_off, key_positions, side="right") - 1
+    # A tag key belongs to the way whose [tags_off[i], tags_off[i+1]) slice contains it;
+    # a way may carry several filter keys, so de-duplicate.
+    way_index = np.unique(np.searchsorted(tags_off, key_positions, side="right") - 1)
     refs, refs_off = ways["refs"], ways["refs_off"]
     return {
         "id": ways["id"][way_index],
@@ -64,15 +77,74 @@ def _building_ways(string_table, ways):
     }
 
 
-def _building_relations(string_table, relations):
-    """The ``building=*`` relations in this block. Yields, per relation, its id, member
-    id/type/role arrays, full tag dict and ``version``/``timestamp``/``changeset``
-    metadata -- everything pyrosm needs to assemble the multipolygon and its columns.
-    Member roles and tags are resolved through the block's string table."""
-    if relations is None or _BUILDING not in string_table:
+def _matching_nodes(string_table, nodes, osm_keys, node_lon, node_lat):
+    """Dense nodes carrying any of ``osm_keys`` -> a dict of parallel arrays/lists
+    (``id`` / ``lon`` / ``lat`` / ``tags`` + ``version`` / ``timestamp`` / ``changeset`` /
+    ``visible`` metadata) for the matching nodes, or ``None``. Tags are parsed from the
+    block's dense ``keys_vals`` stream; untagged nodes (the vast majority) cost nothing.
+    """
+    if nodes is None:
+        return None
+    key_indices = set(_key_indices(string_table, osm_keys))
+    keys_vals = nodes["keys_vals"]
+    if not key_indices or len(keys_vals) == 0:
+        return None
+    ids = nodes["id"]
+    idx, tags = [], []
+    p, end = 0, len(keys_vals)
+    for node_i in range(len(ids)):
+        pairs = []
+        matched = False
+        while p < end and keys_vals[p] != 0:
+            k, v = keys_vals[p], keys_vals[p + 1]
+            p += 2
+            pairs.append((k, v))
+            if k in key_indices:
+                matched = True
+        p += 1  # skip the per-node 0 terminator
+        if matched:
+            idx.append(node_i)
+            tags.append(
+                {
+                    string_table[k]
+                    .decode("utf-8", "replace"): string_table[v]
+                    .decode("utf-8", "replace")
+                    for k, v in pairs
+                }
+            )
+    if not idx:
+        return None
+    idx = np.array(idx, dtype=np.int64)
+
+    # DenseInfo metadata is optional; when a field is absent the decoder returns an empty
+    # array, so default it like pyrosm's parse_dense (visible -> False, the rest -> 0).
+    def meta(name):
+        arr = nodes[name]
+        return arr[idx] if len(arr) == len(ids) else np.zeros(len(idx), dtype=np.int64)
+
+    return {
+        "id": ids[idx],
+        "lon": node_lon[idx],
+        "lat": node_lat[idx],
+        "tags": tags,
+        "version": meta("version"),
+        "timestamp": meta("timestamp"),
+        "changeset": meta("changeset"),
+        "visible": meta("visible"),
+    }
+
+
+def _layer_relations(string_table, relations, osm_keys):
+    """The relations carrying any of ``osm_keys`` in this block. Yields, per relation, its
+    id, member id/type/role arrays, full tag dict and ``version``/``timestamp``/
+    ``changeset`` metadata -- everything pyrosm needs to assemble the (multi)polygon and
+    its columns. Member roles and tags are resolved through the block's string table."""
+    if relations is None:
         return
-    building_idx = string_table.index(_BUILDING)
-    key_positions = np.nonzero(relations["keys"] == building_idx)[0]
+    key_indices = _key_indices(string_table, osm_keys)
+    if not key_indices:
+        return
+    key_positions = np.nonzero(np.isin(relations["keys"], key_indices))[0]
     if len(key_positions) == 0:
         return
     tags_off = relations["tags_off"]
@@ -125,13 +197,14 @@ def _object_array(items):
 
 def _decode_batch(task):
     """Worker: decode a contiguous run of blobs and spill one shard with the node
-    coordinates, the matching building ways (refs + resolved tags + metadata), *all* ways
-    (id + refs, for relation-member lookup) and the building relations, then return the
-    shard path."""
+    coordinates, the matching layer point nodes, the matching layer ways (refs + resolved
+    tags + metadata), *all* ways (id + refs, for relation-member lookup) and the matching
+    layer relations, then return the shard path."""
     worker_id, blobs = task
     node_id, node_lon, node_lat = [], [], []
-    bld_id, bld_refs, bld_tags = [], [], []
-    bld_version, bld_timestamp, bld_visible = [], [], []
+    nf = {k: [] for k in ("id", "lon", "lat", "tags", "meta")}
+    way_match_id, way_match_refs, way_match_tags = [], [], []
+    way_version, way_timestamp, way_visible = [], [], []
     all_id, all_refs, all_count = [], [], []
     rel = {k: [] for k in ("id", "memid", "memtype", "memrole", "tags", "meta")}
     with open(_FILEPATH, "rb") as f:
@@ -140,22 +213,45 @@ def _decode_batch(task):
             string_table, header, nodes, ways, relations = decode_primitive_block(data)
             if nodes is not None:
                 gran = header["granularity"]
+                lat = (nodes["lat"] * gran + header["lat_offset"]) / 1e9
+                lon = (nodes["lon"] * gran + header["lon_offset"]) / 1e9
                 node_id.append(nodes["id"])
-                node_lat.append((nodes["lat"] * gran + header["lat_offset"]) / 1e9)
-                node_lon.append((nodes["lon"] * gran + header["lon_offset"]) / 1e9)
+                node_lat.append(lat)
+                node_lon.append(lon)
+                found = (
+                    _matching_nodes(string_table, nodes, _OSM_KEYS, lon, lat)
+                    if _INCLUDE_NODES
+                    else None
+                )
+                if found is not None:
+                    nf["id"].append(found["id"])
+                    nf["lon"].append(found["lon"])
+                    nf["lat"].append(found["lat"])
+                    nf["tags"].extend(found["tags"])
+                    nf["meta"].append(
+                        np.stack(
+                            [
+                                found["version"],
+                                found["timestamp"],
+                                found["changeset"],
+                                found["visible"],
+                            ],
+                            axis=1,
+                        )
+                    )
             if ways is not None:
                 all_id.append(ways["id"])
                 all_refs.append(ways["refs"])
                 all_count.append(np.diff(ways["refs_off"]))
-                found = _building_ways(string_table, ways)
+                found = _matching_ways(string_table, ways, _OSM_KEYS)
                 if found is not None:
-                    bld_id.append(found["id"])
-                    bld_refs.extend(found["refs"])
-                    bld_tags.extend(found["tags"])
-                    bld_version.append(found["version"])
-                    bld_timestamp.append(found["timestamp"])
-                    bld_visible.append(found["visible"])
-            for r in _building_relations(string_table, relations):
+                    way_match_id.append(found["id"])
+                    way_match_refs.extend(found["refs"])
+                    way_match_tags.extend(found["tags"])
+                    way_version.append(found["version"])
+                    way_timestamp.append(found["timestamp"])
+                    way_visible.append(found["visible"])
+            for r in _layer_relations(string_table, relations, _OSM_KEYS):
                 rel["id"].append(r["id"])
                 rel["memid"].append(r["memid"])
                 rel["memtype"].append(r["memtype"])
@@ -169,18 +265,27 @@ def _decode_batch(task):
         node_id=np.concatenate(node_id) if node_id else np.empty(0, np.int64),
         node_lon=np.concatenate(node_lon) if node_lon else np.empty(0),
         node_lat=np.concatenate(node_lat) if node_lat else np.empty(0),
-        way_id=np.concatenate(bld_id) if bld_id else np.empty(0, np.int64),
-        refs=np.concatenate(bld_refs) if bld_refs else np.empty(0, np.int64),
-        refs_off=_offsets_from_lengths([len(r) for r in bld_refs]),
-        way_tags=_object_array(bld_tags),
+        nfeat_id=np.concatenate(nf["id"]) if nf["id"] else np.empty(0, np.int64),
+        nfeat_lon=np.concatenate(nf["lon"]) if nf["lon"] else np.empty(0),
+        nfeat_lat=np.concatenate(nf["lat"]) if nf["lat"] else np.empty(0),
+        nfeat_tags=_object_array(nf["tags"]),
+        nfeat_meta=(
+            np.concatenate(nf["meta"]) if nf["meta"] else np.empty((0, 4), np.int64)
+        ),
+        way_id=np.concatenate(way_match_id) if way_match_id else np.empty(0, np.int64),
+        refs=(
+            np.concatenate(way_match_refs) if way_match_refs else np.empty(0, np.int64)
+        ),
+        refs_off=_offsets_from_lengths([len(r) for r in way_match_refs]),
+        way_tags=_object_array(way_match_tags),
         way_version=(
-            np.concatenate(bld_version) if bld_version else np.empty(0, np.int64)
+            np.concatenate(way_version) if way_version else np.empty(0, np.int64)
         ),
         way_timestamp=(
-            np.concatenate(bld_timestamp) if bld_timestamp else np.empty(0, np.int64)
+            np.concatenate(way_timestamp) if way_timestamp else np.empty(0, np.int64)
         ),
         way_visible=(
-            np.concatenate(bld_visible) if bld_visible else np.empty(0, np.int64)
+            np.concatenate(way_visible) if way_visible else np.empty(0, np.int64)
         ),
         all_id=np.concatenate(all_id) if all_id else np.empty(0, np.int64),
         all_refs=np.concatenate(all_refs) if all_refs else np.empty(0, np.int64),

--- a/pyrosm/engine/geoparquet.py
+++ b/pyrosm/engine/geoparquet.py
@@ -1,17 +1,18 @@
 """Stream a layer to a GeoParquet file without materialising the whole output frame.
 
-Each chunk is assembled and written to its own temporary parquet file, so only one chunk
-is in memory at a time. Because pyrosm builds a tag column only when that tag occurs in a
-chunk, different chunks carry different columns; the temporary files are then combined
-under one schema that is the union (by name) of every chunk's columns, so a tag column
-that first appears in a later chunk is not dropped. Needs the optional pyarrow dependency.
+Each chunk (the point nodes, then ways in batches, then the relations) is assembled and
+written to its own temporary parquet file, so only one chunk is in memory at a time.
+Because pyrosm builds a tag column only when that tag occurs in a chunk, different chunks
+carry different columns; the temporary files are then combined under one schema that is the
+union (by name) of every chunk's columns, so a tag column that first appears in a later
+chunk is not dropped. Needs the optional pyarrow dependency.
 """
 
 import os
 import shutil
 import tempfile
 
-from pyrosm.engine.collect import _collect_buildings
+from pyrosm.engine.collect import _collect_layer
 from pyrosm.engine.assemble import _assemble_chunk
 
 # Assemble and write this many ways per chunk, so the output frame is never fully
@@ -49,40 +50,63 @@ def _unify_schemas(schemas):
     return unified
 
 
-def _stream_buildings_to_parquet(shard_paths, output, chunk_size, keep_metadata):
-    """Stream the buildings (ways in chunks, then relations) to a GeoParquet at ``output``,
-    spilling each chunk to its own temporary parquet file and then combining the files
-    under the union of their schemas. Returns the path, or ``None`` if there were no
-    buildings to write."""
+def _stream_layer_to_parquet(
+    shard_paths,
+    output,
+    chunk_size,
+    tags_as_columns,
+    keep_metadata,
+    filter_spec,
+    keep_ways,
+    keep_relations,
+):
+    """Stream the layer (point nodes, then ways in chunks, then relations) to a GeoParquet
+    at ``output``, spilling each chunk to its own temporary parquet file and then combining
+    the files under the union of their schemas. Returns the path, or ``None`` if there was
+    nothing to write."""
     import pyarrow.parquet as pq
     from geopandas.io.arrow import _geopandas_to_arrow
 
-    collected = _collect_buildings(shard_paths)
+    collected = _collect_layer(
+        shard_paths,
+        tags_as_columns,
+        keep_metadata,
+        filter_spec,
+        keep_ways,
+        keep_relations,
+    )
     if collected is None:
         return None
-    kept, relations, relation_ways, node_coordinates = collected
+    node_features, kept, relations, relation_ways, node_coordinates = collected
 
-    def to_table(gdf):
+    def to_table(way_records=None, relations=None, relation_ways=None, nodes=None):
+        gdf = _assemble_chunk(
+            node_coordinates,
+            way_records,
+            relations,
+            relation_ways,
+            tags_as_columns,
+            keep_metadata,
+            nodes=nodes,
+        )
+        if gdf is None or len(gdf) == 0:
+            return None
         return _geopandas_to_arrow(gdf, index=False, geometry_encoding="WKB")
 
     def chunk_tables():
+        if node_features is not None:
+            table = to_table(nodes=node_features)
+            if table is not None:
+                yield table
         if kept is not None:
             for start in range(0, len(kept), chunk_size):
-                gdf = _assemble_chunk(
-                    node_coordinates,
-                    kept[start : start + chunk_size],
-                    None,
-                    None,
-                    keep_metadata,
-                )
-                if gdf is not None and len(gdf) > 0:
-                    yield to_table(gdf)
+                table = to_table(way_records=kept[start : start + chunk_size])
+                if table is not None:
+                    yield table
         if relations is not None:
-            rgdf = _assemble_chunk(
-                node_coordinates, None, relations, relation_ways, keep_metadata
-            )
-            if rgdf is not None and len(rgdf) > 0:
-                yield to_table(rgdf)
+            table = to_table(relations=relations, relation_ways=relation_ways)
+            if table is not None:
+                yield table
 
     part_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_parquet_")
     try:

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -19,7 +19,7 @@ def _auto_workers(filepath, n_blobs):
     return max(1, min(os.cpu_count() or 1, n_blobs))
 
 
-def _decode_all(filepath, blobs, workers, shard_dir):
+def _decode_all(filepath, blobs, workers, shard_dir, osm_keys, include_nodes):
     """Decode every data blob into per-worker shards; return the shard paths."""
     n = len(blobs)
     per = (n + workers - 1) // workers
@@ -29,9 +29,11 @@ def _decode_all(filepath, blobs, workers, shard_dir):
         if blobs[i * per : (i + 1) * per]
     ]
     if workers == 1:
-        _init_worker(filepath, shard_dir)
+        _init_worker(filepath, shard_dir, osm_keys, include_nodes)
         return [_decode_batch(tasks[0])] if tasks else []
     with Pool(
-        workers, initializer=_init_worker, initargs=(filepath, shard_dir)
+        workers,
+        initializer=_init_worker,
+        initargs=(filepath, shard_dir, osm_keys, include_nodes),
     ) as pool:
         return pool.map(_decode_batch, tasks)

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -1,34 +1,49 @@
-"""Public out-of-core readers (one per layer). Each indexes the file's blobs, decodes
-them into per-worker shards, then collects and assembles (or streams to GeoParquet) the
-requested layer."""
+"""Public out-of-core readers (one per layer). Each indexes the file's blobs, decodes them
+into per-worker shards selecting the layer's elements (and, for point layers, the matching
+nodes), then collects and assembles (or streams to GeoParquet) the requested layer."""
 
 import tempfile
 import shutil
 
+from pyrosm.data_manager import parse_custom_filter
 from pyrosm.utils._compat import require_pyarrow
 from pyrosm.engine.blobs import _index_blobs
 from pyrosm.engine.pool import _auto_workers, _decode_all
-from pyrosm.engine.assemble import _assemble_buildings
+from pyrosm.engine.assemble import _assemble_layer
 from pyrosm.engine import geoparquet
 
 
-def get_buildings(filepath, workers=None, output=None, keep_metadata=True):
-    """Read building geometries from ``filepath`` with the out-of-core engine.
+def _get_layer(
+    filepath,
+    custom_filter,
+    filter_type,
+    tags_as_columns,
+    workers,
+    output,
+    keep_metadata,
+    include_nodes=True,
+    keep_ways=True,
+    keep_relations=True,
+    osm_keys=None,
+):
+    """Read a layer: decode the file in parallel selecting the elements that carry any of
+    the filter keys (``osm_keys`` if given, else ``custom_filter``'s keys; and, when
+    ``include_nodes``, the matching nodes as point features), refine them by the exact value
+    filter (``filter_type`` keep/exclude), then assemble with the full ``tags_as_columns``
+    schema (every occurring tag as its own column, the rest in a JSON ``tags`` column, and
+    -- when ``keep_metadata`` -- the element metadata), matching the in-memory reader.
+    ``keep_ways`` / ``keep_relations`` drop those element kinds from the output.
 
-    Returns the building ways and relations with the same columns as the in-memory reader:
-    every occurring ``Conf.tags.building`` tag as its own column, the remaining tags as a
-    JSON ``tags`` column, and -- when ``keep_metadata`` -- the ``version`` / ``timestamp``
-    / ``changeset`` / ``visible`` element metadata.
-
-    With ``output=None`` (the default) returns an in-memory GeoDataFrame. With ``output``
-    set to a path, the buildings are streamed to a GeoParquet file in chunks (never fully
-    materialised) and the path is returned; this needs the optional ``pyarrow`` dependency.
-
-    ``workers`` defaults to one for small files (no multiprocessing overhead) and
-    otherwise to a worker per CPU, bounded by the blob count.
-    """
+    Returns an in-memory GeoDataFrame, or -- when ``output`` is a path -- streams the layer
+    to a chunked GeoParquet there and returns the path (needs the optional ``pyarrow``).
+    ``workers`` defaults to one for small files and otherwise to a worker per CPU."""
     if output is not None:
         require_pyarrow()
+    data_filter, derived_keys = parse_custom_filter(custom_filter)
+    if osm_keys is None:
+        osm_keys = derived_keys
+    filter_spec = (osm_keys, data_filter, filter_type)
+    osm_key_bytes = [k.encode("utf-8") for k in osm_keys]
 
     data_blobs = [
         (offset, size)
@@ -40,11 +55,210 @@ def get_buildings(filepath, workers=None, output=None, keep_metadata=True):
 
     shard_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_")
     try:
-        shard_paths = _decode_all(filepath, data_blobs, workers, shard_dir)
+        shard_paths = _decode_all(
+            filepath, data_blobs, workers, shard_dir, osm_key_bytes, include_nodes
+        )
         if output is None:
-            return _assemble_buildings(shard_paths, keep_metadata)
-        return geoparquet._stream_buildings_to_parquet(
-            shard_paths, output, geoparquet._OUTPUT_CHUNK_SIZE, keep_metadata
+            return _assemble_layer(
+                shard_paths,
+                tags_as_columns,
+                keep_metadata,
+                filter_spec,
+                keep_ways,
+                keep_relations,
+            )
+        return geoparquet._stream_layer_to_parquet(
+            shard_paths,
+            output,
+            geoparquet._OUTPUT_CHUNK_SIZE,
+            tags_as_columns,
+            keep_metadata,
+            filter_spec,
+            keep_ways,
+            keep_relations,
         )
     finally:
         shutil.rmtree(shard_dir, ignore_errors=True)
+
+
+def get_buildings(filepath, workers=None, output=None, keep_metadata=True):
+    """Read building geometries (ways + relations) from ``filepath`` with the out-of-core
+    engine, with the same columns as ``OSM(...).get_buildings()``. See :func:`_get_layer`
+    for ``output`` / ``workers`` / ``keep_metadata``."""
+    from pyrosm.config import Conf
+
+    return _get_layer(
+        filepath,
+        {"building": [True]},
+        "keep",
+        Conf.tags.building,
+        workers,
+        output,
+        keep_metadata,
+        include_nodes=False,
+    )
+
+
+def get_landuse(filepath, workers=None, output=None, keep_metadata=True):
+    """Read landuse geometries (ways + relations) from ``filepath`` with the out-of-core
+    engine, with the same columns as ``OSM(...).get_landuse()``. See :func:`_get_layer` for
+    the keyword arguments."""
+    from pyrosm.config import Conf
+
+    return _get_layer(
+        filepath,
+        {"landuse": [True]},
+        "keep",
+        Conf.tags.landuse,
+        workers,
+        output,
+        keep_metadata,
+    )
+
+
+def get_natural(filepath, workers=None, output=None, keep_metadata=True):
+    """Read natural features (nodes + ways + relations) from ``filepath`` with the
+    out-of-core engine, with the same columns as ``OSM(...).get_natural()``. See
+    :func:`_get_layer` for the keyword arguments."""
+    from pyrosm.config import Conf
+
+    return _get_layer(
+        filepath,
+        {"natural": [True]},
+        "keep",
+        Conf.tags.natural,
+        workers,
+        output,
+        keep_metadata,
+    )
+
+
+def get_pois(
+    filepath, custom_filter=None, workers=None, output=None, keep_metadata=True
+):
+    """Read points of interest (nodes + ways + relations) from ``filepath`` with the
+    out-of-core engine, with the same columns as ``OSM(...).get_pois(custom_filter=...)``.
+    ``custom_filter`` defaults to ``{"amenity": True, "shop": True, "tourism": True}``. See
+    :func:`_get_layer` for the other keyword arguments."""
+    from pyrosm.config import Conf
+    from pyrosm.utils import validate_custom_filter
+
+    if custom_filter is None:
+        custom_filter = {"amenity": True, "shop": True, "tourism": True}
+    # Per-key tag columns, exactly as OSM.get_pois builds them (Conf.tags.<key>, or the
+    # basic tags for keys without a dedicated column set).
+    tags_as_columns = []
+    for k in custom_filter.keys():
+        tags_as_columns += getattr(Conf.tags, k, list(Conf.tags._basic_tags))
+    return _get_layer(
+        filepath,
+        validate_custom_filter(custom_filter),
+        "keep",
+        tags_as_columns,
+        workers,
+        output,
+        keep_metadata,
+    )
+
+
+def get_boundaries(
+    filepath,
+    boundary_type="administrative",
+    name=None,
+    custom_filter=None,
+    workers=None,
+    output=None,
+    keep_metadata=True,
+):
+    """Read boundaries (ways + relations) from ``filepath`` with the out-of-core engine,
+    with the same columns as ``OSM(...).get_boundaries()``. ``boundary_type`` selects the
+    ``boundary=*`` value (``"all"`` for any); ``name`` keeps only boundaries whose name
+    contains that text. See :func:`_get_layer` for the other keyword arguments."""
+    from pyrosm.config import Conf
+    from pyrosm.utils import validate_custom_filter, validate_boundary_type
+
+    boundary_type = validate_boundary_type(boundary_type)
+    if name is not None and output is not None:
+        raise ValueError(
+            "get_boundaries(name=...) cannot be combined with output= -- the streamed "
+            "GeoParquet is written before the name filter is applied. Omit output= to "
+            "filter by name, or omit name to stream all boundaries."
+        )
+    value = True if boundary_type == "all" else [boundary_type]
+    if custom_filter is None:
+        custom_filter = {"boundary": value}
+    if "boundary" not in custom_filter:
+        custom_filter["boundary"] = True
+    gdf = _get_layer(
+        filepath,
+        validate_custom_filter(custom_filter),
+        "keep",
+        list(Conf.tags.boundary),
+        workers,
+        output,
+        keep_metadata,
+        include_nodes=False,
+    )
+    # Name post-filter (substring match), as OSM.get_boundaries does. The output= + name
+    # combination is rejected above, so reaching here means an in-memory frame.
+    if name is not None and gdf is not None:
+        if "name" not in gdf.columns:
+            raise ValueError(
+                "Could not filter by name from given area. "
+                "Any of the OSM elements did not have a name tag."
+            )
+        gdf = gdf.dropna(subset=["name"])
+        gdf = gdf.loc[gdf["name"].str.contains(name)].reset_index(drop=True).copy()
+    return gdf
+
+
+def get_data_by_custom_criteria(
+    filepath,
+    custom_filter,
+    osm_keys_to_keep=None,
+    filter_type="keep",
+    tags_as_columns=None,
+    keep_nodes=True,
+    keep_ways=True,
+    keep_relations=True,
+    workers=None,
+    output=None,
+    keep_metadata=True,
+):
+    """Read OSM elements matching an arbitrary ``custom_filter`` from ``filepath`` with the
+    out-of-core engine, with the same columns as
+    ``OSM(...).get_data_by_custom_criteria(...)``. ``osm_keys_to_keep`` (if given) is the
+    set of keys filtered on; ``keep_nodes`` / ``keep_ways`` / ``keep_relations`` select
+    which element kinds are returned. See :func:`_get_layer` for the other keyword
+    arguments."""
+    from pyrosm.config import Conf
+    from pyrosm.utils import validate_custom_filter, validate_osm_keys
+
+    custom_filter = validate_custom_filter(custom_filter)
+    filter_type = filter_type.lower()
+    validate_osm_keys(osm_keys_to_keep)
+    if isinstance(osm_keys_to_keep, str):
+        osm_keys_to_keep = [osm_keys_to_keep]
+    if tags_as_columns is None:
+        tags_as_columns = []
+        for k in custom_filter.keys():
+            try:
+                tags_as_columns += getattr(Conf.tags, k)
+            except Exception:
+                pass
+        # Keys without a dedicated column set become columns themselves.
+        if len(tags_as_columns) == 0:
+            tags_as_columns = list(custom_filter.keys())
+    return _get_layer(
+        filepath,
+        custom_filter,
+        filter_type,
+        tags_as_columns,
+        workers,
+        output,
+        keep_metadata,
+        include_nodes=keep_nodes,
+        keep_ways=keep_ways,
+        keep_relations=keep_relations,
+        osm_keys=osm_keys_to_keep,
+    )

--- a/pyrosm/tagparser.pyx
+++ b/pyrosm/tagparser.pyx
@@ -90,3 +90,10 @@ cdef explode_tag_array(tag_array, tags_as_columns):
     if any_other:
         data["tags"] = other_list
     return data
+
+
+cpdef explode_node_tag_array(tag_array, tags_as_columns):
+    """Python entry point to the node tag-explosion (splits a tag-dict array into the
+    occurring ``tags_as_columns`` columns plus a JSON ``tags`` column), so an alternative
+    reader can build node features with the same columns as the in-memory reader."""
+    return explode_tag_array(tag_array, tags_as_columns)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,7 +10,14 @@ import pytest
 import shapely
 
 from pyrosm import OSM, get_data
-from pyrosm.engine import get_buildings
+from pyrosm.engine import (
+    get_buildings,
+    get_landuse,
+    get_natural,
+    get_pois,
+    get_boundaries,
+    get_data_by_custom_criteria,
+)
 from pyrosm.engine import pool, geoparquet
 from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
 
@@ -250,6 +257,11 @@ def _write_shard(path, **overrides):
         node_id=np.empty(0, np.int64),
         node_lon=np.empty(0),
         node_lat=np.empty(0),
+        nfeat_id=np.empty(0, np.int64),
+        nfeat_lon=np.empty(0),
+        nfeat_lat=np.empty(0),
+        nfeat_tags=np.empty(0, object),
+        nfeat_meta=np.empty((0, 4), np.int64),
         way_id=np.empty(0, np.int64),
         refs=np.empty(0, np.int64),
         refs_off=np.array([0], np.int64),
@@ -304,8 +316,8 @@ def test_engine_get_buildings_no_buildings_returns_none(tmp_path):
     assert get_buildings(fp, output=str(tmp_path / "x.parquet")) is None
 
 
-def test_engine_building_ways_early_returns():
-    from pyrosm.engine.decode import _building_ways
+def test_engine_matching_ways_early_returns():
+    from pyrosm.engine.decode import _matching_ways
 
     ways = {
         "id": np.array([7], np.int64),
@@ -318,28 +330,39 @@ def test_engine_building_ways_early_returns():
         "timestamp": np.array([1], np.int64),
         "visible": np.array([1], np.int64),
     }
-    assert _building_ways([b"highway"], None) is None  # ways is None guard
-    assert _building_ways([b"highway"], ways) is None  # 'building' not in string table
-    # 'building' is in the table but no way carries it as a key.
-    assert _building_ways([b"highway", b"building"], ways) is None
+    assert _matching_ways([b"highway"], None, [b"building"]) is None  # ways is None
+    assert _matching_ways([b"highway"], ways, [b"building"]) is None  # key not in table
+    # the key is in the table but no way carries it.
+    assert _matching_ways([b"highway", b"building"], ways, [b"building"]) is None
 
 
 def test_engine_collect_empty_and_edge_shards(tmp_path):
     from pyrosm.engine.collect import (
-        _collect_building_ways,
+        _collect_matching_ways,
         _collect_kept_ways,
+        _collect_node_features,
         _node_lookup,
         _collect_relation_ways,
         _needed_node_ids,
-        _collect_buildings,
+        _collect_layer,
     )
+    from pyrosm.data_manager import parse_custom_filter
+
+    def keep_all(tag):
+        return True
+
+    data_filter, osm_keys = parse_custom_filter({"building": [True]})
+    filter_spec = (osm_keys, data_filter, "keep")
 
     empty = str(tmp_path / "empty.npz")
     _write_shard(empty)
-    assert _collect_building_ways([empty]) == []
-    assert _collect_kept_ways([empty], np.empty(0, np.int64)) is None
+    assert _collect_matching_ways([empty]) == []
+    assert _collect_kept_ways([empty], np.empty(0, np.int64), keep_all) is None
+    assert _collect_node_features([empty], [], True, keep_all) is None
     assert _node_lookup([empty], np.array([1, 2], np.int64)) is not None
-    assert _collect_buildings([empty]) is None
+    # Node-only result: no coordinates needed -> empty NodeLocations, not a crash.
+    assert _node_lookup([empty], np.empty(0, np.int64)) is not None
+    assert _collect_layer([empty], [], True, filter_spec, True, True) is None
     assert len(_needed_node_ids(None, None)) == 0
 
     bld = str(tmp_path / "bld.npz")
@@ -353,8 +376,8 @@ def test_engine_collect_empty_and_edge_shards(tmp_path):
         way_timestamp=np.array([100], np.int64),
         way_visible=np.array([1], np.int64),
     )
-    # Excluding the only building way (it is a relation member) leaves nothing standalone.
-    assert _collect_kept_ways([bld], np.array([1], np.int64)) is None
+    # Excluding the only way (it is a relation member) leaves nothing standalone.
+    assert _collect_kept_ways([bld], np.array([1], np.int64), keep_all) is None
 
     ways_only = str(tmp_path / "ways.npz")
     _write_shard(
@@ -389,30 +412,44 @@ def test_engine_stream_parquet_chunk_table_branches(
     pytest.importorskip("pyarrow")
     import tempfile
     import shutil
+    from pyrosm.config import Conf
+    from pyrosm.data_manager import parse_custom_filter
     from pyrosm.engine import geoparquet
     from pyrosm.engine.blobs import _index_blobs
     from pyrosm.engine.pool import _decode_all
-    from pyrosm.engine.collect import _collect_buildings
+    from pyrosm.engine.collect import _collect_layer
 
+    data_filter, osm_keys = parse_custom_filter({"building": [True]})
+    filter_spec = (osm_keys, data_filter, "keep")
+    tac = Conf.tags.building
     data_blobs = [(o, s) for (t, o, s) in _index_blobs(helsinki_pbf) if t == "OSMData"]
     shard_dir = tempfile.mkdtemp()
     try:
-        shards = _decode_all(helsinki_pbf, data_blobs, 1, shard_dir)
-        kept, relations, relation_ways, nc = _collect_buildings(shards)
+        shards = _decode_all(
+            helsinki_pbf, data_blobs, 1, shard_dir, [b"building"], False
+        )
+        node_features, kept, relations, relation_ways, nc = _collect_layer(
+            shards, tac, True, filter_spec, True, True
+        )
         assert kept is not None and relations is not None  # helsinki has both
 
         def write(collected):
-            monkeypatch.setattr(
-                geoparquet, "_collect_buildings", lambda paths: collected
-            )
-            return geoparquet._stream_buildings_to_parquet(
-                shards, str(tmp_path / "o.parquet"), 250_000, True
+            monkeypatch.setattr(geoparquet, "_collect_layer", lambda *a, **k: collected)
+            return geoparquet._stream_layer_to_parquet(
+                shards,
+                str(tmp_path / "o.parquet"),
+                250_000,
+                tac,
+                True,
+                filter_spec,
+                True,
+                True,
             )
 
         # relations only (no standalone ways): way loop skipped, relation chunk written.
-        assert write((None, relations, relation_ways, nc)) is not None
+        assert write((None, None, relations, relation_ways, nc)) is not None
         # ways only (no relations): relation branch skipped.
-        assert write((kept, None, None, nc)) is not None
+        assert write((None, kept, None, None, nc)) is not None
         # a way referencing an absent node assembles empty -> no parts -> None.
         absent = [
             {
@@ -424,10 +461,10 @@ def test_engine_stream_parquet_chunk_table_branches(
                 "tags": {"building": "yes"},
             }
         ]
-        assert write((absent, None, None, nc)) is None
+        assert write((None, absent, None, None, nc)) is None
         # a relation whose member ways are all absent assembles empty -> chunk skipped.
         empty_ways = {"id": np.empty(0, np.int64), "nodes": np.empty(0, dtype=object)}
-        assert write((None, relations, empty_ways, nc)) is None
+        assert write((None, None, relations, empty_ways, nc)) is None
     finally:
         shutil.rmtree(shard_dir, ignore_errors=True)
 
@@ -456,3 +493,225 @@ def test_compat_has_pyarrow_false_when_unavailable(monkeypatch):
         monkeypatch.undo()
         importlib.reload(_compat)  # restore the real, pyarrow-present state
     assert _compat.HAS_PYARROW is True
+
+
+@pytest.fixture
+def helsinki_region_pbf():
+    return get_data("helsinki_region_pbf")
+
+
+@pytest.mark.parametrize("fixture", ["test_pbf", "helsinki_pbf"])
+def test_engine_landuse_full_column_parity(fixture, request):
+    # A different layer (different filter key and tag columns) must match
+    # OSM().get_landuse() column-for-column and value-for-value.
+    fp = request.getfixturevalue(fixture)
+    mine = get_landuse(fp)
+    ref = OSM(fp).get_landuse()
+    if ref is None:
+        assert mine is None
+        return
+    _assert_full_parity(mine, ref)
+
+
+@pytest.mark.parametrize("fixture", ["test_pbf", "helsinki_pbf"])
+def test_engine_natural_full_column_parity(fixture, request):
+    # natural includes NODE point features, so this exercises the node path too.
+    fp = request.getfixturevalue(fixture)
+    mine = get_natural(fp)
+    ref = OSM(fp).get_natural()
+    if ref is None:
+        assert mine is None
+        return
+    n_node = int((ref["osm_type"] == "node").sum())
+    assert int((mine["osm_type"] == "node").sum()) == n_node
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_natural_has_node_rows(helsinki_pbf):
+    # The bundled Helsinki extract has natural node features; assert they are produced.
+    mine = get_natural(helsinki_pbf)
+    assert int((mine["osm_type"] == "node").sum()) > 0
+
+
+@pytest.mark.parametrize("fixture", ["test_pbf", "helsinki_pbf"])
+def test_engine_pois_default_parity(fixture, request):
+    # The default POI filter over nodes + ways + relations.
+    fp = request.getfixturevalue(fixture)
+    mine = get_pois(fp)
+    ref = OSM(fp).get_pois()
+    if ref is None:
+        assert mine is None
+        return
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_pois_value_filter_parity(helsinki_pbf):
+    # A value-level custom_filter must refine to the exact values (not just key presence).
+    flt = {"amenity": ["restaurant", "cafe", "bar"]}
+    mine = get_pois(helsinki_pbf, custom_filter=flt)
+    ref = OSM(helsinki_pbf).get_pois(custom_filter=flt)
+    assert mine is not None and len(mine) > 0
+    assert mine["amenity"].isin(flt["amenity"]).all()
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_custom_criteria_value_filter_parity(helsinki_pbf):
+    flt = {"amenity": ["restaurant", "cafe", "pub"]}
+    mine = get_data_by_custom_criteria(helsinki_pbf, custom_filter=flt)
+    ref = OSM(helsinki_pbf).get_data_by_custom_criteria(custom_filter=flt)
+    assert mine is not None and len(mine) > 0
+    _assert_full_parity(mine, ref)
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        {"keep_nodes": False},
+        {"keep_ways": False},
+        {"keep_relations": False},
+        {"keep_nodes": False, "keep_relations": False},
+    ],
+)
+def test_engine_custom_criteria_keep_flags_parity(helsinki_pbf, flags):
+    # keep_nodes / keep_ways / keep_relations must select element kinds exactly as the
+    # in-memory reader.
+    flt = {"amenity": True}
+    mine = get_data_by_custom_criteria(helsinki_pbf, custom_filter=flt, **flags)
+    ref = OSM(helsinki_pbf).get_data_by_custom_criteria(custom_filter=flt, **flags)
+    if ref is None:
+        assert mine is None
+        return
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_boundaries_parity(helsinki_region_pbf):
+    # The Helsinki region extract has administrative boundaries (relations + ways).
+    mine = get_boundaries(helsinki_region_pbf)
+    ref = OSM(helsinki_region_pbf).get_boundaries()
+    assert ref is not None and (ref["osm_type"] == "relation").any()
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_natural_output_parquet_matches(helsinki_pbf, tmp_path):
+    # A point layer (nodes + ways) streamed to GeoParquet must reload equal to the frame.
+    pytest.importorskip("pyarrow")
+    out = str(tmp_path / "natural.parquet")
+    in_memory = get_natural(helsinki_pbf)
+    returned = get_natural(helsinki_pbf, output=out)
+    assert returned == out
+    reloaded = gpd.read_parquet(out)
+    _assert_matches(reloaded, in_memory)
+
+
+def test_engine_boundaries_name_filter_parity(helsinki_region_pbf):
+    # The name= substring post-filter must match OSM().get_boundaries(name=...).
+    mine = get_boundaries(helsinki_region_pbf, name="Vantaa")
+    ref = OSM(helsinki_region_pbf).get_boundaries(name="Vantaa")
+    assert mine is not None and len(mine) > 0
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_custom_criteria_osm_keys_and_explicit_columns(helsinki_pbf):
+    # osm_keys_to_keep as a string (-> list) and an explicit tags_as_columns.
+    kwargs = dict(
+        custom_filter={"building": True},
+        osm_keys_to_keep="building",
+        tags_as_columns=["building"],
+    )
+    mine = get_data_by_custom_criteria(helsinki_pbf, **kwargs)
+    ref = OSM(helsinki_pbf).get_data_by_custom_criteria(**kwargs)
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_custom_criteria_non_conf_key_parity(helsinki_pbf):
+    # A filter key without a dedicated Conf.tags column set becomes its own column.
+    flt = {"source": True}
+    mine = get_data_by_custom_criteria(helsinki_pbf, custom_filter=flt)
+    ref = OSM(helsinki_pbf).get_data_by_custom_criteria(custom_filter=flt)
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_node_feature_edge_cases(tmp_path):
+    from pyrosm.engine.decode import _matching_nodes
+    from pyrosm.engine.collect import _collect_node_features
+
+    # _matching_nodes returns None when there are no dense nodes in the block.
+    assert (
+        _matching_nodes([b"natural"], None, [b"natural"], np.empty(0), np.empty(0))
+        is None
+    )
+    # A node feature that fails the value filter is dropped (no node passes).
+    nfeat = str(tmp_path / "nfeat.npz")
+    _write_shard(
+        nfeat,
+        nfeat_id=np.array([1], np.int64),
+        nfeat_lon=np.array([24.9]),
+        nfeat_lat=np.array([60.1]),
+        nfeat_tags=np.array([{"natural": "tree"}], dtype=object),
+        nfeat_meta=np.zeros((1, 4), np.int64),
+    )
+    assert _collect_node_features([nfeat], ["natural"], True, lambda t: False) is None
+
+
+def test_engine_natural_keep_metadata_false_parity(helsinki_pbf):
+    # keep_metadata=False over a point layer (nodes + ways) must match the in-memory reader.
+    mine = get_natural(helsinki_pbf, keep_metadata=False)
+    ref = OSM(helsinki_pbf, keep_metadata=False).get_natural()
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_boundaries_custom_filter_adds_boundary_key(helsinki_region_pbf):
+    # A custom_filter without 'boundary' gets it added, matching OSM().get_boundaries().
+    flt = {"admin_level": True}
+    mine = get_boundaries(helsinki_region_pbf, custom_filter=dict(flt))
+    ref = OSM(helsinki_region_pbf).get_boundaries(custom_filter=dict(flt))
+    if ref is None or len(ref) == 0:
+        assert mine is None or len(mine) == 0
+        return
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_boundaries_name_without_name_column_raises(helsinki_pbf, monkeypatch):
+    # name= on a result that has no 'name' column raises, as the in-memory reader does.
+    from shapely.geometry import Point
+    from pyrosm.engine import readers
+
+    fake = gpd.GeoDataFrame({"id": [1]}, geometry=[Point(0, 0)])
+    monkeypatch.setattr(readers, "_get_layer", lambda *a, **k: fake)
+    with pytest.raises(ValueError, match="Could not filter by name"):
+        readers.get_boundaries(helsinki_pbf, name="x")
+
+
+def test_engine_boundaries_name_with_output_raises(helsinki_pbf, tmp_path):
+    # name= filtering cannot be combined with output= (the streamed GeoParquet would be
+    # written unfiltered); it must fail fast instead of silently writing all boundaries.
+    with pytest.raises(ValueError, match="cannot be combined with output"):
+        get_boundaries(helsinki_pbf, name="x", output=str(tmp_path / "b.parquet"))
+
+
+def test_engine_stream_skips_empty_node_chunk(tmp_path, monkeypatch):
+    # A node chunk that assembles to nothing is skipped (no row group); with only that
+    # chunk present, the writer produces no parts and returns None.
+    pytest.importorskip("pyarrow")
+    from pyrosm.config import Conf
+    from pyrosm.data_manager import parse_custom_filter
+    from pyrosm.engine import geoparquet
+
+    data_filter, osm_keys = parse_custom_filter({"natural": [True]})
+    filter_spec = (osm_keys, data_filter, "keep")
+    node_features = {
+        "id": np.array([1], np.int64)
+    }  # presence is enough; assemble stubbed
+    monkeypatch.setattr(geoparquet, "_assemble_chunk", lambda *a, **k: None)
+    monkeypatch.setattr(
+        geoparquet,
+        "_collect_layer",
+        lambda *a, **k: (node_features, None, None, None, None),
+    )
+    out = str(tmp_path / "x.parquet")
+    assert (
+        geoparquet._stream_layer_to_parquet(
+            [], out, 250_000, Conf.tags.natural, True, filter_spec, True, True
+        )
+        is None
+    )


### PR DESCRIPTION
Generalises the out-of-core engine (`pyrosm/engine/`) over the *layer*, so each layer is a `custom_filter` + `tags_as_columns` passed to one shared `_get_layer`. Adds the readers `get_landuse`, `get_natural`, `get_pois`, `get_boundaries` and `get_data_by_custom_criteria` alongside the existing `get_buildings`, all reproducing the in-memory `OSM(...).get_<layer>()` output column-for-column and value-for-value.

What it adds:
- **Layer-generic element selection**: workers pre-select the ways and relations carrying any of the layer's filter keys, and -- for layers that emit point features (natural, pois, custom criteria) -- the matching dense *nodes*, with their tags parsed from the block's `keys_vals` stream.
- **Value-level filtering**: the main process refines the worker's key-presence candidates by pyrosm's exact value filter, so a `custom_filter` like `{"amenity": ["restaurant"]}` matches the in-memory reader rather than keeping every `amenity`.
- **`get_data_by_custom_criteria`** with `osm_keys_to_keep`, `filter_type`, and `keep_nodes` / `keep_ways` / `keep_relations` to select element kinds; **`get_boundaries`** with `boundary_type` and the `name` substring post-filter.

Supporting cpdef wrappers (Python entry points to existing in-memory `cdef` helpers, so the engine filters and explodes tags with identical semantics):
- `data_filter.element_should_be_kept` -- the per-element keep/exclude decision.
- `data_manager.parse_custom_filter` -- normalise a `custom_filter` into `(data_filter, osm_keys)`.
- `tagparser.explode_node_tag_array` -- node tag-explosion into the same columns the in-memory reader builds.

The node, way and relation chunks all flow through the existing per-chunk-file GeoParquet writer for the `output=` path. `get_boundaries(name=..., output=...)` raises an explicit error (the streamed file is written before the name filter, so it cannot be name-filtered) rather than silently writing unfiltered data.

The engine remains opt-in and is not yet reachable from the `OSM` class; the readers are used directly through `pyrosm.engine`.

How it is verified: `tests/test_engine.py` asserts parity against the in-memory reader on the bundled `test_pbf` / `helsinki_pbf` extracts (and the `helsinki_region_pbf` extract for boundaries) for each layer -- full column + value parity, node point rows, value-level `custom_filter`, the `keep_nodes` / `keep_ways` / `keep_relations` flags, the boundaries `name` filter, and `keep_metadata=False` -- plus the internal element-selection, value-filter and GeoParquet-writer branches.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
