### PR TITLE
Add network reader and bounding_box to the out-of-core engine

### DIFF
--- a/pyrosm/engine/__init__.py
+++ b/pyrosm/engine/__init__.py
@@ -18,6 +18,7 @@ from pyrosm.engine.readers import (
     get_pois,
     get_boundaries,
     get_data_by_custom_criteria,
+    get_network,
 )
 
 __all__ = [
@@ -27,4 +28,5 @@ __all__ = [
     "get_pois",
     "get_boundaries",
     "get_data_by_custom_criteria",
+    "get_network",
 ]

--- a/pyrosm/engine/assemble.py
+++ b/pyrosm/engine/assemble.py
@@ -2,7 +2,17 @@
 tag and geometry pipeline, so the output matches the in-memory reader column-for-column.
 """
 
-from pyrosm.engine.collect import _ways_arrays, _collect_layer
+import numpy as np
+
+from pyrosm.data_filter import element_should_be_kept
+from pyrosm.engine.bounding_box import _in_box_nodes
+from pyrosm.engine.collect import (
+    _ways_arrays,
+    _collect_layer,
+    _collect_kept_ways,
+    _node_lookup,
+    _needed_node_ids,
+)
 
 
 def _assemble_chunk(
@@ -13,11 +23,13 @@ def _assemble_chunk(
     tags_as_columns,
     keep_metadata,
     nodes=None,
+    bounding_box=None,
+    complete_relations=False,
 ):
     """Build one GeoDataFrame from node, way and/or relation elements using pyrosm's own
     tag + geometry pipeline (full columns, missing-node handling, polygon/linestring
-    typing, ring assembly, dropna, orientation), so the result matches the in-memory
-    reader exactly."""
+    typing, ring assembly, dropna, orientation, the ``bounding_box`` spatial filter), so the
+    result matches the in-memory reader exactly."""
     from pyrosm.frames import prepare_geodataframe
 
     ways = (
@@ -32,8 +44,9 @@ def _assemble_chunk(
         relations,
         relation_ways,
         list(tags_as_columns),
-        None,
+        bounding_box,
         keep_metadata=keep_metadata,
+        complete_relations=complete_relations,
     )
     if gdf is not None and "nodes" in gdf.columns:
         gdf = gdf.drop(columns=["nodes"])
@@ -41,7 +54,14 @@ def _assemble_chunk(
 
 
 def _assemble_layer(
-    shard_paths, tags_as_columns, keep_metadata, filter_spec, keep_ways, keep_relations
+    shard_paths,
+    tags_as_columns,
+    keep_metadata,
+    filter_spec,
+    keep_ways=True,
+    keep_relations=True,
+    bounding_box=None,
+    complete_relations=False,
 ):
     """Assemble all matching nodes, ways and relations into one in-memory GeoDataFrame."""
     collected = _collect_layer(
@@ -51,6 +71,8 @@ def _assemble_layer(
         filter_spec,
         keep_ways,
         keep_relations,
+        bounding_box,
+        complete_relations,
     )
     if collected is None:
         return None
@@ -63,4 +85,48 @@ def _assemble_layer(
         tags_as_columns,
         keep_metadata,
         nodes=node_features,
+        bounding_box=bounding_box,
+        complete_relations=complete_relations,
     )
+
+
+def _assemble_network(
+    shard_paths, tags_as_columns, keep_metadata, filter_spec, segments, bounding_box
+):
+    """Assemble the matching highway ways as a network (LineString edges + a ``length``
+    column) through pyrosm's ``parse_network`` path. Returns ``(edges, nodes)``; ``nodes``
+    is the graph-export node frame, only built when ``segments`` is True
+    (``get_network(nodes=True)``). A ``None`` ``data_filter`` (network types ``all`` /
+    ``driving_psv``) keeps every highway way."""
+    from pyrosm.frames import prepare_geodataframe
+
+    osm_keys, data_filter, filter_type = filter_spec
+
+    def keep(tag):
+        return data_filter is None or element_should_be_kept(
+            tag, osm_keys, data_filter, filter_type
+        )
+
+    in_box = _in_box_nodes(shard_paths) if bounding_box is not None else None
+    kept = _collect_kept_ways(shard_paths, np.empty(0, np.int64), keep, in_box)
+    if kept is None:
+        return None, None
+    node_coordinates = _node_lookup(shard_paths, _needed_node_ids(kept, None))
+    ways = _ways_arrays(kept, tags_as_columns, keep_metadata)
+    edges, node_gdf = prepare_geodataframe(
+        None,
+        node_coordinates,
+        ways,
+        None,
+        None,
+        list(tags_as_columns),
+        bounding_box,
+        parse_network=True,
+        calculate_seg_lengths=segments,
+        keep_metadata=keep_metadata,
+    )
+    # The per-way 'nodes' list is dropped by default (it breaks file export), matching
+    # OSM.get_network with the default keep_node_info=False.
+    if edges is not None and "nodes" in edges.columns:
+        edges = edges.drop(columns=["nodes"])
+    return edges, node_gdf

--- a/pyrosm/engine/bounding_box.py
+++ b/pyrosm/engine/bounding_box.py
@@ -1,0 +1,78 @@
+"""Bounding-box helpers: validate/normalise a box, reduce it to its bounds, flag in-box
+coordinates, and read back the in-box node ids spilled per shard."""
+
+import numpy as np
+from shapely.geometry import (
+    Polygon,
+    MultiPolygon,
+    MultiLineString,
+    LineString,
+    LinearRing,
+)
+
+from pyrosm.utils import validate_bounding_box
+
+_ALLOWED_BBOX_TYPES = (Polygon, MultiPolygon, MultiLineString, LineString, LinearRing)
+
+
+def _normalize_bounding_box(bounding_box):
+    """Validate and normalise a bounding box exactly as ``OSM.__init__`` does, so the
+    out-of-core engine accepts the same inputs and raises the same errors: a Shapely
+    geometry is closed via ``validate_bounding_box``; a list must hold
+    ``[minx, miny, maxx, maxy]`` with minx < maxx and miny < maxy."""
+    if bounding_box is None:
+        return None
+    if type(bounding_box) in _ALLOWED_BBOX_TYPES:
+        return validate_bounding_box(bounding_box)
+    if isinstance(bounding_box, list):
+        if not len(bounding_box) == 4:
+            raise ValueError(
+                "When passing bounding box as a list it should contain 4 coordinates: "
+                "[minx, miny, maxx, maxy]."
+            )
+        minx, miny, maxx, maxy = bounding_box
+        if minx >= maxx or miny >= maxy:
+            raise ValueError(
+                "Invalid bounding box {bbox}: expected [minx, miny, maxx, maxy] with "
+                "minx < maxx and miny < maxy. Please double-check the order of the "
+                "coordinates (they may be swapped/inverted).".format(bbox=bounding_box)
+            )
+        return bounding_box
+    raise ValueError(
+        "bounding_box should be a list, Shapely Polygon or a Shapely LinearRing."
+    )
+
+
+def _bbox_bounds(bounding_box):
+    """The ``(xmin, ymin, xmax, ymax)`` rectangle of a bounding box (a list/tuple or a
+    shapely geometry), used to flag in-box nodes; ``None`` when no box is given."""
+    if bounding_box is None:
+        return None
+    if isinstance(bounding_box, (list, tuple)):
+        return tuple(bounding_box)
+    return tuple(bounding_box.bounds)
+
+
+def _in_box_mask(lon, lat, bounds):
+    """Boolean mask of the coordinates inside ``bounds`` (``xmin, ymin, xmax, ymax``)."""
+    xmin, ymin, xmax, ymax = bounds
+    return (lon >= xmin) & (lon <= xmax) & (lat >= ymin) & (lat <= ymax)
+
+
+def _filter_features_to_box(found, bounds):
+    """Keep only the node features whose coordinate is inside ``bounds``, or ``None``."""
+    mask = _in_box_mask(found["lon"], found["lat"], bounds)
+    if not mask.any():
+        return None
+    return {
+        k: ([t for t, m in zip(v, mask) if m] if k == "tags" else np.asarray(v)[mask])
+        for k, v in found.items()
+    }
+
+
+def _in_box_nodes(shard_paths):
+    """The unique ids of all nodes that fell inside the bounding box (spilled per shard).
+    A way is kept when at least one of its nodes is in this set (complete-ways semantics).
+    """
+    ids = [z for z in (np.load(p)["in_box_id"] for p in shard_paths) if len(z)]
+    return np.unique(np.concatenate(ids)) if ids else np.empty(0, np.int64)

--- a/pyrosm/engine/collect.py
+++ b/pyrosm/engine/collect.py
@@ -12,6 +12,7 @@ from pyrosm._arrays import way_records_to_arrays
 from pyrosm.tagparser import explode_way_tags, explode_node_tag_array
 from pyrosm.data_filter import element_should_be_kept
 from pyrosm.engine.decode import _object_array
+from pyrosm.engine.bounding_box import _in_box_nodes
 
 # Relation.MemberType -> the byte labels pyrosm's relation assembly expects.
 _MEMBER_TYPE = {0: b"node", 1: b"way", 2: b"relation"}
@@ -120,11 +121,16 @@ def _node_lookup(shard_paths, needed):
     return NodeLocations(coords)
 
 
-def _collect_kept_ways(shard_paths, exclude_ids, keep):
+def _collect_kept_ways(shard_paths, exclude_ids, keep, in_box=None):
     """The standalone way records to output: the spilled candidates refined by the exact
-    value filter ``keep``, then with the relation member ways dropped (pyrosm assigns those
-    to the relation, so they are not standalone way rows)."""
+    value filter ``keep``, then -- when reading a bounding box -- restricted to ways with at
+    least one node inside it (kept whole, so geometry is not cut at the edge), and finally
+    with the relation member ways dropped (pyrosm assigns those to the relation, so they are
+    not standalone way rows)."""
     records = [r for r in _collect_matching_ways(shard_paths) if keep(r["tags"])]
+    if in_box is not None:
+        inside = set(in_box.tolist())
+        records = [r for r in records if not inside.isdisjoint(r["nodes"])]
     if not records:
         return None
     if len(exclude_ids):
@@ -191,14 +197,18 @@ def _collect_relations(shard_paths, keep):
     return relations, member_ids
 
 
-def _collect_relation_ways(shard_paths, member_ids):
+def _collect_relation_ways(shard_paths, member_ids, in_box=None):
     """Look up the member ways (id -> node refs) of the kept relations from the spilled
     all-ways store. Returned as a ``{id, nodes}`` dict sorted by id ascending -- pyrosm
-    aligns member roles to the sorted member ids, so the ways must match that order.
-    ``None`` if there are no way members, or none of them are present."""
+    aligns member roles to the sorted member ids, so the ways must match that order. When
+    ``in_box`` is given (a bounding-box read without ``complete_relations``), only member
+    ways with a node in the box are kept, so the relation geometry is the in-box partial --
+    matching the in-memory reader. ``None`` if there are no way members, or none present.
+    """
     if len(member_ids) == 0:
         return None
     found = {}
+    inside = None if in_box is None else set(in_box.tolist())
     for path in shard_paths:
         z = np.load(path, allow_pickle=True)
         wid, off, refs = z["all_id"], z["all_refs_off"], z["all_refs"]
@@ -206,13 +216,39 @@ def _collect_relation_ways(shard_paths, member_ids):
             continue
         pos = np.clip(np.searchsorted(member_ids, wid), 0, len(member_ids) - 1)
         for k in np.nonzero(member_ids[pos] == wid)[0]:
-            found[int(wid[k])] = refs[off[k] : off[k + 1]]
+            way_refs = refs[off[k] : off[k + 1]]
+            if inside is None or not inside.isdisjoint(way_refs.tolist()):
+                found[int(wid[k])] = way_refs
     if not found:
         return None
     ids = np.array(sorted(found), dtype=np.int64)
     nodes = np.empty(len(ids), dtype=object)
     nodes[:] = [found[int(i)] for i in ids]
     return {"id": ids, "nodes": nodes}
+
+
+def _restrict_relations_to_box(relations, present_ids):
+    """Keep only the relations with at least one member way inside the box (``present_ids``)
+    -- out-of-box relations are dropped by the final spatial filter anyway, and excluding
+    them here keeps their tags from leaking as spurious all-None columns. Returns the
+    filtered struct and its way-member ids (``(None, empty)`` if none qualify)."""
+    mask = np.array(
+        [
+            not present_ids.isdisjoint(
+                m["member_id"][m["member_type"] == b"way"].tolist()
+            )
+            for m in relations["members"]
+        ],
+        dtype=bool,
+    )
+    if not mask.any():
+        return None, np.empty(0, np.int64)
+    kept = {k: v[mask] for k, v in relations.items()}
+    way_ids = [m["member_id"][m["member_type"] == b"way"] for m in kept["members"]]
+    member_ids = (
+        np.unique(np.concatenate(way_ids)) if way_ids else np.empty(0, np.int64)
+    )
+    return kept, member_ids
 
 
 def _ways_arrays(records, tags_as_columns, keep_metadata):
@@ -246,33 +282,48 @@ def _collect_layer(
     filter_spec,
     keep_ways=True,
     keep_relations=True,
+    bounding_box=None,
+    complete_relations=False,
 ):
     """Shared collection for both output modes: node features, standalone ways, relations,
     their member ways and the node coordinates the ways/relations reference. ``filter_spec``
     is ``(osm_keys, data_filter, filter_type)``; the spilled key-presence candidates are
     refined here by pyrosm's exact value filter. ``keep_ways`` / ``keep_relations`` drop
-    those element kinds from the output (``get_data_by_custom_criteria``). ``None`` if there
+    those element kinds from the output (``get_data_by_custom_criteria``). With a
+    ``bounding_box`` only in-box ways/nodes are kept; relation member ways are likewise
+    restricted to in-box (partial geometry) unless ``complete_relations``. ``None`` if there
     is nothing to assemble."""
     osm_keys, data_filter, filter_type = filter_spec
 
     def keep(tag):
         return element_should_be_kept(tag, osm_keys, data_filter, filter_type)
 
+    in_box = _in_box_nodes(shard_paths) if bounding_box is not None else None
     if keep_relations:
         relations, member_ids = _collect_relations(shard_paths, keep)
+        if relations is not None and in_box is not None:
+            # Restrict to relations with >=1 member way in the box (the rest are dropped by
+            # the final spatial filter anyway; excluding them here keeps their tags from
+            # creating spurious all-None columns and matches the in-memory completion scope).
+            present = _collect_relation_ways(shard_paths, member_ids, in_box)
+            present_ids = set() if present is None else set(present["id"].tolist())
+            relations, member_ids = _restrict_relations_to_box(relations, present_ids)
+        member_box = None if complete_relations else in_box
         relation_ways = (
-            _collect_relation_ways(shard_paths, member_ids)
+            _collect_relation_ways(shard_paths, member_ids, member_box)
             if relations is not None
             else None
         )
-        # No member way present (all outside the data) -> the relation can't be assembled.
+        # No member way present (all outside the data/box) -> the relation can't be built.
         if relation_ways is None:
             relations = None
     else:
         # Without relations there is no member-way set, so matching ways that would have
         # been members stay as standalone ways (matching get_data_by_custom_criteria).
         relations, relation_ways, member_ids = None, None, np.empty(0, np.int64)
-    kept = _collect_kept_ways(shard_paths, member_ids, keep) if keep_ways else None
+    kept = (
+        _collect_kept_ways(shard_paths, member_ids, keep, in_box) if keep_ways else None
+    )
     node_features = _collect_node_features(
         shard_paths, tags_as_columns, keep_metadata, keep
     )

--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -11,22 +11,26 @@ import numpy as np
 
 from pyrosm.primitive_block_decoder import decode_primitive_block
 from pyrosm.engine.blobs import _read_block
+from pyrosm.engine.bounding_box import _in_box_mask, _filter_features_to_box
 
 # Per-worker globals, set by the pool initializer (or directly for the in-process path).
 # ``_OSM_KEYS`` holds the layer's filter keys (utf-8 bytes) used to pre-select elements;
-# ``_INCLUDE_NODES`` is False for layers that emit no node features (buildings, boundary).
+# ``_INCLUDE_NODES`` is False for layers that emit no node features (buildings, boundary);
+# ``_BBOX_BOUNDS`` is ``(xmin, ymin, xmax, ymax)`` when reading a bounding box, else None.
 _FILEPATH = None
 _SHARD_DIR = None
 _OSM_KEYS = None
 _INCLUDE_NODES = True
+_BBOX_BOUNDS = None
 
 
-def _init_worker(filepath, shard_dir, osm_keys, include_nodes):
-    global _FILEPATH, _SHARD_DIR, _OSM_KEYS, _INCLUDE_NODES
+def _init_worker(filepath, shard_dir, osm_keys, include_nodes, bbox_bounds):
+    global _FILEPATH, _SHARD_DIR, _OSM_KEYS, _INCLUDE_NODES, _BBOX_BOUNDS
     _FILEPATH = filepath
     _SHARD_DIR = shard_dir
     _OSM_KEYS = osm_keys
     _INCLUDE_NODES = include_nodes
+    _BBOX_BOUNDS = bbox_bounds
 
 
 def _key_indices(string_table, osm_keys):
@@ -201,7 +205,7 @@ def _decode_batch(task):
     tags + metadata), *all* ways (id + refs, for relation-member lookup) and the matching
     layer relations, then return the shard path."""
     worker_id, blobs = task
-    node_id, node_lon, node_lat = [], [], []
+    node_id, node_lon, node_lat, in_box = [], [], [], []
     nf = {k: [] for k in ("id", "lon", "lat", "tags", "meta")}
     way_match_id, way_match_refs, way_match_tags = [], [], []
     way_version, way_timestamp, way_visible = [], [], []
@@ -218,11 +222,16 @@ def _decode_batch(task):
                 node_id.append(nodes["id"])
                 node_lat.append(lat)
                 node_lon.append(lon)
+                if _BBOX_BOUNDS is not None:
+                    in_box.append(nodes["id"][_in_box_mask(lon, lat, _BBOX_BOUNDS)])
                 found = (
                     _matching_nodes(string_table, nodes, _OSM_KEYS, lon, lat)
                     if _INCLUDE_NODES
                     else None
                 )
+                # A node feature is kept only if it falls inside the bounding box.
+                if found is not None and _BBOX_BOUNDS is not None:
+                    found = _filter_features_to_box(found, _BBOX_BOUNDS)
                 if found is not None:
                     nf["id"].append(found["id"])
                     nf["lon"].append(found["lon"])
@@ -265,6 +274,7 @@ def _decode_batch(task):
         node_id=np.concatenate(node_id) if node_id else np.empty(0, np.int64),
         node_lon=np.concatenate(node_lon) if node_lon else np.empty(0),
         node_lat=np.concatenate(node_lat) if node_lat else np.empty(0),
+        in_box_id=np.concatenate(in_box) if in_box else np.empty(0, np.int64),
         nfeat_id=np.concatenate(nf["id"]) if nf["id"] else np.empty(0, np.int64),
         nfeat_lon=np.concatenate(nf["lon"]) if nf["lon"] else np.empty(0),
         nfeat_lat=np.concatenate(nf["lat"]) if nf["lat"] else np.empty(0),

--- a/pyrosm/engine/geoparquet.py
+++ b/pyrosm/engine/geoparquet.py
@@ -59,6 +59,8 @@ def _stream_layer_to_parquet(
     filter_spec,
     keep_ways,
     keep_relations,
+    bounding_box=None,
+    complete_relations=False,
 ):
     """Stream the layer (point nodes, then ways in chunks, then relations) to a GeoParquet
     at ``output``, spilling each chunk to its own temporary parquet file and then combining
@@ -74,6 +76,8 @@ def _stream_layer_to_parquet(
         filter_spec,
         keep_ways,
         keep_relations,
+        bounding_box,
+        complete_relations,
     )
     if collected is None:
         return None
@@ -88,6 +92,8 @@ def _stream_layer_to_parquet(
             tags_as_columns,
             keep_metadata,
             nodes=nodes,
+            bounding_box=bounding_box,
+            complete_relations=complete_relations,
         )
         if gdf is None or len(gdf) == 0:
             return None

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -1,8 +1,11 @@
 """Worker-count policy and ``multiprocessing.Pool`` orchestration for decoding blobs."""
 
 import os
+import shutil
+import tempfile
 from multiprocessing import Pool
 
+from pyrosm.engine.blobs import _index_blobs
 from pyrosm.engine.decode import _init_worker, _decode_batch
 
 # Parallelising the decode only pays off above this file size; smaller files decode in a
@@ -19,7 +22,9 @@ def _auto_workers(filepath, n_blobs):
     return max(1, min(os.cpu_count() or 1, n_blobs))
 
 
-def _decode_all(filepath, blobs, workers, shard_dir, osm_keys, include_nodes):
+def _decode_all(
+    filepath, blobs, workers, shard_dir, osm_keys, include_nodes, bbox_bounds=None
+):
     """Decode every data blob into per-worker shards; return the shard paths."""
     n = len(blobs)
     per = (n + workers - 1) // workers
@@ -28,12 +33,37 @@ def _decode_all(filepath, blobs, workers, shard_dir, osm_keys, include_nodes):
         for i in range(workers)
         if blobs[i * per : (i + 1) * per]
     ]
+    init_args = (filepath, shard_dir, osm_keys, include_nodes, bbox_bounds)
     if workers == 1:
-        _init_worker(filepath, shard_dir, osm_keys, include_nodes)
+        _init_worker(*init_args)
         return [_decode_batch(tasks[0])] if tasks else []
-    with Pool(
-        workers,
-        initializer=_init_worker,
-        initargs=(filepath, shard_dir, osm_keys, include_nodes),
-    ) as pool:
+    with Pool(workers, initializer=_init_worker, initargs=init_args) as pool:
         return pool.map(_decode_batch, tasks)
+
+
+def _decode_and_run(
+    filepath, osm_key_bytes, include_nodes, workers, run, bbox_bounds=None
+):
+    """Index + parallel-decode ``filepath`` into a temp shard dir, call ``run(shard_paths)``
+    and clean up. The shared front half of every public read."""
+    data_blobs = [
+        (offset, size)
+        for (blob_type, offset, size) in _index_blobs(filepath)
+        if blob_type == "OSMData"
+    ]
+    if workers is None:
+        workers = _auto_workers(filepath, len(data_blobs))
+    shard_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_")
+    try:
+        shard_paths = _decode_all(
+            filepath,
+            data_blobs,
+            workers,
+            shard_dir,
+            osm_key_bytes,
+            include_nodes,
+            bbox_bounds,
+        )
+        return run(shard_paths)
+    finally:
+        shutil.rmtree(shard_dir, ignore_errors=True)

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -1,15 +1,13 @@
 """Public out-of-core readers (one per layer). Each indexes the file's blobs, decodes them
 into per-worker shards selecting the layer's elements (and, for point layers, the matching
-nodes), then collects and assembles (or streams to GeoParquet) the requested layer."""
-
-import tempfile
-import shutil
+nodes), then collects and assembles (or streams to GeoParquet) the requested layer. A
+``bounding_box`` restricts the read to that area."""
 
 from pyrosm.data_manager import parse_custom_filter
 from pyrosm.utils._compat import require_pyarrow
-from pyrosm.engine.blobs import _index_blobs
-from pyrosm.engine.pool import _auto_workers, _decode_all
-from pyrosm.engine.assemble import _assemble_layer
+from pyrosm.engine.pool import _decode_and_run
+from pyrosm.engine.bounding_box import _bbox_bounds, _normalize_bounding_box
+from pyrosm.engine.assemble import _assemble_layer, _assemble_network
 from pyrosm.engine import geoparquet
 
 
@@ -25,6 +23,8 @@ def _get_layer(
     keep_ways=True,
     keep_relations=True,
     osm_keys=None,
+    bounding_box=None,
+    complete_relations=False,
 ):
     """Read a layer: decode the file in parallel selecting the elements that carry any of
     the filter keys (``osm_keys`` if given, else ``custom_filter``'s keys; and, when
@@ -32,7 +32,9 @@ def _get_layer(
     filter (``filter_type`` keep/exclude), then assemble with the full ``tags_as_columns``
     schema (every occurring tag as its own column, the rest in a JSON ``tags`` column, and
     -- when ``keep_metadata`` -- the element metadata), matching the in-memory reader.
-    ``keep_ways`` / ``keep_relations`` drop those element kinds from the output.
+    ``keep_ways`` / ``keep_relations`` drop those element kinds from the output. A
+    ``bounding_box`` restricts the read to that area (relations are partial unless
+    ``complete_relations``).
 
     Returns an in-memory GeoDataFrame, or -- when ``output`` is a path -- streams the layer
     to a chunked GeoParquet there and returns the path (needs the optional ``pyarrow``).
@@ -44,20 +46,10 @@ def _get_layer(
         osm_keys = derived_keys
     filter_spec = (osm_keys, data_filter, filter_type)
     osm_key_bytes = [k.encode("utf-8") for k in osm_keys]
+    bounding_box = _normalize_bounding_box(bounding_box)
+    bounds = _bbox_bounds(bounding_box)
 
-    data_blobs = [
-        (offset, size)
-        for (blob_type, offset, size) in _index_blobs(filepath)
-        if blob_type == "OSMData"
-    ]
-    if workers is None:
-        workers = _auto_workers(filepath, len(data_blobs))
-
-    shard_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_")
-    try:
-        shard_paths = _decode_all(
-            filepath, data_blobs, workers, shard_dir, osm_key_bytes, include_nodes
-        )
+    def run(shard_paths):
         if output is None:
             return _assemble_layer(
                 shard_paths,
@@ -66,6 +58,8 @@ def _get_layer(
                 filter_spec,
                 keep_ways,
                 keep_relations,
+                bounding_box,
+                complete_relations,
             )
         return geoparquet._stream_layer_to_parquet(
             shard_paths,
@@ -76,15 +70,27 @@ def _get_layer(
             filter_spec,
             keep_ways,
             keep_relations,
+            bounding_box,
+            complete_relations,
         )
-    finally:
-        shutil.rmtree(shard_dir, ignore_errors=True)
+
+    return _decode_and_run(
+        filepath, osm_key_bytes, include_nodes, workers, run, bbox_bounds=bounds
+    )
 
 
-def get_buildings(filepath, workers=None, output=None, keep_metadata=True):
+def get_buildings(
+    filepath,
+    bounding_box=None,
+    complete_relations=False,
+    workers=None,
+    output=None,
+    keep_metadata=True,
+):
     """Read building geometries (ways + relations) from ``filepath`` with the out-of-core
     engine, with the same columns as ``OSM(...).get_buildings()``. See :func:`_get_layer`
-    for ``output`` / ``workers`` / ``keep_metadata``."""
+    for ``bounding_box`` / ``complete_relations`` / ``output`` / ``workers`` /
+    ``keep_metadata``."""
     from pyrosm.config import Conf
 
     return _get_layer(
@@ -96,10 +102,19 @@ def get_buildings(filepath, workers=None, output=None, keep_metadata=True):
         output,
         keep_metadata,
         include_nodes=False,
+        bounding_box=bounding_box,
+        complete_relations=complete_relations,
     )
 
 
-def get_landuse(filepath, workers=None, output=None, keep_metadata=True):
+def get_landuse(
+    filepath,
+    bounding_box=None,
+    complete_relations=False,
+    workers=None,
+    output=None,
+    keep_metadata=True,
+):
     """Read landuse geometries (ways + relations) from ``filepath`` with the out-of-core
     engine, with the same columns as ``OSM(...).get_landuse()``. See :func:`_get_layer` for
     the keyword arguments."""
@@ -113,10 +128,19 @@ def get_landuse(filepath, workers=None, output=None, keep_metadata=True):
         workers,
         output,
         keep_metadata,
+        bounding_box=bounding_box,
+        complete_relations=complete_relations,
     )
 
 
-def get_natural(filepath, workers=None, output=None, keep_metadata=True):
+def get_natural(
+    filepath,
+    bounding_box=None,
+    complete_relations=False,
+    workers=None,
+    output=None,
+    keep_metadata=True,
+):
     """Read natural features (nodes + ways + relations) from ``filepath`` with the
     out-of-core engine, with the same columns as ``OSM(...).get_natural()``. See
     :func:`_get_layer` for the keyword arguments."""
@@ -130,11 +154,19 @@ def get_natural(filepath, workers=None, output=None, keep_metadata=True):
         workers,
         output,
         keep_metadata,
+        bounding_box=bounding_box,
+        complete_relations=complete_relations,
     )
 
 
 def get_pois(
-    filepath, custom_filter=None, workers=None, output=None, keep_metadata=True
+    filepath,
+    custom_filter=None,
+    bounding_box=None,
+    complete_relations=False,
+    workers=None,
+    output=None,
+    keep_metadata=True,
 ):
     """Read points of interest (nodes + ways + relations) from ``filepath`` with the
     out-of-core engine, with the same columns as ``OSM(...).get_pois(custom_filter=...)``.
@@ -158,6 +190,8 @@ def get_pois(
         workers,
         output,
         keep_metadata,
+        bounding_box=bounding_box,
+        complete_relations=complete_relations,
     )
 
 
@@ -166,6 +200,8 @@ def get_boundaries(
     boundary_type="administrative",
     name=None,
     custom_filter=None,
+    bounding_box=None,
+    complete_relations=False,
     workers=None,
     output=None,
     keep_metadata=True,
@@ -198,6 +234,8 @@ def get_boundaries(
         output,
         keep_metadata,
         include_nodes=False,
+        bounding_box=bounding_box,
+        complete_relations=complete_relations,
     )
     # Name post-filter (substring match), as OSM.get_boundaries does. The output= + name
     # combination is rejected above, so reaching here means an in-memory frame.
@@ -221,6 +259,8 @@ def get_data_by_custom_criteria(
     keep_nodes=True,
     keep_ways=True,
     keep_relations=True,
+    bounding_box=None,
+    complete_relations=False,
     workers=None,
     output=None,
     keep_metadata=True,
@@ -261,4 +301,100 @@ def get_data_by_custom_criteria(
         keep_ways=keep_ways,
         keep_relations=keep_relations,
         osm_keys=osm_keys_to_keep,
+        bounding_box=bounding_box,
+        complete_relations=complete_relations,
+    )
+
+
+def _network_filter(network_type):
+    """Resolve a predefined ``network_type`` to its filter dict (or ``None`` for the
+    unrestricted ``all`` / ``driving_psv``), mirroring ``OSM._get_network_filter``."""
+    from pyrosm.config import Conf
+
+    possible = Conf._possible_network_filters
+    msg = "'network_type' should be one of: " + ", ".join(possible)
+    if not isinstance(network_type, str):
+        raise ValueError(msg)
+    network_type = network_type.lower()
+    if network_type not in possible:
+        raise ValueError(msg)
+    if network_type == "walking":
+        return Conf.network_filters.walking
+    if network_type == "driving":
+        return Conf.network_filters.driving
+    if network_type == "driving+service":
+        return Conf.network_filters.driving_psv
+    if network_type == "cycling":
+        return Conf.network_filters.cycling
+    return None  # "all" and "driving_psv" -> every highway
+
+
+def get_network(
+    filepath,
+    network_type="walking",
+    nodes=False,
+    custom_filter=None,
+    filter_type="exclude",
+    bounding_box=None,
+    workers=None,
+    keep_metadata=True,
+):
+    """Read a street network (``highway=*`` ways as LineString edges + a ``length`` column)
+    from ``filepath`` with the out-of-core engine, with the same columns as
+    ``OSM(...).get_network()``. ``network_type`` selects a predefined filter (``walking`` /
+    ``driving`` / ``cycling`` / ``all`` / ...); a ``custom_filter`` replaces it
+    (``filter_type`` keep/exclude). ``bounding_box`` (a ``[minx, miny, maxx, maxy]`` list or
+    a shapely polygon) restricts the read to that area.
+
+    ``nodes=True`` (the graph-export node frame) is not yet supported by this backend: the
+    coordinate store carries only id/lon/lat, so the node frame would lack the element
+    metadata the in-memory reader produces."""
+    from pyrosm.config import Conf
+    from pyrosm.utils import validate_custom_filter
+
+    if nodes:
+        raise NotImplementedError(
+            "get_network(nodes=True) (graph-export node frame) is not yet supported by "
+            "the out-of-core engine; only the edges are available."
+        )
+
+    tags_as_columns = list(Conf.tags.highway)
+    if custom_filter is not None:
+        custom_filter = validate_custom_filter(custom_filter)
+        filter_type = filter_type.lower()
+        if filter_type not in ("keep", "exclude"):
+            raise ValueError(
+                "'filter_type' -parameter should be either 'keep' or 'exclude'."
+            )
+        network_filter = custom_filter
+        # Expose the filter keys as columns too (e.g. 'bicycle', 'service').
+        for key in custom_filter.keys():
+            if key not in tags_as_columns:
+                tags_as_columns.append(key)
+    else:
+        network_filter = _network_filter(network_type)
+        # Predefined networks are always exclude filters keyed on 'highway'.
+        filter_type = "exclude"
+
+    data_filter = (
+        None if network_filter is None else parse_custom_filter(network_filter)[0]
+    )
+    # Networks always select highway ways (the filter values may reference other keys).
+    filter_spec = (["highway"], data_filter, filter_type)
+    bounding_box = _normalize_bounding_box(bounding_box)
+    bounds = _bbox_bounds(bounding_box)
+
+    def run(shard_paths):
+        edges, _ = _assemble_network(
+            shard_paths,
+            tags_as_columns,
+            keep_metadata,
+            filter_spec,
+            False,
+            bounding_box,
+        )
+        return edges
+
+    return _decode_and_run(
+        filepath, [b"highway"], False, workers, run, bbox_bounds=bounds
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -17,6 +17,7 @@ from pyrosm.engine import (
     get_pois,
     get_boundaries,
     get_data_by_custom_criteria,
+    get_network,
 )
 from pyrosm.engine import pool, geoparquet
 from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
@@ -257,6 +258,7 @@ def _write_shard(path, **overrides):
         node_id=np.empty(0, np.int64),
         node_lon=np.empty(0),
         node_lat=np.empty(0),
+        in_box_id=np.empty(0, np.int64),
         nfeat_id=np.empty(0, np.int64),
         nfeat_lon=np.empty(0),
         nfeat_lat=np.empty(0),
@@ -715,3 +717,263 @@ def test_engine_stream_skips_empty_node_chunk(tmp_path, monkeypatch):
         )
         is None
     )
+
+
+@pytest.mark.parametrize(
+    "network_type", ["walking", "driving", "driving+service", "cycling", "all"]
+)
+def test_engine_network_parity(network_type, helsinki_pbf):
+    # Street network: highway ways as LineString edges + a 'length' column. 'all' keeps
+    # every highway (a None data_filter); the others apply a predefined exclude filter.
+    mine = get_network(helsinki_pbf, network_type=network_type)
+    ref = OSM(helsinki_pbf).get_network(network_type=network_type)
+    assert ref is not None and len(ref) > 0
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_network_custom_filter_parity(helsinki_pbf):
+    # The 'crossing' key (not among the default highway columns) is added to the column
+    # allow-list; no kept way carries it here, so -- matching the in-memory reader -- it
+    # yields no column.
+    flt = {"highway": ["footway", "path", "pedestrian"], "crossing": True}
+    mine = get_network(helsinki_pbf, custom_filter=flt, filter_type="keep")
+    ref = OSM(helsinki_pbf).get_network(custom_filter=flt, filter_type="keep")
+    assert mine is not None and len(mine) > 0
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_network_nodes_true_not_supported(helsinki_pbf):
+    # The graph-export node frame is not available from the out-of-core engine yet.
+    with pytest.raises(NotImplementedError):
+        get_network(helsinki_pbf, nodes=True)
+
+
+def test_engine_network_invalid_args(helsinki_pbf):
+    with pytest.raises(ValueError):
+        get_network(helsinki_pbf, network_type="not-a-network")
+    with pytest.raises(ValueError):
+        get_network(helsinki_pbf, network_type=123)
+    with pytest.raises(ValueError):
+        get_network(helsinki_pbf, custom_filter={"highway": True}, filter_type="bogus")
+
+
+def _central_bbox(gdf, frac=0.4):
+    # The central `frac` of a layer's extent -- a box that still contains way and relation
+    # features, to exercise the bounding_box read path.
+    minx, miny, maxx, maxy = gdf.total_bounds
+    pad = (1 - frac) / 2
+    return [
+        minx + (maxx - minx) * pad,
+        miny + (maxy - miny) * pad,
+        minx + (maxx - minx) * (1 - pad),
+        miny + (maxy - miny) * (1 - pad),
+    ]
+
+
+@pytest.mark.parametrize("complete_relations", [False, True])
+def test_engine_buildings_bounding_box_parity(helsinki_pbf, complete_relations):
+    # A bounding box restricts buildings (ways + relations) to that area; relations are
+    # partial by default and complete with complete_relations=True -- matching the in-memory
+    # reader either way.
+    bbox = _central_bbox(OSM(helsinki_pbf).get_buildings())
+    mine = get_buildings(
+        helsinki_pbf, bounding_box=bbox, complete_relations=complete_relations
+    )
+    ref = OSM(
+        helsinki_pbf, bounding_box=bbox, complete_relations=complete_relations
+    ).get_buildings()
+    assert ref is not None and (ref["osm_type"] == "relation").any()
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_pois_bounding_box_parity(helsinki_pbf):
+    # bbox over a layer with node features: nodes + ways restricted to the box.
+    bbox = _central_bbox(OSM(helsinki_pbf).get_pois())
+    mine = get_pois(helsinki_pbf, bounding_box=bbox)
+    ref = OSM(helsinki_pbf, bounding_box=bbox).get_pois()
+    assert ref is not None and (ref["osm_type"] == "node").any()
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_network_bounding_box_parity(helsinki_pbf):
+    # A bounding box keeps ways with >=1 node inside it (kept whole), then the final spatial
+    # filter clips to the box -- matching the in-memory reader.
+    full = OSM(helsinki_pbf).get_network(network_type="driving")
+    bbox = _central_bbox(full, frac=0.5)
+    ref = OSM(helsinki_pbf, bounding_box=bbox).get_network(network_type="driving")
+    mine = get_network(helsinki_pbf, network_type="driving", bounding_box=bbox)
+    assert ref is not None and 0 < len(ref) < len(full)
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_custom_criteria_bounding_box_parity(helsinki_pbf):
+    flt = {"building": True}
+    bbox = _central_bbox(OSM(helsinki_pbf).get_buildings())
+    mine = get_data_by_custom_criteria(
+        helsinki_pbf, custom_filter=flt, filter_type="keep", bounding_box=bbox
+    )
+    ref = OSM(helsinki_pbf, bounding_box=bbox).get_data_by_custom_criteria(
+        custom_filter=flt, filter_type="keep"
+    )
+    assert mine is not None and len(mine) > 0
+    _assert_full_parity(mine, ref)
+
+
+def test_engine_bounding_box_polygon_parity(helsinki_pbf):
+    # A shapely-polygon bounding box is validated/normalised through the same path as the
+    # in-memory reader and yields the same result as the equivalent coordinate list.
+    from shapely.geometry import box
+
+    poly = box(*_central_bbox(OSM(helsinki_pbf).get_buildings()))
+    mine = get_buildings(helsinki_pbf, bounding_box=poly)
+    ref = OSM(helsinki_pbf, bounding_box=poly).get_buildings()
+    assert ref is not None and len(ref) > 0
+    _assert_full_parity(mine, ref)
+
+
+@pytest.mark.parametrize("bad", [[1, 2, 3], [25, 61, 24, 60], "not-a-bbox"])
+def test_engine_bounding_box_validation_matches_in_memory(helsinki_pbf, bad):
+    # Malformed boxes (wrong length, inverted coordinates, wrong type) raise the same
+    # ValueError the in-memory reader raises.
+    with pytest.raises(ValueError):
+        OSM(helsinki_pbf, bounding_box=bad)
+    with pytest.raises(ValueError):
+        get_buildings(helsinki_pbf, bounding_box=bad)
+
+
+def test_engine_bbox_helpers():
+    from shapely.geometry import box
+    from pyrosm.engine.bounding_box import (
+        _bbox_bounds,
+        _in_box_mask,
+        _filter_features_to_box,
+    )
+
+    assert _bbox_bounds(None) is None
+    assert _bbox_bounds([0, 1, 2, 3]) == (0, 1, 2, 3)
+    assert _bbox_bounds(box(0, 1, 2, 3)) == (0.0, 1.0, 2.0, 3.0)
+
+    mask = _in_box_mask(np.array([0.0, 5.0]), np.array([0.0, 5.0]), (-1, -1, 1, 1))
+    assert mask.tolist() == [True, False]
+
+    found = {
+        "id": np.array([1, 2], np.int64),
+        "lon": np.array([0.0, 5.0]),
+        "lat": np.array([0.0, 5.0]),
+        "tags": [{"a": "1"}, {"b": "2"}],
+    }
+    kept = _filter_features_to_box(found, (-1, -1, 1, 1))
+    assert kept["id"].tolist() == [1] and kept["tags"] == [{"a": "1"}]
+    assert _filter_features_to_box(found, (10, 10, 11, 11)) is None  # nothing inside
+
+
+def test_engine_in_box_nodes(tmp_path):
+    from pyrosm.engine.bounding_box import _in_box_nodes
+
+    empty = str(tmp_path / "e.npz")
+    _write_shard(empty)
+    assert len(_in_box_nodes([empty])) == 0  # no in-box ids anywhere
+    a = str(tmp_path / "a.npz")
+    _write_shard(a, in_box_id=np.array([3, 1, 3], np.int64))
+    b = str(tmp_path / "b.npz")
+    _write_shard(b, in_box_id=np.array([2], np.int64))
+    assert _in_box_nodes([a, b]).tolist() == [1, 2, 3]  # unique, sorted
+
+
+def test_engine_assemble_network_empty_returns_none(tmp_path):
+    from pyrosm.config import Conf
+    from pyrosm.engine.assemble import _assemble_network
+
+    empty = str(tmp_path / "e.npz")
+    _write_shard(empty)
+    # A None data_filter keeps every highway; with no ways at all the result is empty.
+    edges, nodes = _assemble_network(
+        [empty],
+        list(Conf.tags.highway),
+        True,
+        (["highway"], None, "exclude"),
+        False,
+        None,
+    )
+    assert edges is None and nodes is None
+
+
+def test_engine_assemble_network_edges_without_nodes_column(tmp_path):
+    from pyrosm.config import Conf
+    from pyrosm.engine.assemble import _assemble_network
+
+    shard = str(tmp_path / "s.npz")
+    _write_shard(
+        shard,
+        node_id=np.array([5], np.int64),
+        node_lon=np.array([24.9]),
+        node_lat=np.array([60.1]),
+        way_id=np.array([1], np.int64),
+        refs=np.array([5, 5], np.int64),
+        refs_off=np.array([0, 2], np.int64),
+        way_tags=np.array([{"highway": "footway"}], dtype=object),
+        way_version=np.array([1], np.int64),
+        way_timestamp=np.array([1], np.int64),
+        way_visible=np.array([1], np.int64),
+    )
+    # A degenerate way (both refs the same node) assembles edges that carry no 'nodes'
+    # column, so the default node-info drop is correctly skipped.
+    edges, _ = _assemble_network(
+        [shard],
+        list(Conf.tags.highway),
+        True,
+        (["highway"], None, "exclude"),
+        False,
+        None,
+    )
+    assert edges is not None and "nodes" not in edges.columns
+
+
+def test_engine_assemble_network_none_edges(tmp_path, monkeypatch):
+    from pyrosm import frames
+    from pyrosm.config import Conf
+    from pyrosm.engine import assemble
+
+    shard = str(tmp_path / "s.npz")
+    _write_shard(
+        shard,
+        node_id=np.array([5, 6], np.int64),
+        node_lon=np.array([24.90, 24.91]),
+        node_lat=np.array([60.10, 60.11]),
+        way_id=np.array([1], np.int64),
+        refs=np.array([5, 6], np.int64),
+        refs_off=np.array([0, 2], np.int64),
+        way_tags=np.array([{"highway": "footway"}], dtype=object),
+        way_version=np.array([1], np.int64),
+        way_timestamp=np.array([1], np.int64),
+        way_visible=np.array([1], np.int64),
+    )
+    # When the geometry pipeline yields no edges, the node-info drop is skipped.
+    monkeypatch.setattr(frames, "prepare_geodataframe", lambda *a, **k: (None, None))
+    edges, nodes = assemble._assemble_network(
+        [shard],
+        list(Conf.tags.highway),
+        True,
+        (["highway"], None, "exclude"),
+        False,
+        None,
+    )
+    assert edges is None and nodes is None
+
+
+def test_engine_collect_bbox_relation_branches(tmp_path):
+    from pyrosm.engine.collect import _collect_relation_ways, _restrict_relations_to_box
+
+    empty = str(tmp_path / "e.npz")
+    _write_shard(empty)
+    # No member ids at all -> nothing to look up.
+    assert _collect_relation_ways([empty], np.empty(0, np.int64)) is None
+    # A relation whose only member way is outside the box is dropped entirely.
+    relations = {
+        "id": np.array([1], np.int64),
+        "members": [
+            {"member_id": np.array([5], np.int64), "member_type": np.array([b"way"])}
+        ],
+    }
+    kept, ids = _restrict_relations_to_box(relations, set())
+    assert kept is None and len(ids) == 0


### PR DESCRIPTION
## Network

- `pyrosm.engine.get_network(filepath, network_type=..., custom_filter=..., filter_type=..., bounding_box=..., workers=, keep_metadata=)` builds street-network edges (highway ways as LineString geometries with a `length` column) through pyrosm's `parse_network` path.
- Supports the predefined `network_type` filters (`walking`, `driving`, `driving+service`, `cycling`, `all`) and a `custom_filter`; resolution mirrors `OSM._get_network_filter` (`all`/`driving_psv` keep every highway).
- `get_network(nodes=True)` raises `NotImplementedError`: the coordinate store carries only id/lon/lat, so the graph-export node frame is not produced by this backend.
- Adds `assemble._assemble_network`.

## Bounding box

- New `pyrosm/engine/bounding_box.py`: workers flag in-box node ids per shard; a way is kept whole when at least one of its nodes is inside the box, after which `prepare_geodataframe` applies the same exact spatial filter as the in-memory reader.
- `bounding_box` and `complete_relations` are threaded through every layer reader and the GeoParquet streaming path. Relations are partial by default and complete with `complete_relations=True`, matching the in-memory reader either way.
- `_normalize_bounding_box` validates and normalises the box exactly as `OSM.__init__` does — reusing `utils.validate_bounding_box` for shapely geometries and raising the same `ValueError`s for malformed lists/types.

## Verification

- Parity tests in `tests/test_engine.py` assert the engine reproduces `OSM(...).get_network()` and the per-layer `bounding_box` reads column-for-column and value-for-value (geometry equality at zero tolerance): `walking`/`driving`/`driving+service`/`cycling`/`all`/custom networks, bounding-box reads over buildings, POIs, network and custom-criteria, and `complete_relations` both ways. A polygon-bbox parity test and malformed-bbox tests confirm the box handling matches the in-memory reader.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
