### PR TITLE
Fall back to serial decode when the worker pool can't start

### DIFF
--- a/pyrosm/engine/__init__.py
+++ b/pyrosm/engine/__init__.py
@@ -9,6 +9,14 @@ set rather than the whole file.
 
 The public ``get_*`` readers re-exported here mirror the in-memory reader's output
 column-for-column.
+
+Parallel reading and the ``__main__`` guard: files above ~70 MB are decoded in parallel
+worker processes. On macOS and Windows the workers start with ``spawn`` and re-import the
+program's entry point, so a read that runs at import time must be placed under an
+``if __name__ == "__main__":`` guard to decode in parallel. Without the guard the read
+still completes -- it falls back to a single process and emits a warning -- but it is not
+parallel. On Linux (``fork``) no guard is needed. Pass ``workers=1`` to read in a single
+process unconditionally.
 """
 
 from pyrosm.engine.readers import (

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -1,9 +1,11 @@
-"""Worker-count policy and ``multiprocessing.Pool`` orchestration for decoding blobs."""
+"""Worker-count policy and parallel-decode orchestration for decoding blobs."""
 
 import os
 import shutil
 import tempfile
-from multiprocessing import Pool
+import warnings
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 
 from pyrosm.engine.blobs import _index_blobs
 from pyrosm.engine.decode import _init_worker, _decode_batch
@@ -22,11 +24,25 @@ def _auto_workers(filepath, n_blobs):
     return max(1, min(os.cpu_count() or 1, n_blobs))
 
 
+def _decode_serial(tasks, init_args):
+    """Decode every task in this process (the single-process path and the parallel
+    fallback). Returns the flat list of shard paths."""
+    _init_worker(*init_args)
+    return [path for task in tasks for path in _decode_batch(task)]
+
+
 def _decode_all(
     filepath, blobs, workers, shard_dir, osm_keys, include_nodes, bbox_bounds=None
 ):
     """Decode every data blob into per-block shards (each worker spills one shard per block
-    as it is decoded); return the flat list of shard paths."""
+    as it is decoded); return the flat list of shard paths.
+
+    Parallel decoding uses a process pool. ``ProcessPoolExecutor`` reports a broken pool
+    instead of endlessly respawning dead workers (which would hang), so two failure modes
+    fall back to a single process with a warning rather than hanging or erroring: the read
+    running in a module not guarded by ``if __name__ == "__main__":`` (each spawned worker
+    re-imports and re-runs it, so the workers die on start), and environments that forbid
+    creating a process pool at all."""
     n = len(blobs)
     per = (n + workers - 1) // workers
     tasks = [
@@ -36,10 +52,22 @@ def _decode_all(
     ]
     init_args = (filepath, shard_dir, osm_keys, include_nodes, bbox_bounds)
     if workers == 1:
-        _init_worker(*init_args)
-        return _decode_batch(tasks[0]) if tasks else []
-    with Pool(workers, initializer=_init_worker, initargs=init_args) as pool:
-        return [path for paths in pool.map(_decode_batch, tasks) for path in paths]
+        return _decode_serial(tasks, init_args)
+    try:
+        with ProcessPoolExecutor(
+            max_workers=workers, initializer=_init_worker, initargs=init_args
+        ) as pool:
+            return [path for paths in pool.map(_decode_batch, tasks) for path in paths]
+    except (BrokenProcessPool, OSError):
+        warnings.warn(
+            "Parallel decoding could not start and fell back to a single process. This "
+            'happens when the read is not inside an `if __name__ == "__main__":` block (the '
+            "worker processes cannot re-import the entry point), or in environments that "
+            "forbid process pools. Guard the entry point, or pass workers=1 to silence this.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return _decode_serial(tasks, init_args)
 
 
 def _decode_and_run(

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -38,7 +38,10 @@ def _get_layer(
 
     Returns an in-memory GeoDataFrame, or -- when ``output`` is a path -- streams the layer
     to a chunked GeoParquet there and returns the path (needs the optional ``pyarrow``).
-    ``workers`` defaults to one for small files and otherwise to a worker per CPU."""
+    ``workers`` defaults to one for small files and otherwise to a worker per CPU; on
+    macOS/Windows a parallel read must run under an ``if __name__ == "__main__":`` guard
+    (otherwise it falls back to one process with a warning) -- see the package docstring.
+    """
     if output is not None:
         require_pyarrow()
     data_filter, derived_keys = parse_custom_filter(custom_filter)

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -69,6 +69,24 @@ class OSM:
         opt-in. It has no effect on a whole-file read (no `bounding_box`), which
         already holds every member. Only member ways are completed; relations
         whose members are themselves relations (super-relations) are not.
+
+    engine : str (default: 'in_memory')
+        Which reader backend to use. `'in_memory'` (the default) parses the whole
+        file into memory. `'out_of_core'` decodes the file in a single streaming
+        pass with bounded peak memory, spilling intermediate data to disk.
+
+        The out-of-core backend reads large files (above ~70 MB) using parallel
+        worker processes. On macOS and Windows those workers start with `spawn`,
+        which re-imports the program's entry point, so to read in parallel the
+        `OSM(...)` read must run under an `if __name__ == "__main__":` guard::
+
+            if __name__ == "__main__":
+                osm = OSM(fp, engine="out_of_core")
+                buildings = osm.get_buildings()
+
+        Without the guard the read still completes -- it falls back to a single
+        process and warns -- but it is not parallel. On Linux (`fork`) no guard is
+        needed.
     """
 
     allowed_bbox_types = [

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -225,6 +225,83 @@ def test_auto_workers_decides_on_file_size_not_blob_count(tmp_path):
     assert pool._auto_workers(str(big), 2) == min(cpus, 2)
 
 
+def _fake_executor(raise_init=None, raise_map=None):
+    """A ProcessPoolExecutor stand-in that runs map() in-process, optionally raising at
+    construction or at map() to exercise the parallel branch and its fallback without real
+    worker processes."""
+
+    class _F:
+        def __init__(self, max_workers=None, initializer=None, initargs=()):
+            if raise_init is not None:
+                raise raise_init("simulated")
+            if initializer is not None:
+                initializer(*initargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def map(self, fn, tasks):
+            if raise_map is not None:
+                raise raise_map("simulated")
+            return [fn(t) for t in tasks]
+
+    return _F
+
+
+def test_engine_parallel_decode_runs_and_matches_serial(helsinki_pbf, monkeypatch):
+    # The parallel branch (map over per-worker tasks, then flatten the shard paths) yields
+    # the same result as the single-process path.
+    monkeypatch.setattr(pool, "ProcessPoolExecutor", _fake_executor())
+    mine = get_buildings(helsinki_pbf, workers=3)
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
+
+
+@pytest.mark.parametrize("where", ["construction", "run"])
+def test_engine_parallel_decode_falls_back_to_serial(where, helsinki_pbf, monkeypatch):
+    # A process pool that cannot start (OSError, e.g. a restricted environment) or whose
+    # workers die (BrokenProcessPool, e.g. an unguarded __main__) must fall back to a single
+    # process with a warning, not hang or error, and still produce the correct result.
+    from concurrent.futures.process import BrokenProcessPool
+
+    if where == "construction":
+        fake = _fake_executor(raise_init=OSError)
+    else:
+        fake = _fake_executor(raise_map=BrokenProcessPool)
+    monkeypatch.setattr(pool, "ProcessPoolExecutor", fake)
+    with pytest.warns(RuntimeWarning, match="single process"):
+        mine = get_buildings(helsinki_pbf, workers=3)
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
+
+
+def test_engine_unguarded_module_read_does_not_hang(test_pbf, tmp_path):
+    # A read at module level (no `if __name__ == "__main__":` guard) must not hang: the
+    # spawned workers cannot re-import the entry point, so the decode falls back to a single
+    # process. Run it as a subprocess with a timeout so a regression surfaces as a failure.
+    import subprocess
+    import sys
+    import textwrap
+
+    script = tmp_path / "unguarded.py"
+    script.write_text(textwrap.dedent("""
+            import warnings
+            from pyrosm import engine
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                gdf = engine.get_buildings(%r, workers=3)
+            print("ROWS", 0 if gdf is None else len(gdf))
+            """ % test_pbf))
+    r = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert "ROWS" in r.stdout, r.stderr[-800:]
+
+
 def test_read_block_decodes_lzma_and_rejects_unsupported(tmp_path):
     # _read_block must decode an lzma-compressed Blob and raise on a Blob that carries no
     # recognised compression field.


### PR DESCRIPTION
## Problem

The out-of-core engine's parallel decode used `multiprocessing.Pool`. A `Pool` re-spawns workers that die during start-up, so if the workers cannot start it spins forever instead of failing. This happens in a common case: a read called at module level (no `if __name__ == "__main__":` guard) under the spawn start method (macOS/Windows) — each spawned worker re-imports the entry-point module, re-runs the read, attempts a nested pool, and dies; the parent keeps respawning them and the read hangs.

## Change

`_decode_all` now uses `concurrent.futures.ProcessPoolExecutor`, which reports a `BrokenProcessPool` rather than respawning dead workers. The parallel decode is wrapped to catch `BrokenProcessPool` (workers could not start) and `OSError` (environments that forbid creating a process pool at all) and fall back to a single-process decode — `_decode_serial`, shared with the existing `workers=1` path — emitting a `RuntimeWarning` that points at the missing `if __name__ == "__main__":` guard. So instead of hanging, the read completes in one process.

## Verification

Tests in `tests/test_engine.py` cover the parallel branch and both fallback paths (`OSError` at pool construction, `BrokenProcessPool` at run), asserting the fallback warns and produces a result identical to the single-process path, plus a subprocess test that runs an unguarded module-level read under a timeout to assert it completes rather than hangs.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
