### PR TITLE
Spill each decoded block to its own shard

### DIFF
--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -1,6 +1,7 @@
 """Worker-side decode and spill.
 
-A worker decodes a contiguous run of blobs and writes one shard holding the node
+A worker decodes a contiguous run of blobs and spills each block to its own shard as it is
+decoded (so only one block's arrays are held in memory at a time). Each shard holds the node
 coordinates, the matching layer features (ways, point nodes and relations -- selected by
 filter-key presence) and *every* way (id + refs, for relation-member lookup).
 """
@@ -199,123 +200,134 @@ def _object_array(items):
     return arr
 
 
-def _decode_batch(task):
-    """Worker: decode a contiguous run of blobs and spill one shard with the node
-    coordinates, the matching layer point nodes, the matching layer ways (refs + resolved
-    tags + metadata), *all* ways (id + refs, for relation-member lookup) and the matching
-    layer relations, then return the shard path."""
-    worker_id, blobs = task
+def _decode_one_block(string_table, header, nodes, ways, relations):
+    """Decode one primitive block into the per-shard arrays: node coordinates, the matching
+    layer point nodes, the matching layer ways (refs + resolved tags + metadata), *all* ways
+    (id + refs, for relation-member lookup) and the matching layer relations. Returns a dict
+    of the npz arrays ``_write_shard`` spills (every key present, empty when absent)."""
     node_id, node_lon, node_lat, in_box = [], [], [], []
     nf = {k: [] for k in ("id", "lon", "lat", "tags", "meta")}
     way_match_id, way_match_refs, way_match_tags = [], [], []
     way_version, way_timestamp, way_visible = [], [], []
     all_id, all_refs, all_count = [], [], []
     rel = {k: [] for k in ("id", "memid", "memtype", "memrole", "tags", "meta")}
-    with open(_FILEPATH, "rb") as f:
-        for offset, size in blobs:
-            data = _read_block(f, offset, size)
-            string_table, header, nodes, ways, relations = decode_primitive_block(data)
-            if nodes is not None:
-                gran = header["granularity"]
-                lat = (nodes["lat"] * gran + header["lat_offset"]) / 1e9
-                lon = (nodes["lon"] * gran + header["lon_offset"]) / 1e9
-                node_id.append(nodes["id"])
-                node_lat.append(lat)
-                node_lon.append(lon)
-                if _BBOX_BOUNDS is not None:
-                    in_box.append(nodes["id"][_in_box_mask(lon, lat, _BBOX_BOUNDS)])
-                found = (
-                    _matching_nodes(string_table, nodes, _OSM_KEYS, lon, lat)
-                    if _INCLUDE_NODES
-                    else None
-                )
-                # A node feature is kept only if it falls inside the bounding box.
-                if found is not None and _BBOX_BOUNDS is not None:
-                    found = _filter_features_to_box(found, _BBOX_BOUNDS)
-                if found is not None:
-                    nf["id"].append(found["id"])
-                    nf["lon"].append(found["lon"])
-                    nf["lat"].append(found["lat"])
-                    nf["tags"].extend(found["tags"])
-                    nf["meta"].append(
-                        np.stack(
-                            [
-                                found["version"],
-                                found["timestamp"],
-                                found["changeset"],
-                                found["visible"],
-                            ],
-                            axis=1,
-                        )
-                    )
-            if ways is not None:
-                all_id.append(ways["id"])
-                all_refs.append(ways["refs"])
-                all_count.append(np.diff(ways["refs_off"]))
-                found = _matching_ways(string_table, ways, _OSM_KEYS)
-                if found is not None:
-                    way_match_id.append(found["id"])
-                    way_match_refs.extend(found["refs"])
-                    way_match_tags.extend(found["tags"])
-                    way_version.append(found["version"])
-                    way_timestamp.append(found["timestamp"])
-                    way_visible.append(found["visible"])
-            for r in _layer_relations(string_table, relations, _OSM_KEYS):
-                rel["id"].append(r["id"])
-                rel["memid"].append(r["memid"])
-                rel["memtype"].append(r["memtype"])
-                rel["memrole"].append(r["memrole"])
-                rel["tags"].append(r["tags"])
-                rel["meta"].append((r["version"], r["timestamp"], r["changeset"]))
 
-    path = os.path.join(_SHARD_DIR, "shard_%d.npz" % worker_id)
-    np.savez(
-        path,
-        node_id=np.concatenate(node_id) if node_id else np.empty(0, np.int64),
-        node_lon=np.concatenate(node_lon) if node_lon else np.empty(0),
-        node_lat=np.concatenate(node_lat) if node_lat else np.empty(0),
-        in_box_id=np.concatenate(in_box) if in_box else np.empty(0, np.int64),
-        nfeat_id=np.concatenate(nf["id"]) if nf["id"] else np.empty(0, np.int64),
-        nfeat_lon=np.concatenate(nf["lon"]) if nf["lon"] else np.empty(0),
-        nfeat_lat=np.concatenate(nf["lat"]) if nf["lat"] else np.empty(0),
-        nfeat_tags=_object_array(nf["tags"]),
-        nfeat_meta=(
+    if nodes is not None:
+        gran = header["granularity"]
+        lat = (nodes["lat"] * gran + header["lat_offset"]) / 1e9
+        lon = (nodes["lon"] * gran + header["lon_offset"]) / 1e9
+        node_id.append(nodes["id"])
+        node_lat.append(lat)
+        node_lon.append(lon)
+        if _BBOX_BOUNDS is not None:
+            in_box.append(nodes["id"][_in_box_mask(lon, lat, _BBOX_BOUNDS)])
+        found = (
+            _matching_nodes(string_table, nodes, _OSM_KEYS, lon, lat)
+            if _INCLUDE_NODES
+            else None
+        )
+        # A node feature is kept only if it falls inside the bounding box.
+        if found is not None and _BBOX_BOUNDS is not None:
+            found = _filter_features_to_box(found, _BBOX_BOUNDS)
+        if found is not None:
+            nf["id"].append(found["id"])
+            nf["lon"].append(found["lon"])
+            nf["lat"].append(found["lat"])
+            nf["tags"].extend(found["tags"])
+            nf["meta"].append(
+                np.stack(
+                    [
+                        found["version"],
+                        found["timestamp"],
+                        found["changeset"],
+                        found["visible"],
+                    ],
+                    axis=1,
+                )
+            )
+    if ways is not None:
+        all_id.append(ways["id"])
+        all_refs.append(ways["refs"])
+        all_count.append(np.diff(ways["refs_off"]))
+        found = _matching_ways(string_table, ways, _OSM_KEYS)
+        if found is not None:
+            way_match_id.append(found["id"])
+            way_match_refs.extend(found["refs"])
+            way_match_tags.extend(found["tags"])
+            way_version.append(found["version"])
+            way_timestamp.append(found["timestamp"])
+            way_visible.append(found["visible"])
+    for r in _layer_relations(string_table, relations, _OSM_KEYS):
+        rel["id"].append(r["id"])
+        rel["memid"].append(r["memid"])
+        rel["memtype"].append(r["memtype"])
+        rel["memrole"].append(r["memrole"])
+        rel["tags"].append(r["tags"])
+        rel["meta"].append((r["version"], r["timestamp"], r["changeset"]))
+
+    return {
+        "node_id": np.concatenate(node_id) if node_id else np.empty(0, np.int64),
+        "node_lon": np.concatenate(node_lon) if node_lon else np.empty(0),
+        "node_lat": np.concatenate(node_lat) if node_lat else np.empty(0),
+        "in_box_id": np.concatenate(in_box) if in_box else np.empty(0, np.int64),
+        "nfeat_id": np.concatenate(nf["id"]) if nf["id"] else np.empty(0, np.int64),
+        "nfeat_lon": np.concatenate(nf["lon"]) if nf["lon"] else np.empty(0),
+        "nfeat_lat": np.concatenate(nf["lat"]) if nf["lat"] else np.empty(0),
+        "nfeat_tags": _object_array(nf["tags"]),
+        "nfeat_meta": (
             np.concatenate(nf["meta"]) if nf["meta"] else np.empty((0, 4), np.int64)
         ),
-        way_id=np.concatenate(way_match_id) if way_match_id else np.empty(0, np.int64),
-        refs=(
+        "way_id": (
+            np.concatenate(way_match_id) if way_match_id else np.empty(0, np.int64)
+        ),
+        "refs": (
             np.concatenate(way_match_refs) if way_match_refs else np.empty(0, np.int64)
         ),
-        refs_off=_offsets_from_lengths([len(r) for r in way_match_refs]),
-        way_tags=_object_array(way_match_tags),
-        way_version=(
+        "refs_off": _offsets_from_lengths([len(r) for r in way_match_refs]),
+        "way_tags": _object_array(way_match_tags),
+        "way_version": (
             np.concatenate(way_version) if way_version else np.empty(0, np.int64)
         ),
-        way_timestamp=(
+        "way_timestamp": (
             np.concatenate(way_timestamp) if way_timestamp else np.empty(0, np.int64)
         ),
-        way_visible=(
+        "way_visible": (
             np.concatenate(way_visible) if way_visible else np.empty(0, np.int64)
         ),
-        all_id=np.concatenate(all_id) if all_id else np.empty(0, np.int64),
-        all_refs=np.concatenate(all_refs) if all_refs else np.empty(0, np.int64),
-        all_refs_off=_offsets_from_lengths(
+        "all_id": np.concatenate(all_id) if all_id else np.empty(0, np.int64),
+        "all_refs": np.concatenate(all_refs) if all_refs else np.empty(0, np.int64),
+        "all_refs_off": _offsets_from_lengths(
             np.concatenate(all_count).tolist() if all_count else []
         ),
-        rel_id=np.array(rel["id"], dtype=np.int64),
-        rel_memid=(
+        "rel_id": np.array(rel["id"], dtype=np.int64),
+        "rel_memid": (
             np.concatenate(rel["memid"]) if rel["memid"] else np.empty(0, np.int64)
         ),
-        rel_memoff=_offsets_from_lengths([len(m) for m in rel["memid"]]),
-        rel_memtype=(
+        "rel_memoff": _offsets_from_lengths([len(m) for m in rel["memid"]]),
+        "rel_memtype": (
             np.concatenate(rel["memtype"]) if rel["memtype"] else np.empty(0, np.int64)
         ),
-        rel_memrole=(
+        "rel_memrole": (
             np.concatenate(rel["memrole"])
             if rel["memrole"]
             else np.empty(0, dtype=object)
         ),
-        rel_tags=_object_array(rel["tags"]),
-        rel_meta=np.array(rel["meta"], dtype=np.int64).reshape(-1, 3),
-    )
-    return path
+        "rel_tags": _object_array(rel["tags"]),
+        "rel_meta": np.array(rel["meta"], dtype=np.int64).reshape(-1, 3),
+    }
+
+
+def _decode_batch(task):
+    """Worker: decode a contiguous run of blobs, spilling each block to its own shard as it
+    is decoded (so only one block's arrays are held in memory at a time, rather than the
+    whole batch), and return the list of shard paths."""
+    worker_id, blobs = task
+    paths = []
+    with open(_FILEPATH, "rb") as f:
+        for seq, (offset, size) in enumerate(blobs):
+            data = _read_block(f, offset, size)
+            arrays = _decode_one_block(*decode_primitive_block(data))
+            path = os.path.join(_SHARD_DIR, "shard_%d_%d.npz" % (worker_id, seq))
+            np.savez(path, **arrays)
+            paths.append(path)
+    return paths

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -25,7 +25,8 @@ def _auto_workers(filepath, n_blobs):
 def _decode_all(
     filepath, blobs, workers, shard_dir, osm_keys, include_nodes, bbox_bounds=None
 ):
-    """Decode every data blob into per-worker shards; return the shard paths."""
+    """Decode every data blob into per-block shards (each worker spills one shard per block
+    as it is decoded); return the flat list of shard paths."""
     n = len(blobs)
     per = (n + workers - 1) // workers
     tasks = [
@@ -36,9 +37,9 @@ def _decode_all(
     init_args = (filepath, shard_dir, osm_keys, include_nodes, bbox_bounds)
     if workers == 1:
         _init_worker(*init_args)
-        return [_decode_batch(tasks[0])] if tasks else []
+        return _decode_batch(tasks[0]) if tasks else []
     with Pool(workers, initializer=_init_worker, initargs=init_args) as pool:
-        return pool.map(_decode_batch, tasks)
+        return [path for paths in pool.map(_decode_batch, tasks) for path in paths]
 
 
 def _decode_and_run(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -252,8 +252,8 @@ def test_read_block_decodes_lzma_and_rejects_unsupported(tmp_path):
 
 
 def _write_shard(path, **overrides):
-    """Write a per-worker shard in the layout decode._decode_batch produces; every array
-    is empty by default so a test can fill in only the ones it needs."""
+    """Write a shard in the layout decode._decode_one_block produces; every array is empty
+    by default so a test can fill in only the ones it needs."""
     arrays = dict(
         node_id=np.empty(0, np.int64),
         node_lon=np.empty(0),


### PR DESCRIPTION
## Change

The out-of-core decode workers previously accumulated every block in a contiguous run of blobs and wrote one shard per worker with a single `np.savez` at the end, so the decode-phase working set was the whole batch. Each worker now spills one shard per block as it is decoded, so only a single block's arrays are held in memory at a time.

- `decode._decode_batch` is split into `_decode_one_block` (decode one primitive block into the per-shard npz arrays) and a loop that writes one shard per block and returns the list of shard paths.
- `pool._decode_all` flattens the per-worker path lists.
- The shard layout, and the collect/assemble phases that read the shards, are unchanged.

## Memory

On a 180 MB Berlin extract (1890 blocks, single worker), decode-phase peak RSS dropped from ~2269 MB to ~363 MB. Decode wall time rose from ~11.4 s to ~15.0 s, from writing one shard per block rather than one per worker.

## Verification

Tests in `tests/test_engine.py` (buildings / networks / bounding-box / parallel-vs-single / the GeoParquet streaming path) confirm the out-of-core readers still reproduce the in-memory reader column-for-column and value-for-value after the change.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
