### PR TITLE
Add get_network(nodes=True) to the out-of-core engine

### DIFF
--- a/pyrosm/engine/assemble.py
+++ b/pyrosm/engine/assemble.py
@@ -11,6 +11,7 @@ from pyrosm.engine.collect import (
     _collect_layer,
     _collect_kept_ways,
     _node_lookup,
+    _gather_node_records,
     _needed_node_ids,
 )
 
@@ -91,13 +92,21 @@ def _assemble_layer(
 
 
 def _assemble_network(
-    shard_paths, tags_as_columns, keep_metadata, filter_spec, segments, bounding_box
+    shard_paths,
+    tags_as_columns,
+    keep_metadata,
+    filter_spec,
+    segments,
+    bounding_box,
+    filepath=None,
 ):
     """Assemble the matching highway ways as a network (LineString edges + a ``length``
     column) through pyrosm's ``parse_network`` path. Returns ``(edges, nodes)``; ``nodes``
     is the graph-export node frame, only built when ``segments`` is True
-    (``get_network(nodes=True)``). A ``None`` ``data_filter`` (network types ``all`` /
-    ``driving_psv``) keeps every highway way."""
+    (``get_network(nodes=True)``), which needs the node tags + metadata, so the coordinate
+    store is gathered with a second pass over ``filepath`` rather than the lean shard lookup.
+    A ``None`` ``data_filter`` (network types ``all`` / ``driving_psv``) keeps every highway
+    way."""
     from pyrosm.frames import prepare_geodataframe
 
     osm_keys, data_filter, filter_type = filter_spec
@@ -111,7 +120,11 @@ def _assemble_network(
     kept = _collect_kept_ways(shard_paths, np.empty(0, np.int64), keep, in_box)
     if kept is None:
         return None, None
-    node_coordinates = _node_lookup(shard_paths, _needed_node_ids(kept, None))
+    needed = _needed_node_ids(kept, None)
+    if segments:
+        node_coordinates = _gather_node_records(filepath, needed, keep_metadata)
+    else:
+        node_coordinates = _node_lookup(shard_paths, needed)
     ways = _ways_arrays(kept, tags_as_columns, keep_metadata)
     edges, node_gdf = prepare_geodataframe(
         None,

--- a/pyrosm/engine/collect.py
+++ b/pyrosm/engine/collect.py
@@ -121,6 +121,61 @@ def _node_lookup(shard_paths, needed):
     return NodeLocations(coords)
 
 
+# Node-record column dtypes for the graph-export gather (id/coords + element metadata).
+_NODE_RECORD_DTYPES = {
+    "id": np.int64,
+    "lon": np.float64,
+    "lat": np.float64,
+    "version": np.int64,
+    "timestamp": np.int64,
+    "changeset": np.int64,
+    "visible": bool,
+}
+
+
+def _gather_node_records(filepath, node_ids, keep_metadata):
+    """Second pass over the file gathering the full records (coordinates + tags + metadata)
+    of ``node_ids``, returned as a rich ``NodeLocations`` -- the coordinate store the
+    graph-export node frame is built from (its records carry the node tags and metadata the
+    lean coordinate lookup omits). Only the requested (network) nodes are materialised, so
+    peak memory stays bounded by the graph's node set rather than the whole file."""
+    import pandas as pd
+
+    from pyrosm.node_lookup import NodeLocations
+    from pyrosm.primitive_block_decoder import decode_primitive_block
+    from pyrosm.engine.blobs import _index_blobs, _read_block
+    from pyrosm.engine.decode import _node_records_by_id
+
+    wanted = set(node_ids.tolist())
+    cols = ["id", "lon", "lat", "visible"]
+    if keep_metadata:
+        cols += ["version", "timestamp", "changeset"]
+    arrays = {c: [] for c in cols}
+    tags = []
+    with open(filepath, "rb") as f:
+        for blob_type, offset, size in _index_blobs(filepath):
+            if blob_type != "OSMData":
+                continue
+            st, header, nodes, _, _ = decode_primitive_block(
+                _read_block(f, offset, size)
+            )
+            rec = _node_records_by_id(st, header, nodes, wanted, keep_metadata)
+            if rec is not None:
+                for c in cols:
+                    arrays[c].append(rec[c])
+                tags.extend(rec["tags"])
+    frame = {
+        c: (
+            np.concatenate(arrays[c])
+            if arrays[c]
+            else np.empty(0, _NODE_RECORD_DTYPES[c])
+        )
+        for c in cols
+    }
+    frame["tags"] = tags
+    return NodeLocations(pd.DataFrame(frame))
+
+
 def _collect_kept_ways(shard_paths, exclude_ids, keep, in_box=None):
     """The standalone way records to output: the spilled candidates refined by the exact
     value filter ``keep``, then -- when reading a bounding box -- restricted to ways with at

--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -139,6 +139,63 @@ def _matching_nodes(string_table, nodes, osm_keys, node_lon, node_lat):
     }
 
 
+def _node_records_by_id(string_table, header, nodes, wanted, keep_metadata):
+    """Full records (id / lon / lat / tags + metadata) for the dense nodes whose id is in
+    ``wanted`` -- the second-pass gather that builds the graph-export node frame's coordinate
+    store. Tags are resolved through the string table; an untagged node gets ``tags=None`` and
+    metadata is included only when ``keep_metadata`` (matching the in-memory reader). Returns a
+    dict of parallel arrays/lists, or ``None`` when no wanted node is in this block."""
+    if nodes is None:
+        return None
+    ids = nodes["id"]
+    gran = header["granularity"]
+    lat = (nodes["lat"] * gran + header["lat_offset"]) / 1e9
+    lon = (nodes["lon"] * gran + header["lon_offset"]) / 1e9
+    keys_vals = nodes["keys_vals"]
+    idx, tags = [], []
+    p, end = 0, len(keys_vals)
+    for node_i in range(len(ids)):
+        pairs = []
+        while p < end and keys_vals[p] != 0:
+            pairs.append((keys_vals[p], keys_vals[p + 1]))
+            p += 2
+        p += 1  # skip the per-node 0 terminator
+        if ids[node_i] in wanted:
+            idx.append(node_i)
+            tags.append(
+                {
+                    string_table[k]
+                    .decode("utf-8", "replace"): string_table[v]
+                    .decode("utf-8", "replace")
+                    for k, v in pairs
+                }
+                if pairs
+                else None
+            )
+    if not idx:
+        return None
+    idx = np.array(idx, dtype=np.int64)
+
+    def meta(name):
+        arr = nodes[name]
+        return arr[idx] if len(arr) == len(ids) else np.zeros(len(idx), dtype=np.int64)
+
+    # 'visible' is kept regardless of keep_metadata (the in-memory node frame retains it);
+    # version/timestamp/changeset are the metadata dropped when keep_metadata is False.
+    record = {
+        "id": ids[idx],
+        "lon": lon[idx],
+        "lat": lat[idx],
+        "tags": tags,
+        "visible": meta("visible").astype(bool),
+    }
+    if keep_metadata:
+        record["version"] = meta("version")
+        record["timestamp"] = meta("timestamp")
+        record["changeset"] = meta("changeset")
+    return record
+
+
 def _layer_relations(string_table, relations, osm_keys):
     """The relations carrying any of ``osm_keys`` in this block. Yields, per relation, its
     id, member id/type/role arrays, full tag dict and ``version``/``timestamp``/

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -406,17 +406,11 @@ def get_network(
     columns. ``bounding_box`` (a ``[minx, miny, maxx, maxy]`` list or a shapely polygon)
     restricts the read to that area.
 
-    ``nodes=True`` (the graph-export node frame) is not yet supported by this backend: the
-    coordinate store carries only id/lon/lat, so the node frame would lack the element
-    metadata the in-memory reader produces."""
+    ``nodes=True`` returns ``(nodes, edges)``: the ways are sliced into per-segment edges
+    and the graph-export node frame is built (its node tags + metadata are gathered with a
+    second pass over the file), matching ``OSM(...).get_network(nodes=True)``."""
     from pyrosm.config import Conf
     from pyrosm.utils import validate_custom_filter, validate_tags_as_columns
-
-    if nodes:
-        raise NotImplementedError(
-            "get_network(nodes=True) (graph-export node frame) is not yet supported by "
-            "the out-of-core engine; only the edges are available."
-        )
 
     tags_as_columns = list(Conf.tags.highway)
     if tags_to_keep is not None:
@@ -451,15 +445,16 @@ def get_network(
     bounds = _bbox_bounds(bounding_box)
 
     def run(shard_paths):
-        edges, _ = _assemble_network(
+        edges, node_gdf = _assemble_network(
             shard_paths,
             tags_as_columns,
             keep_metadata,
             filter_spec,
-            False,
+            nodes,
             bounding_box,
+            filepath=filepath,
         )
-        return edges
+        return (node_gdf, edges) if nodes else edges
 
     return _decode_and_run(
         filepath, [b"highway"], False, workers, run, bbox_bounds=bounds

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -742,10 +742,74 @@ def test_engine_network_custom_filter_parity(helsinki_pbf):
     _assert_full_parity(mine, ref)
 
 
-def test_engine_network_nodes_true_not_supported(helsinki_pbf):
-    # The graph-export node frame is not available from the out-of-core engine yet.
-    with pytest.raises(NotImplementedError):
-        get_network(helsinki_pbf, nodes=True)
+@pytest.mark.parametrize("network_type", ["walking", "driving", "all"])
+def test_engine_network_nodes_parity(network_type, helsinki_pbf):
+    # nodes=True returns (nodes, edges): the ways are sliced into per-segment edges and the
+    # graph-export node frame (node coordinates + tags + metadata) is built, both matching
+    # the in-memory reader.
+    mine_nodes, mine_edges = get_network(
+        helsinki_pbf, network_type=network_type, nodes=True
+    )
+    ref_nodes, ref_edges = OSM(helsinki_pbf).get_network(
+        network_type=network_type, nodes=True
+    )
+    assert ref_edges is not None and len(ref_edges) > 0
+    _assert_full_parity(mine_edges, ref_edges)
+    # The node frame has no osm_type/relation rows; key it on id alone.
+    a = mine_nodes.sort_values("id").reset_index(drop=True)
+    b = ref_nodes.sort_values("id").reset_index(drop=True)
+    _assert_full_parity(a.assign(osm_type="node"), b.assign(osm_type="node"))
+
+
+def test_engine_network_nodes_keep_metadata_false_parity(helsinki_pbf):
+    mine_nodes, mine_edges = get_network(
+        helsinki_pbf, network_type="driving", nodes=True, keep_metadata=False
+    )
+    ref_nodes, ref_edges = OSM(helsinki_pbf, keep_metadata=False).get_network(
+        network_type="driving", nodes=True
+    )
+    assert "changeset" not in mine_nodes.columns and "visible" in mine_nodes.columns
+    _assert_full_parity(mine_edges, ref_edges)
+    a = mine_nodes.sort_values("id").reset_index(drop=True).assign(osm_type="node")
+    b = ref_nodes.sort_values("id").reset_index(drop=True).assign(osm_type="node")
+    _assert_full_parity(a, b)
+
+
+def test_engine_node_records_by_id_edge_cases():
+    from pyrosm.engine.decode import _node_records_by_id
+
+    header = {"granularity": 100, "lat_offset": 0, "lon_offset": 0}
+    st = [b"", b"amenity", b"cafe"]
+    # A block with no dense nodes (a way/relation block) yields nothing.
+    assert _node_records_by_id(st, header, None, {1}, True) is None
+    nodes = {
+        "id": np.array([1, 2], np.int64),
+        "lat": np.array([600000000, 600000010], np.int64),
+        "lon": np.array([240000000, 240000010], np.int64),
+        # node 1 untagged; node 2 tagged amenity=cafe (key/value string-table indices 1,2).
+        "keys_vals": np.array([0, 1, 2, 0], np.int64),
+        "version": np.array([3, 3], np.int64),
+        "timestamp": np.array([7, 7], np.int64),
+        "changeset": np.array([9, 9], np.int64),
+        "visible": np.array([1, 1], np.int64),
+    }
+    # No requested id present in the block -> nothing gathered.
+    assert _node_records_by_id(st, header, nodes, {999}, True) is None
+    rec = _node_records_by_id(st, header, nodes, {1, 2}, True)
+    assert rec["tags"] == [None, {"amenity": "cafe"}]
+    assert rec["version"].tolist() == [3, 3] and rec["visible"].dtype == bool
+    # keep_metadata=False drops version/timestamp/changeset but keeps visible.
+    lean = _node_records_by_id(st, header, nodes, {1}, False)
+    assert "version" not in lean and "visible" in lean
+
+
+def test_engine_gather_node_records_empty(helsinki_pbf):
+    from pyrosm.engine.collect import _gather_node_records
+
+    # No node ids requested: every block yields no record, so the rich coordinate store is
+    # built from the empty-array fallback.
+    nc = _gather_node_records(helsinki_pbf, np.empty(0, np.int64), True)
+    assert nc is not None
 
 
 def test_engine_network_invalid_args(helsinki_pbf):
@@ -1084,11 +1148,24 @@ def test_osm_engine_validation_and_unsupported_combos(helsinki_pbf):
         OSM(helsinki_pbf, engine="bogus")
     ooc = OSM(helsinki_pbf, engine="out_of_core")
     with pytest.raises(NotImplementedError):
-        ooc.get_network(nodes=True)
-    with pytest.raises(NotImplementedError):
         ooc.get_buildings(timestamp="2021-01-01 00:00:00")
     with pytest.raises(NotImplementedError):
         ooc.get_data_by_custom_criteria(custom_filter=None)
+
+
+def test_osm_out_of_core_network_nodes_parity(helsinki_pbf):
+    # The public OSM API returns the (nodes, edges) tuple from the out-of-core engine, equal
+    # to the in-memory reader's.
+    mine_nodes, mine_edges = OSM(helsinki_pbf, engine="out_of_core").get_network(
+        network_type="cycling", nodes=True
+    )
+    ref_nodes, ref_edges = OSM(helsinki_pbf).get_network(
+        network_type="cycling", nodes=True
+    )
+    _assert_full_parity(mine_edges, ref_edges)
+    a = mine_nodes.sort_values("id").reset_index(drop=True).assign(osm_type="node")
+    b = ref_nodes.sort_values("id").reset_index(drop=True).assign(osm_type="node")
+    _assert_full_parity(a, b)
 
 
 def test_osm_out_of_core_history_file_not_supported(test_pbf, tmp_path):


### PR DESCRIPTION
## Change

`OSM(engine="out_of_core").get_network(nodes=True)` (and `pyrosm.engine.get_network(..., nodes=True)`) now returns the `(nodes, edges)` tuple instead of raising, matching the in-memory reader:

- The highway ways are sliced into per-segment edges (each segment a row), and a graph-export node frame is built with the node coordinates, tags and metadata (`version` / `timestamp` / `changeset` / `visible`).
- The node tags and metadata are gathered with a targeted second pass over the file (`decode._node_records_by_id` + `collect._gather_node_records`) for only the nodes the network references, so peak memory stays bounded by the graph's node set rather than the whole file. `assemble._assemble_network` uses this rich coordinate store when slicing segments; the lean shard coordinate lookup is unchanged for `nodes=False`.

## Verification

Tests in `tests/test_engine.py` assert that `get_network(nodes=True)` reproduces `OSM(...).get_network(nodes=True)` for both the edges and the node frame — column-for-column and value-for-value (geometry equality at zero tolerance) — across the predefined and custom networks and with `keep_metadata=True` and `False` (the node frame keeps `visible` but drops `version`/`timestamp`/`changeset` when metadata is off, matching the in-memory reader).

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
