### PR TITLE
Wire engine="out_of_core" into the public OSM API

### DIFF
--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -79,8 +79,39 @@ def _get_layer(
     )
 
 
+def _resolve_tags_as_columns(base_tags, extra_attributes, tags_to_keep):
+    """Build the tag-as-columns list the way the in-memory feature methods do: ``tags_to_keep``
+    replaces the layer default, ``extra_attributes`` appends (both validated)."""
+    from pyrosm.utils import validate_tags_as_columns
+
+    tags_as_columns = list(base_tags)
+    if tags_to_keep is not None:
+        validate_tags_as_columns(tags_to_keep)
+        tags_as_columns = list(tags_to_keep)
+    if extra_attributes is not None:
+        validate_tags_as_columns(extra_attributes)
+        tags_as_columns = tags_as_columns + list(extra_attributes)
+    return tags_as_columns
+
+
+def _ensure_layer_key(custom_filter, key):
+    """A ``None`` ``custom_filter`` becomes ``{key: [True]}``; otherwise the layer key is
+    ensured present -- mirroring the in-memory ``get_<layer>_data`` default merge."""
+    from pyrosm.utils import validate_custom_filter
+
+    if custom_filter is None:
+        return {key: [True]}
+    custom_filter = dict(validate_custom_filter(custom_filter))
+    if key not in custom_filter:
+        custom_filter[key] = [True]
+    return custom_filter
+
+
 def get_buildings(
     filepath,
+    custom_filter=None,
+    extra_attributes=None,
+    tags_to_keep=None,
     bounding_box=None,
     complete_relations=False,
     workers=None,
@@ -88,16 +119,17 @@ def get_buildings(
     keep_metadata=True,
 ):
     """Read building geometries (ways + relations) from ``filepath`` with the out-of-core
-    engine, with the same columns as ``OSM(...).get_buildings()``. See :func:`_get_layer`
-    for ``bounding_box`` / ``complete_relations`` / ``output`` / ``workers`` /
-    ``keep_metadata``."""
+    engine, with the same columns as ``OSM(...).get_buildings()``. ``custom_filter`` refines
+    which buildings to keep (the ``building`` key is always ensured); ``extra_attributes`` /
+    ``tags_to_keep`` adjust the tag columns. See :func:`_get_layer` for ``bounding_box`` /
+    ``complete_relations`` / ``output`` / ``workers`` / ``keep_metadata``."""
     from pyrosm.config import Conf
 
     return _get_layer(
         filepath,
-        {"building": [True]},
+        _ensure_layer_key(custom_filter, "building"),
         "keep",
-        Conf.tags.building,
+        _resolve_tags_as_columns(Conf.tags.building, extra_attributes, tags_to_keep),
         workers,
         output,
         keep_metadata,
@@ -109,6 +141,9 @@ def get_buildings(
 
 def get_landuse(
     filepath,
+    custom_filter=None,
+    extra_attributes=None,
+    tags_to_keep=None,
     bounding_box=None,
     complete_relations=False,
     workers=None,
@@ -116,15 +151,16 @@ def get_landuse(
     keep_metadata=True,
 ):
     """Read landuse geometries (ways + relations) from ``filepath`` with the out-of-core
-    engine, with the same columns as ``OSM(...).get_landuse()``. See :func:`_get_layer` for
-    the keyword arguments."""
+    engine, with the same columns as ``OSM(...).get_landuse()``. ``custom_filter`` refines
+    which landuse to keep (the ``landuse`` key is always ensured); ``extra_attributes`` /
+    ``tags_to_keep`` adjust the tag columns. See :func:`_get_layer` for the others."""
     from pyrosm.config import Conf
 
     return _get_layer(
         filepath,
-        {"landuse": [True]},
+        _ensure_layer_key(custom_filter, "landuse"),
         "keep",
-        Conf.tags.landuse,
+        _resolve_tags_as_columns(Conf.tags.landuse, extra_attributes, tags_to_keep),
         workers,
         output,
         keep_metadata,
@@ -135,6 +171,9 @@ def get_landuse(
 
 def get_natural(
     filepath,
+    custom_filter=None,
+    extra_attributes=None,
+    tags_to_keep=None,
     bounding_box=None,
     complete_relations=False,
     workers=None,
@@ -142,15 +181,17 @@ def get_natural(
     keep_metadata=True,
 ):
     """Read natural features (nodes + ways + relations) from ``filepath`` with the
-    out-of-core engine, with the same columns as ``OSM(...).get_natural()``. See
-    :func:`_get_layer` for the keyword arguments."""
+    out-of-core engine, with the same columns as ``OSM(...).get_natural()``. ``custom_filter``
+    refines which natural features to keep (the ``natural`` key is always ensured);
+    ``extra_attributes`` / ``tags_to_keep`` adjust the tag columns. See :func:`_get_layer` for
+    the others."""
     from pyrosm.config import Conf
 
     return _get_layer(
         filepath,
-        {"natural": [True]},
+        _ensure_layer_key(custom_filter, "natural"),
         "keep",
-        Conf.tags.natural,
+        _resolve_tags_as_columns(Conf.tags.natural, extra_attributes, tags_to_keep),
         workers,
         output,
         keep_metadata,
@@ -162,6 +203,8 @@ def get_natural(
 def get_pois(
     filepath,
     custom_filter=None,
+    extra_attributes=None,
+    tags_to_keep=None,
     bounding_box=None,
     complete_relations=False,
     workers=None,
@@ -170,8 +213,9 @@ def get_pois(
 ):
     """Read points of interest (nodes + ways + relations) from ``filepath`` with the
     out-of-core engine, with the same columns as ``OSM(...).get_pois(custom_filter=...)``.
-    ``custom_filter`` defaults to ``{"amenity": True, "shop": True, "tourism": True}``. See
-    :func:`_get_layer` for the other keyword arguments."""
+    ``custom_filter`` defaults to ``{"amenity": True, "shop": True, "tourism": True}``;
+    ``extra_attributes`` / ``tags_to_keep`` adjust the tag columns. See :func:`_get_layer` for
+    the other keyword arguments."""
     from pyrosm.config import Conf
     from pyrosm.utils import validate_custom_filter
 
@@ -179,14 +223,14 @@ def get_pois(
         custom_filter = {"amenity": True, "shop": True, "tourism": True}
     # Per-key tag columns, exactly as OSM.get_pois builds them (Conf.tags.<key>, or the
     # basic tags for keys without a dedicated column set).
-    tags_as_columns = []
+    base_tags = []
     for k in custom_filter.keys():
-        tags_as_columns += getattr(Conf.tags, k, list(Conf.tags._basic_tags))
+        base_tags += getattr(Conf.tags, k, list(Conf.tags._basic_tags))
     return _get_layer(
         filepath,
         validate_custom_filter(custom_filter),
         "keep",
-        tags_as_columns,
+        _resolve_tags_as_columns(base_tags, extra_attributes, tags_to_keep),
         workers,
         output,
         keep_metadata,
@@ -200,6 +244,8 @@ def get_boundaries(
     boundary_type="administrative",
     name=None,
     custom_filter=None,
+    extra_attributes=None,
+    tags_to_keep=None,
     bounding_box=None,
     complete_relations=False,
     workers=None,
@@ -209,7 +255,8 @@ def get_boundaries(
     """Read boundaries (ways + relations) from ``filepath`` with the out-of-core engine,
     with the same columns as ``OSM(...).get_boundaries()``. ``boundary_type`` selects the
     ``boundary=*`` value (``"all"`` for any); ``name`` keeps only boundaries whose name
-    contains that text. See :func:`_get_layer` for the other keyword arguments."""
+    contains that text; ``extra_attributes`` / ``tags_to_keep`` adjust the tag columns. See
+    :func:`_get_layer` for the other keyword arguments."""
     from pyrosm.config import Conf
     from pyrosm.utils import validate_custom_filter, validate_boundary_type
 
@@ -229,7 +276,7 @@ def get_boundaries(
         filepath,
         validate_custom_filter(custom_filter),
         "keep",
-        list(Conf.tags.boundary),
+        _resolve_tags_as_columns(Conf.tags.boundary, extra_attributes, tags_to_keep),
         workers,
         output,
         keep_metadata,
@@ -259,6 +306,7 @@ def get_data_by_custom_criteria(
     keep_nodes=True,
     keep_ways=True,
     keep_relations=True,
+    extra_attributes=None,
     bounding_box=None,
     complete_relations=False,
     workers=None,
@@ -269,10 +317,14 @@ def get_data_by_custom_criteria(
     out-of-core engine, with the same columns as
     ``OSM(...).get_data_by_custom_criteria(...)``. ``osm_keys_to_keep`` (if given) is the
     set of keys filtered on; ``keep_nodes`` / ``keep_ways`` / ``keep_relations`` select
-    which element kinds are returned. See :func:`_get_layer` for the other keyword
-    arguments."""
+    which element kinds are returned; ``extra_attributes`` adds further tag columns. See
+    :func:`_get_layer` for the other keyword arguments."""
     from pyrosm.config import Conf
-    from pyrosm.utils import validate_custom_filter, validate_osm_keys
+    from pyrosm.utils import (
+        validate_custom_filter,
+        validate_osm_keys,
+        validate_tags_as_columns,
+    )
 
     custom_filter = validate_custom_filter(custom_filter)
     filter_type = filter_type.lower()
@@ -289,6 +341,11 @@ def get_data_by_custom_criteria(
         # Keys without a dedicated column set become columns themselves.
         if len(tags_as_columns) == 0:
             tags_as_columns = list(custom_filter.keys())
+    else:
+        validate_tags_as_columns(tags_as_columns)
+    if extra_attributes is not None:
+        validate_tags_as_columns(extra_attributes)
+        tags_as_columns = list(tags_as_columns) + list(extra_attributes)
     return _get_layer(
         filepath,
         custom_filter,
@@ -332,9 +389,11 @@ def _network_filter(network_type):
 def get_network(
     filepath,
     network_type="walking",
+    extra_attributes=None,
     nodes=False,
     custom_filter=None,
     filter_type="exclude",
+    tags_to_keep=None,
     bounding_box=None,
     workers=None,
     keep_metadata=True,
@@ -343,14 +402,15 @@ def get_network(
     from ``filepath`` with the out-of-core engine, with the same columns as
     ``OSM(...).get_network()``. ``network_type`` selects a predefined filter (``walking`` /
     ``driving`` / ``cycling`` / ``all`` / ...); a ``custom_filter`` replaces it
-    (``filter_type`` keep/exclude). ``bounding_box`` (a ``[minx, miny, maxx, maxy]`` list or
-    a shapely polygon) restricts the read to that area.
+    (``filter_type`` keep/exclude). ``extra_attributes`` / ``tags_to_keep`` adjust the tag
+    columns. ``bounding_box`` (a ``[minx, miny, maxx, maxy]`` list or a shapely polygon)
+    restricts the read to that area.
 
     ``nodes=True`` (the graph-export node frame) is not yet supported by this backend: the
     coordinate store carries only id/lon/lat, so the node frame would lack the element
     metadata the in-memory reader produces."""
     from pyrosm.config import Conf
-    from pyrosm.utils import validate_custom_filter
+    from pyrosm.utils import validate_custom_filter, validate_tags_as_columns
 
     if nodes:
         raise NotImplementedError(
@@ -359,6 +419,9 @@ def get_network(
         )
 
     tags_as_columns = list(Conf.tags.highway)
+    if tags_to_keep is not None:
+        validate_tags_as_columns(tags_to_keep)
+        tags_as_columns = list(tags_to_keep)
     if custom_filter is not None:
         custom_filter = validate_custom_filter(custom_filter)
         filter_type = filter_type.lower()
@@ -375,6 +438,9 @@ def get_network(
         network_filter = _network_filter(network_type)
         # Predefined networks are always exclude filters keyed on 'highway'.
         filter_type = "exclude"
+    if extra_attributes is not None:
+        validate_tags_as_columns(extra_attributes)
+        tags_as_columns = tags_as_columns + list(extra_attributes)
 
     data_filter = (
         None if network_filter is None else parse_custom_filter(network_filter)[0]

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -80,7 +80,12 @@ class OSM:
     ]
 
     def __init__(
-        self, filepath, bounding_box=None, keep_metadata=True, complete_relations=False
+        self,
+        filepath,
+        bounding_box=None,
+        keep_metadata=True,
+        complete_relations=False,
+        engine="in_memory",
     ):
         # Check input file
         self.filepath = validate_input_file(filepath)
@@ -92,6 +97,10 @@ class OSM:
         if not isinstance(complete_relations, bool):
             raise ValueError("'complete_relations' should be a boolean.")
         self.complete_relations = complete_relations
+
+        if engine not in ("in_memory", "out_of_core"):
+            raise ValueError("'engine' should be either 'in_memory' or 'out_of_core'.")
+        self.engine = engine
 
         # Check if file contains history
         self._osh_file = False
@@ -146,6 +155,29 @@ class OSM:
         # Timestamp
         self._current_timestamp = None
         self._timestamp_changed = False
+
+    def _read_engine(self, reader, timestamp, with_relations=True, **kwargs):
+        """Route a feature read to the out-of-core engine reader of the given name, threading
+        the constructor-level ``bounding_box`` / ``keep_metadata`` (and ``complete_relations``
+        for the layer readers). History reads are not yet supported by this backend, so any
+        ``.osh.pbf`` file (which selects element versions implicitly even without a
+        ``timestamp``) or an explicit ``timestamp`` raises rather than silently returning all
+        historical versions."""
+        if self._osh_file or timestamp is not None:
+            raise NotImplementedError(
+                "Reading history files (.osh.pbf) or a specific 'timestamp' is not yet "
+                "supported by the out-of-core engine; use engine='in_memory' for history "
+                "reads."
+            )
+        # Import the package qualified so the 'engine' name does not shadow the constructor
+        # parameter of the same name.
+        from pyrosm import engine as engine_backend
+
+        kwargs["bounding_box"] = self.bounding_box
+        kwargs["keep_metadata"] = self.keep_metadata
+        if with_relations:
+            kwargs["complete_relations"] = self.complete_relations
+        return getattr(engine_backend, reader)(self.filepath, **kwargs)
 
     def _get_pbf_elements(self, bounding_box):
         (
@@ -314,6 +346,19 @@ class OSM:
         Take a look at the OSM documentation for further details about the data:
         `https://wiki.openstreetmap.org/wiki/Key:highway <https://wiki.openstreetmap.org/wiki/Key:highway>`__
         """
+        if self.engine == "out_of_core":
+            return self._read_engine(
+                "get_network",
+                timestamp,
+                with_relations=False,
+                network_type=network_type,
+                extra_attributes=extra_attributes,
+                nodes=nodes,
+                custom_filter=custom_filter,
+                filter_type=filter_type,
+                tags_to_keep=tags_to_keep,
+            )
+
         # Get filter (also validates network_type, which still drives the graph
         # semantics even when a custom_filter is provided)
         network_filter = self._get_network_filter(network_type)
@@ -428,6 +473,15 @@ class OSM:
         `https://wiki.openstreetmap.org/wiki/Key:building <https://wiki.openstreetmap.org/wiki/Key:building>`__
 
         """
+        if self.engine == "out_of_core":
+            return self._read_engine(
+                "get_buildings",
+                timestamp,
+                custom_filter=custom_filter,
+                extra_attributes=extra_attributes,
+                tags_to_keep=tags_to_keep,
+            )
+
         # Default tags to keep as columns
         tags_as_columns = list(self.conf.tags.building)
 
@@ -508,6 +562,15 @@ class OSM:
         `https://wiki.openstreetmap.org/wiki/Key:landuse <https://wiki.openstreetmap.org/wiki/Key:landuse>`__
 
         """
+
+        if self.engine == "out_of_core":
+            return self._read_engine(
+                "get_landuse",
+                timestamp,
+                custom_filter=custom_filter,
+                extra_attributes=extra_attributes,
+                tags_to_keep=tags_to_keep,
+            )
 
         self._read_pbf(timestamp)
 
@@ -590,6 +653,15 @@ class OSM:
         `https://wiki.openstreetmap.org/wiki/Key:natural <https://wiki.openstreetmap.org/wiki/Key:natural>`__
 
         """
+
+        if self.engine == "out_of_core":
+            return self._read_engine(
+                "get_natural",
+                timestamp,
+                custom_filter=custom_filter,
+                extra_attributes=extra_attributes,
+                tags_to_keep=tags_to_keep,
+            )
 
         self._read_pbf(timestamp)
 
@@ -686,6 +758,17 @@ class OSM:
         `https://wiki.openstreetmap.org/wiki/Key:boundary <https://wiki.openstreetmap.org/wiki/Key:boundary>`__
 
         """
+
+        if self.engine == "out_of_core":
+            return self._read_engine(
+                "get_boundaries",
+                timestamp,
+                boundary_type=boundary_type,
+                name=name,
+                custom_filter=custom_filter,
+                extra_attributes=extra_attributes,
+                tags_to_keep=tags_to_keep,
+            )
 
         self._read_pbf(timestamp)
 
@@ -805,6 +888,15 @@ class OSM:
         'tourism', 'viewpoint', 'wilderness_hut', 'zoo']
 
         """
+        if self.engine == "out_of_core":
+            return self._read_engine(
+                "get_pois",
+                timestamp,
+                custom_filter=custom_filter,
+                extra_attributes=extra_attributes,
+                tags_to_keep=tags_to_keep,
+            )
+
         # If custom_filter has not been defined, initialize with default
         if custom_filter is None:
             custom_filter = {"amenity": True, "shop": True, "tourism": True}
@@ -917,6 +1009,26 @@ class OSM:
             the time will represent midnight of the given day, such as "2021-01-01 00:00:00".
 
         """
+
+        if self.engine == "out_of_core":
+            if custom_filter is None:
+                raise NotImplementedError(
+                    "get_data_by_custom_criteria(custom_filter=None) ('return everything') "
+                    "is not yet supported by the out-of-core engine; pass an explicit "
+                    "custom_filter."
+                )
+            return self._read_engine(
+                "get_data_by_custom_criteria",
+                timestamp,
+                custom_filter=custom_filter,
+                osm_keys_to_keep=osm_keys_to_keep,
+                filter_type=filter_type,
+                tags_as_columns=tags_as_columns,
+                keep_nodes=keep_nodes,
+                keep_ways=keep_ways,
+                keep_relations=keep_relations,
+                extra_attributes=extra_attributes,
+            )
 
         # custom_filter=None means "return everything": keep every tagged element
         # with no key/value filtering (issue #113).

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -977,3 +977,127 @@ def test_engine_collect_bbox_relation_branches(tmp_path):
     }
     kept, ids = _restrict_relations_to_box(relations, set())
     assert kept is None and len(ids) == 0
+
+
+# ---------------------------------------------------------------------------
+# Public OSM API wired to the out-of-core engine (engine="out_of_core").
+# ---------------------------------------------------------------------------
+
+
+def _osm_parity(fp, method, **kwargs):
+    """The out-of-core engine, reached through the public OSM API, matches the in-memory
+    reader for the given feature method and keyword arguments. A fresh copy of the keyword
+    arguments is passed to each reader since the in-memory reader mutates the custom_filter
+    dict in place (it ensures the layer key), which would otherwise mask the engine's own
+    key-ensuring branch."""
+    import copy
+
+    ref = getattr(OSM(fp), method)(**copy.deepcopy(kwargs))
+    mine = getattr(OSM(fp, engine="out_of_core"), method)(**copy.deepcopy(kwargs))
+    if ref is None:
+        assert mine is None
+        return
+    _assert_full_parity(mine, ref)
+
+
+@pytest.mark.parametrize(
+    "method", ["get_buildings", "get_landuse", "get_natural", "get_pois"]
+)
+def test_osm_out_of_core_layer_parity(method, helsinki_pbf):
+    _osm_parity(helsinki_pbf, method)
+
+
+def test_osm_out_of_core_network_parity(helsinki_pbf):
+    _osm_parity(helsinki_pbf, "get_network", network_type="driving")
+
+
+def test_osm_out_of_core_boundaries_parity(helsinki_region_pbf):
+    _osm_parity(helsinki_region_pbf, "get_boundaries")
+    _osm_parity(helsinki_region_pbf, "get_boundaries", extra_attributes=["wikidata"])
+
+
+def test_osm_out_of_core_custom_criteria_parity(helsinki_pbf):
+    _osm_parity(
+        helsinki_pbf,
+        "get_data_by_custom_criteria",
+        custom_filter={"amenity": ["restaurant", "cafe"]},
+    )
+    # An explicit tags_as_columns (the validated branch) + extra_attributes + a string
+    # osm_keys_to_keep (the str-wrap branch).
+    _osm_parity(
+        helsinki_pbf,
+        "get_data_by_custom_criteria",
+        custom_filter={"amenity": ["restaurant"]},
+        tags_as_columns=["amenity", "name"],
+        extra_attributes=["cuisine"],
+        osm_keys_to_keep="amenity",
+    )
+
+
+def test_osm_out_of_core_custom_filter_parity(helsinki_pbf):
+    # custom_filter with the layer key present, and without it (the engine ensures the key).
+    _osm_parity(helsinki_pbf, "get_buildings", custom_filter={"building": ["retail"]})
+    _osm_parity(helsinki_pbf, "get_buildings", custom_filter={"amenity": ["school"]})
+    _osm_parity(helsinki_pbf, "get_landuse", custom_filter={"landuse": ["residential"]})
+    _osm_parity(
+        helsinki_pbf, "get_natural", custom_filter={"natural": ["wood", "water"]}
+    )
+
+
+def test_osm_out_of_core_extra_attributes_and_tags_to_keep_parity(helsinki_pbf):
+    _osm_parity(helsinki_pbf, "get_buildings", extra_attributes=["wikidata"])
+    _osm_parity(helsinki_pbf, "get_buildings", tags_to_keep=["building", "name"])
+    _osm_parity(
+        helsinki_pbf,
+        "get_pois",
+        custom_filter={"amenity": ["cafe"]},
+        extra_attributes=["operator"],
+    )
+    _osm_parity(
+        helsinki_pbf,
+        "get_network",
+        network_type="cycling",
+        extra_attributes=["maxspeed"],
+    )
+    _osm_parity(helsinki_pbf, "get_network", tags_to_keep=["highway", "name"])
+
+
+@pytest.mark.parametrize("complete_relations", [False, True])
+def test_osm_out_of_core_bbox_complete_relations_parity(
+    helsinki_pbf, complete_relations
+):
+    bbox = _central_bbox(OSM(helsinki_pbf).get_buildings())
+    ref = OSM(
+        helsinki_pbf, bounding_box=bbox, complete_relations=complete_relations
+    ).get_buildings()
+    mine = OSM(
+        helsinki_pbf,
+        bounding_box=bbox,
+        complete_relations=complete_relations,
+        engine="out_of_core",
+    ).get_buildings()
+    _assert_full_parity(mine, ref)
+
+
+def test_osm_engine_validation_and_unsupported_combos(helsinki_pbf):
+    with pytest.raises(ValueError):
+        OSM(helsinki_pbf, engine="bogus")
+    ooc = OSM(helsinki_pbf, engine="out_of_core")
+    with pytest.raises(NotImplementedError):
+        ooc.get_network(nodes=True)
+    with pytest.raises(NotImplementedError):
+        ooc.get_buildings(timestamp="2021-01-01 00:00:00")
+    with pytest.raises(NotImplementedError):
+        ooc.get_data_by_custom_criteria(custom_filter=None)
+
+
+def test_osm_out_of_core_history_file_not_supported(test_pbf, tmp_path):
+    # A .osh.pbf history file selects element versions implicitly even without a timestamp,
+    # which the out-of-core engine does not do, so it must raise rather than return every
+    # historical version. The filename (not the content) marks it as history.
+    import shutil
+
+    osh = str(tmp_path / "history.osh.pbf")
+    shutil.copy(test_pbf, osh)
+    with pytest.raises(NotImplementedError):
+        OSM(osh, engine="out_of_core").get_buildings()


### PR DESCRIPTION
## OSM API

- `OSM(filepath, ..., engine="in_memory" | "out_of_core")` (default `"in_memory"`) selects the reading backend. With `"out_of_core"`, each feature method (`get_buildings` / `get_landuse` / `get_natural` / `get_pois` / `get_boundaries` / `get_data_by_custom_criteria` / `get_network`) routes to the matching `pyrosm.engine` reader, threading the constructor-level `bounding_box` / `keep_metadata` / `complete_relations` and the per-call keyword arguments. An invalid `engine` value raises `ValueError`.
- Reads not supported by the out-of-core backend raise `NotImplementedError` rather than returning incorrect data: history files (`.osh.pbf`) and an explicit `timestamp`, `get_network(nodes=True)` (the graph-export node frame), and `get_data_by_custom_criteria(custom_filter=None)` ("return everything").

## Engine readers

- `pyrosm.engine.get_buildings` / `get_landuse` / `get_natural` gain a `custom_filter` argument (the layer key is always ensured, mirroring the in-memory `get_<layer>_data` merge).
- Every engine reader gains `extra_attributes` (appends tag columns) and `tags_to_keep` (replaces the default tag columns); `get_data_by_custom_criteria` gains `extra_attributes`. The tag-column rules match the in-memory feature methods.

## Verification

- Tests in `tests/test_engine.py` assert that `OSM(..., engine="out_of_core").get_<layer>(...)` reproduces `OSM(...).get_<layer>(...)` column-for-column and value-for-value (geometry equality at zero tolerance) across every layer, `custom_filter` (with and without the layer key), `extra_attributes`, `tags_to_keep`, the predefined and custom networks, and `bounding_box` + `complete_relations` set on the constructor. Further tests assert the `NotImplementedError` / `ValueError` cases above, including an `.osh.pbf` file read without a timestamp.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
