### PR TITLE
Route out-of-core history (.osh / timestamp) reads to the in-memory reader

### DIFF
--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -87,6 +87,13 @@ class OSM:
         Without the guard the read still completes -- it falls back to a single
         process and warns -- but it is not parallel. On Linux (`fork`) no guard is
         needed.
+
+        History reads -- an `.osh.pbf` file, or any feature call with a
+        `timestamp` -- are served by the in-memory reader even when
+        `engine='out_of_core'`: selecting the latest version of each element
+        at/before the timestamp uses pyrosm's `get_latest_version`, which pandas
+        evaluates eagerly over the whole multi-version frame, so history is read
+        in memory.
     """
 
     allowed_bbox_types = [
@@ -174,19 +181,20 @@ class OSM:
         self._current_timestamp = None
         self._timestamp_changed = False
 
-    def _read_engine(self, reader, timestamp, with_relations=True, **kwargs):
+    def _use_engine(self, timestamp):
+        """Whether the out-of-core engine handles this read. History reads -- an ``.osh.pbf``
+        file, or an explicit ``timestamp`` -- route to the in-memory reader instead: selecting
+        the latest version of each element at/before the timestamp is pyrosm's per-id
+        ``get_latest_version`` merge (``df.groupby("id").last()``, each column's last non-null
+        value across an element's versions), which pandas evaluates eagerly over the whole
+        materialised multi-version frame, so history is read in memory."""
+        return self.engine == "out_of_core" and timestamp is None and not self._osh_file
+
+    def _read_engine(self, reader, with_relations=True, **kwargs):
         """Route a feature read to the out-of-core engine reader of the given name, threading
         the constructor-level ``bounding_box`` / ``keep_metadata`` (and ``complete_relations``
-        for the layer readers). History reads are not yet supported by this backend, so any
-        ``.osh.pbf`` file (which selects element versions implicitly even without a
-        ``timestamp``) or an explicit ``timestamp`` raises rather than silently returning all
-        historical versions."""
-        if self._osh_file or timestamp is not None:
-            raise NotImplementedError(
-                "Reading history files (.osh.pbf) or a specific 'timestamp' is not yet "
-                "supported by the out-of-core engine; use engine='in_memory' for history "
-                "reads."
-            )
+        for the layer readers). Only non-history reads reach here; history reads use the
+        in-memory path (see :meth:`_use_engine`)."""
         # Import the package qualified so the 'engine' name does not shadow the constructor
         # parameter of the same name.
         from pyrosm import engine as engine_backend
@@ -364,10 +372,9 @@ class OSM:
         Take a look at the OSM documentation for further details about the data:
         `https://wiki.openstreetmap.org/wiki/Key:highway <https://wiki.openstreetmap.org/wiki/Key:highway>`__
         """
-        if self.engine == "out_of_core":
+        if self._use_engine(timestamp):
             return self._read_engine(
                 "get_network",
-                timestamp,
                 with_relations=False,
                 network_type=network_type,
                 extra_attributes=extra_attributes,
@@ -491,10 +498,9 @@ class OSM:
         `https://wiki.openstreetmap.org/wiki/Key:building <https://wiki.openstreetmap.org/wiki/Key:building>`__
 
         """
-        if self.engine == "out_of_core":
+        if self._use_engine(timestamp):
             return self._read_engine(
                 "get_buildings",
-                timestamp,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -581,10 +587,9 @@ class OSM:
 
         """
 
-        if self.engine == "out_of_core":
+        if self._use_engine(timestamp):
             return self._read_engine(
                 "get_landuse",
-                timestamp,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -672,10 +677,9 @@ class OSM:
 
         """
 
-        if self.engine == "out_of_core":
+        if self._use_engine(timestamp):
             return self._read_engine(
                 "get_natural",
-                timestamp,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -777,10 +781,9 @@ class OSM:
 
         """
 
-        if self.engine == "out_of_core":
+        if self._use_engine(timestamp):
             return self._read_engine(
                 "get_boundaries",
-                timestamp,
                 boundary_type=boundary_type,
                 name=name,
                 custom_filter=custom_filter,
@@ -906,10 +909,9 @@ class OSM:
         'tourism', 'viewpoint', 'wilderness_hut', 'zoo']
 
         """
-        if self.engine == "out_of_core":
+        if self._use_engine(timestamp):
             return self._read_engine(
                 "get_pois",
-                timestamp,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -1028,7 +1030,7 @@ class OSM:
 
         """
 
-        if self.engine == "out_of_core":
+        if self._use_engine(timestamp):
             if custom_filter is None:
                 raise NotImplementedError(
                     "get_data_by_custom_criteria(custom_filter=None) ('return everything') "
@@ -1037,7 +1039,6 @@ class OSM:
                 )
             return self._read_engine(
                 "get_data_by_custom_criteria",
-                timestamp,
                 custom_filter=custom_filter,
                 osm_keys_to_keep=osm_keys_to_keep,
                 filter_type=filter_type,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -33,6 +33,11 @@ def helsinki_pbf():
     return get_data("helsinki_pbf")
 
 
+@pytest.fixture
+def helsinki_history_pbf():
+    return get_data("helsinki_test_history_pbf")
+
+
 def _rewrite_pbf_raw(src, dst):
     """Re-encode every blob of ``src`` with an uncompressed ``raw`` payload. Bundled
     extracts are all zlib, so this synthesises a file that exercises the engine's ``raw``
@@ -1224,7 +1229,9 @@ def test_osm_engine_validation_and_unsupported_combos(helsinki_pbf):
     with pytest.raises(ValueError):
         OSM(helsinki_pbf, engine="bogus")
     ooc = OSM(helsinki_pbf, engine="out_of_core")
-    with pytest.raises(NotImplementedError):
+    # A timestamp on a non-history file routes to the in-memory path, which rejects it
+    # (history timestamps require an .osh.pbf) -- the engine does not silently ignore it.
+    with pytest.raises(ValueError):
         ooc.get_buildings(timestamp="2021-01-01 00:00:00")
     with pytest.raises(NotImplementedError):
         ooc.get_data_by_custom_criteria(custom_filter=None)
@@ -1245,13 +1252,65 @@ def test_osm_out_of_core_network_nodes_parity(helsinki_pbf):
     _assert_full_parity(a, b)
 
 
-def test_osm_out_of_core_history_file_not_supported(test_pbf, tmp_path):
-    # A .osh.pbf history file selects element versions implicitly even without a timestamp,
-    # which the out-of-core engine does not do, so it must raise rather than return every
-    # historical version. The filename (not the content) marks it as history.
-    import shutil
+# History (.osh) reads route to the in-memory selection even under engine="out_of_core"
+# (the latest-version-per-element merge is global, so streaming gives no benefit); the
+# result must match the in-memory reader exactly.
 
-    osh = str(tmp_path / "history.osh.pbf")
-    shutil.copy(test_pbf, osh)
-    with pytest.raises(NotImplementedError):
-        OSM(osh, engine="out_of_core").get_buildings()
+
+def _osm_history_parity(fp, method, timestamp, **kwargs):
+    import copy
+
+    ref = getattr(OSM(fp, engine="in_memory"), method)(
+        timestamp=timestamp, **copy.deepcopy(kwargs)
+    )
+    mine = getattr(OSM(fp, engine="out_of_core"), method)(
+        timestamp=timestamp, **copy.deepcopy(kwargs)
+    )
+    if ref is None:
+        assert mine is None
+        return
+    _assert_full_parity(mine, ref)
+
+
+@pytest.mark.parametrize("timestamp", ["2010-01-01", "2015-01-01"])
+@pytest.mark.parametrize(
+    "method,kwargs",
+    [
+        ("get_network", {}),
+        ("get_buildings", {}),
+        ("get_landuse", {}),
+        ("get_natural", {}),
+        ("get_pois", {}),
+        ("get_boundaries", {}),
+        ("get_data_by_custom_criteria", {"custom_filter": {"highway": True}}),
+    ],
+)
+def test_osm_out_of_core_history_routes_to_in_memory(
+    helsinki_history_pbf, method, kwargs, timestamp
+):
+    _osm_history_parity(helsinki_history_pbf, method, timestamp, **kwargs)
+
+
+def test_osm_out_of_core_history_without_timestamp_routes_to_in_memory(
+    helsinki_history_pbf,
+):
+    # An .osh.pbf with no timestamp uses the current UTC time (with a warning) in both
+    # engines; the out-of-core engine routes to the in-memory selection, matching it.
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ref = OSM(helsinki_history_pbf, engine="in_memory").get_network()
+        mine = OSM(helsinki_history_pbf, engine="out_of_core").get_network()
+    _assert_full_parity(mine, ref)
+
+
+def test_use_engine_routing(helsinki_pbf, helsinki_history_pbf):
+    # The out-of-core engine handles only non-history reads; an .osh file or an explicit
+    # timestamp routes to the in-memory path.
+    assert OSM(helsinki_pbf, engine="out_of_core")._use_engine(None) is True
+    assert OSM(helsinki_pbf, engine="out_of_core")._use_engine("2015-01-01") is False
+    assert OSM(helsinki_pbf, engine="in_memory")._use_engine(None) is False
+    osh = OSM(helsinki_history_pbf, engine="out_of_core")
+    assert osh._use_engine(None) is False
+    assert osh._use_engine("2015-01-01") is False


### PR DESCRIPTION
Under `engine="out_of_core"`, a history read -- an `.osh.pbf` file or any feature call with a `timestamp` -- is now served by the in-memory reader instead of raising `NotImplementedError`. A new `OSM._use_engine(timestamp)` gate routes `.osh`/`timestamp` reads to the in-memory path and keeps every other read on the out-of-core engine; `_read_engine` no longer takes `timestamp`.

Version selection (`get_latest_version` = `df.groupby("id").last()`, each column's last non-null value across an element's versions) is evaluated eagerly by pandas over the whole multi-version frame, so history is read in memory; routing there gives parity by construction. Non-history reads are unchanged.

- `OSM(fp, engine="out_of_core").get_<layer>(timestamp=...)` matches the in-memory reader.
- `.osh.pbf` with no `timestamp` uses current UTC (existing warning), as in-memory.
- `timestamp` on a plain `.pbf` raises `ValueError`, as in-memory.

Verified with parity tests across the seven feature methods on the bundled history extract (two timestamps), plus the no-timestamp UTC path, the plain-`.pbf` `ValueError`, and `_use_engine` routing.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.