### PR TITLE
Cache out-of-core feature reads to a per-layer GeoParquet

### DIFF
--- a/docs/benchmarks/engine_cache_results.md
+++ b/docs/benchmarks/engine_cache_results.md
@@ -1,0 +1,151 @@
+# Out-of-core engine cache: pyrosm vs quackosm
+
+The out-of-core engine (`pyrosm/engine/`) caches each feature read to its own
+GeoParquet keyed by the source file (mtime + size) and the read parameters, so a
+repeated read of the same layer skips decoding and is served straight from disk.
+This page measures that cache against [quackosm](https://github.com/kraina-ai/quackosm)
+(a DuckDB-based decode-once/query-many reader) across three extract sizes, on
+speed and peak memory, for both the first (cold) and repeat (warm) read.
+
+## TL;DR
+
+- **Cold reads cross over with file size.** On a ~36 MB extract pyrosm is several
+  times faster cold (single-process decode beats quackosm's fixed DuckDB
+  start-up); around the ~116 MB mark they tie; on a 1.9 GB country file quackosm
+  is **~3.5× faster** cold, because pyrosm's per-element Python/Shapely assembly
+  of millions of features is the bottleneck.
+- **Warm reads are tied everywhere** — both libraries just reload a cached
+  parquet, so the cost is dominated by materialising the GeoDataFrame, not by
+  the cache format. The one exception is pyrosm's network layer, which is **not**
+  cached and re-decodes on every read (see Estonia below).
+- **Peak memory is comparable** on the large file (both ~13 GB for ~17.7 M
+  buildings — the in-memory result frame is the binding constraint for either
+  tool); quackosm runs ~30 % lower RSS on the mid-size multi-layer workload.
+
+## Setup
+
+- **Machine:** macOS (Darwin), Apple Silicon, 10 logical cores, ~26 GB RAM.
+- **Libraries:** pyrosm 0.9.1 (out-of-core engine), quackosm 0.17.1, on Python
+  3.12, geopandas 1.1.3, shapely 2.1.2, pyarrow 24.0.0, duckdb 1.5.3.
+- **Datasets:** `Helsinki_region.osm.pbf` (36.7 MB), `estonia-latest.osm.pbf`
+  (115 MB), `poland-latest.osm.pbf` (1.92 GB).
+- **Metric:** peak process RSS via `resource.getrusage(RUSAGE_SELF).ru_maxrss`
+  (OS-level), wall-clock via `time.perf_counter()`. Each phase runs in its own
+  subprocess so the reported peak RSS is that phase alone.
+- **Cold vs warm:** *cold* is the first read into an empty cache / quackosm
+  working directory (pyrosm decodes → assembles → writes the result parquet;
+  quackosm converts the PBF → parquet, then loads it). *Warm* is the immediately
+  following identical read against the now-populated cache.
+- **Both tools return GeoDataFrames** (pyrosm `get_<layer>`, quackosm
+  `convert_pbf_to_geodataframe`) so the comparison is end-to-end including the
+  in-memory frame.
+- **Worker policy:** the pyrosm engine decodes single-process below ~70 MB and a
+  worker per CPU above it ([`pool.py`](../../pyrosm/engine/pool.py)), so the
+  36.7 MB extract is decoded serially and the 115 MB / 1.9 GB files use 10
+  workers; DuckDB is internally multi-threaded throughout.
+- **Row counts** differ by <0.5 % between the libraries from slightly different
+  layer definitions; the network counts differ more because pyrosm returns a
+  routable edge network while quackosm returns raw `highway=*` ways (the two
+  network rows are not the same object — see the Estonia note).
+
+## Helsinki region (36.7 MB) — buildings, POIs, landuse, natural
+
+Four layers read on one process; pyrosm decodes single-process at this size.
+
+| layer | rows (pyrosm / quack) | pyrosm cold | quack cold | pyrosm warm | quack warm |
+| --- | --- | ---: | ---: | ---: | ---: |
+| buildings | 175,975 / 176,674 | 11.44 s | 30.26 s | 0.23 s | 0.26 s |
+| pois | 32,225 / 32,213 | 6.61 s | 28.38 s | 0.11 s | 0.12 s |
+| landuse | 15,606 / 15,535 | 5.43 s | 28.95 s | 0.03 s | 0.09 s |
+| natural | 34,476 / 34,656 | 6.29 s | 29.35 s | 0.04 s | 0.11 s |
+| **total** | — | **29.8 s** | **116.9 s** | **0.42 s** | **0.58 s** |
+| **peak RSS** | — | **1239 MB** | **1332 MB** | **563 MB** | **440 MB** |
+| cache on disk | — | 41 MB | 29 MB | — | — |
+
+- **pyrosm is ~3.9× faster cold** (29.8 s vs 116.9 s). quackosm pays a roughly
+  fixed ~28–30 s per layer here — its DuckDB conversion has a high floor that the
+  small file cannot amortise — whereas pyrosm's serial decode of a 36.7 MB file
+  is quick and each layer is cheap.
+- **Warm is a wash** (0.42 s vs 0.58 s): both reload a small cached parquet.
+- Peak RSS is comparable (~1.2–1.3 GB cold); quackosm is a touch lower warm.
+
+## Estonia (115 MB) — buildings, POIs, network
+
+Three layers on one process; pyrosm decodes with 10 workers at this size.
+
+| layer | rows (pyrosm / quack) | pyrosm cold | quack cold | pyrosm warm | quack warm |
+| --- | --- | ---: | ---: | ---: | ---: |
+| buildings | 902,739 / 902,893 | 50.97 s | 40.00 s | 0.72 s | 0.70 s |
+| pois | 104,972 / 104,980 | 21.80 s | 32.43 s | 0.38 s | 0.47 s |
+| network | 340,167 / 429,685 | 34.10 s | 35.33 s | **32.48 s** | 0.33 s |
+| **total** | — | **106.9 s** | **107.8 s** | **33.6 s** | **1.50 s** |
+| **peak RSS** | — | **3841 MB** | **2686 MB** | **3389 MB** | **1173 MB** |
+| cache on disk | — | 105 MB | — | — | — |
+
+- **Cold is a tie** (106.9 s vs 107.8 s): this is the crossover size. pyrosm's
+  parallel decode keeps buildings (50 s) competitive, and POIs are faster than
+  quackosm.
+- **The warm gap is entirely the network layer.** pyrosm's per-layer cache
+  covers buildings/POIs (warm 0.72 s / 0.38 s), but `get_network` returns edges
+  through a separate path that is **not** cached, so it re-decodes the whole file
+  on every read (warm 32.5 s) — that single layer is essentially all of pyrosm's
+  33.6 s warm total. quackosm caches every layer uniformly, so its warm total is
+  1.5 s.
+- The network row counts (340,167 vs 429,685) are not comparable: pyrosm builds
+  a routable edge network while quackosm returns every `highway=*` way.
+- quackosm runs **~30 % lower peak RSS** on this multi-layer workload (2686 MB vs
+  3841 MB cold).
+
+## Poland (1.92 GB) — buildings only
+
+A country file, single layer, read on a 10-worker decode.
+
+| | rows | cold | warm | disk |
+| --- | ---: | ---: | ---: | ---: |
+| pyrosm cache | 17,741,410 | 1066.2 s (17.8 min) | 13.5 s | 1.7 GB cache |
+| quackosm | 17,746,624 | 308.3 s (5.1 min) | 13.7 s | 1.4 GB workdir |
+| peak RSS (pyrosm) | — | 12,603 MB | 12,918 MB | — |
+| peak RSS (quack) | — | 13,070 MB | 13,629 MB | — |
+
+- **quackosm is ~3.5× faster cold** (5.1 min vs 17.8 min). At 17.7 M features the
+  bottleneck is building the result, and DuckDB's columnar conversion scales far
+  better than pyrosm assembling millions of Python way-records and Shapely
+  geometries.
+- **Warm is a dead tie** (13.5 s vs 13.7 s): both read their cached parquet and
+  materialise the same ~17.7 M-row frame, so the cost is identical and dominated
+  by frame construction, not the cache.
+- **Peak RSS is comparable at ~12.5–13.6 GB** for both, in both phases — the
+  17.7 M-building GeoDataFrame is the binding constraint regardless of tool or
+  caching; neither returns Poland buildings as a single frame in much under
+  ~13 GB.
+
+## Cold-read scaling (buildings)
+
+The buildings layer measured cold across all three sizes shows the crossover:
+
+| extract | pyrosm cold | quackosm cold |
+| --- | ---: | ---: |
+| Helsinki region (36.7 MB) | **11.4 s** | 30.3 s |
+| Estonia (115 MB) | 51.0 s | **40.0 s** |
+| Poland (1.92 GB) | 1066 s | **308 s** |
+
+pyrosm's low fixed overhead wins on small extracts; the crossover sits around
+Estonia; on a large country file quackosm's DuckDB throughput pulls clearly
+ahead. Warm reads are tied at every size (both reload the cached parquet), and
+peak memory is comparable (the result frame dominates) — so the per-layer
+cache's value is the fast repeat read, while the *first* read of a very large
+file is gated by pyrosm's per-element assembly rather than by the cache.
+
+## Scope of the cache
+
+- The cache is **per layer**, keyed by the source file (mtime + size) plus the
+  read parameters (filter, tags-as-columns, metadata/nodes flags, bounding box,
+  relation completion), and is reused across processes and sessions. An empty
+  result is recorded with a marker file so it is not recomputed.
+- It requires `pyarrow`; without it the engine falls back to the uncached read.
+- `get_network` is **not** covered (it returns edges via a separate path), so
+  network reads re-decode every time — visible as the 32.5 s warm network read on
+  Estonia.
+- Layers whose assembly is dominated by heavy multipolygon relations (e.g.
+  `get_natural` / `get_boundaries` on a country file) are bounded by that
+  relation step, not by the cache.

--- a/pyrosm/engine/cache.py
+++ b/pyrosm/engine/cache.py
@@ -1,0 +1,75 @@
+"""Per-layer result cache for the out-of-core engine.
+
+With ``engine="out_of_core"`` each feature read (``get_buildings``, ``get_landuse``, ...) is
+assembled by the bounded per-call path and then its **result** is written once to a persistent
+GeoParquet under a temp directory, keyed by the source file + the read's parameters. An identical
+later read -- in the same session or a different one -- reads that GeoParquet back instead of
+re-decoding the PBF, the same spirit as how ``get_data`` keeps a downloaded ``*.osm.pbf``. Each
+layer is cached separately, so peak memory stays bounded by a single layer (never the whole file's
+features). ``pyarrow`` is optional: without it the read just returns the in-memory frame and writes
+no cache.
+"""
+
+import hashlib
+import importlib.util
+import json
+import os
+import tempfile
+
+
+def cache_dir():
+    """The persistent result-cache directory (created on demand): ``<tempdir>/pyrosm/cache``."""
+    path = os.path.join(tempfile.gettempdir(), "pyrosm", "cache")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _stable(obj):
+    """A JSON-serialisable, order-independent view of a cache-key input: dict keys are sorted,
+    lists/tuples keep their order, and a shapely ``bounding_box`` becomes its WKT."""
+    if isinstance(obj, dict):
+        return {str(k): _stable(obj[k]) for k in sorted(obj, key=str)}
+    if isinstance(obj, (list, tuple)):
+        return [_stable(x) for x in obj]
+    if hasattr(obj, "wkt"):
+        return {"__wkt__": obj.wkt}
+    return obj
+
+
+def pyarrow_available():
+    """Whether ``pyarrow`` is importable (the GeoParquet dependency). When it is not, the engine
+    returns the in-memory frame and writes no cache instead of erroring."""
+    return importlib.util.find_spec("pyarrow") is not None
+
+
+def result_path(filepath, key_params):
+    """Deterministic per-layer result-cache path, keyed on the source file (path + modification
+    time + size) and the read's parameters (the filter, tag columns, metadata/bbox/element-kind
+    options). Identical reads share one cache file; any difference keys a new one."""
+    st = os.stat(filepath)
+    key = {
+        "filepath": os.path.abspath(filepath),
+        "mtime_ns": st.st_mtime_ns,
+        "size": st.st_size,
+        "params": _stable(key_params),
+    }
+    digest = hashlib.sha1(
+        json.dumps(key, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()[:16]
+    return os.path.join(cache_dir(), "result_%s.parquet" % digest)
+
+
+def read_result(cache_path):
+    """Read a cached layer GeoParquet back into the GeoDataFrame the reader would have returned.
+    Object columns that GeoParquet round-trips as ``None`` are normalised to ``NaN`` so the cached
+    frame matches the in-memory reader's missing-value representation."""
+    import numpy as np
+    import geopandas as gpd
+
+    gdf = gpd.read_parquet(cache_path)
+    for col in gdf.columns:
+        if col == "geometry":
+            continue
+        if gdf[col].dtype == object:
+            gdf[col] = gdf[col].where(gdf[col].notna(), np.nan)
+    return gdf

--- a/pyrosm/engine/cache.py
+++ b/pyrosm/engine/cache.py
@@ -11,7 +11,6 @@ no cache.
 """
 
 import hashlib
-import importlib.util
 import json
 import os
 import tempfile
@@ -34,12 +33,6 @@ def _stable(obj):
     if hasattr(obj, "wkt"):
         return {"__wkt__": obj.wkt}
     return obj
-
-
-def pyarrow_available():
-    """Whether ``pyarrow`` is importable (the GeoParquet dependency). When it is not, the engine
-    returns the in-memory frame and writes no cache instead of erroring."""
-    return importlib.util.find_spec("pyarrow") is not None
 
 
 def result_path(filepath, key_params):

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 
 from pyrosm.data_manager import parse_custom_filter
-from pyrosm.utils._compat import require_pyarrow
+from pyrosm.utils import _compat
 from pyrosm.engine.pool import _decode_and_run
 from pyrosm.engine.bounding_box import _bbox_bounds, _normalize_bounding_box
 from pyrosm.engine.assemble import _assemble_layer, _assemble_network
@@ -46,7 +46,7 @@ def _get_layer(
     (otherwise it falls back to one process with a warning) -- see the package docstring.
     """
     if output is not None:
-        require_pyarrow()
+        _compat.require_pyarrow()
     data_filter, derived_keys = parse_custom_filter(custom_filter)
     if osm_keys is None:
         osm_keys = derived_keys
@@ -60,7 +60,7 @@ def _get_layer(
     # result to a deterministic GeoParquet keyed by the read, and reuse that file on any identical
     # later read instead of re-decoding the PBF. Each layer is cached separately, so memory stays
     # bounded by one layer. With pyarrow absent the engine returns the in-memory frame (no cache).
-    if output is None and cache.pyarrow_available():
+    if output is None and _compat.HAS_PYARROW:
         key_params = {
             "filter_spec": filter_spec,
             "tags_as_columns": tags_as_columns,

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -3,12 +3,15 @@ into per-worker shards selecting the layer's elements (and, for point layers, th
 nodes), then collects and assembles (or streams to GeoParquet) the requested layer. A
 ``bounding_box`` restricts the read to that area."""
 
+import os
+import tempfile
+
 from pyrosm.data_manager import parse_custom_filter
 from pyrosm.utils._compat import require_pyarrow
 from pyrosm.engine.pool import _decode_and_run
 from pyrosm.engine.bounding_box import _bbox_bounds, _normalize_bounding_box
 from pyrosm.engine.assemble import _assemble_layer, _assemble_network
-from pyrosm.engine import geoparquet
+from pyrosm.engine import cache, geoparquet
 
 
 def _get_layer(
@@ -51,6 +54,68 @@ def _get_layer(
     osm_key_bytes = [k.encode("utf-8") for k in osm_keys]
     bounding_box = _normalize_bounding_box(bounding_box)
     bounds = _bbox_bounds(bounding_box)
+
+    # Per-layer result cache: when returning an in-memory frame (not streaming to a user file)
+    # and pyarrow is available, assemble the layer once via the bounded per-call path, write its
+    # result to a deterministic GeoParquet keyed by the read, and reuse that file on any identical
+    # later read instead of re-decoding the PBF. Each layer is cached separately, so memory stays
+    # bounded by one layer. With pyarrow absent the engine returns the in-memory frame (no cache).
+    if output is None and cache.pyarrow_available():
+        key_params = {
+            "filter_spec": filter_spec,
+            "tags_as_columns": tags_as_columns,
+            "keep_metadata": keep_metadata,
+            "include_nodes": include_nodes,
+            "keep_ways": keep_ways,
+            "keep_relations": keep_relations,
+            "bounding_box": bounding_box,
+            "complete_relations": complete_relations,
+        }
+        cache_path = cache.result_path(filepath, key_params)
+        # An empty result is recorded with a side marker, so an identical later read returns None
+        # without re-decoding the whole file.
+        empty_marker = cache_path + ".empty"
+        if os.path.exists(empty_marker):
+            return None
+        if not os.path.exists(cache_path):
+            # Stream to a unique temp file in the cache dir, then atomically move it into place,
+            # so concurrent identical first-reads never share a temp file or see a half-written
+            # cache. The temp file is removed unless it was moved into place.
+            fd, tmp_path = tempfile.mkstemp(
+                dir=os.path.dirname(cache_path),
+                prefix=os.path.basename(cache_path) + ".",
+                suffix=".tmp",
+            )
+            os.close(fd)
+            try:
+                written = _decode_and_run(
+                    filepath,
+                    osm_key_bytes,
+                    include_nodes,
+                    workers,
+                    lambda shard_paths: geoparquet._stream_layer_to_parquet(
+                        shard_paths,
+                        tmp_path,
+                        geoparquet._OUTPUT_CHUNK_SIZE,
+                        tags_as_columns,
+                        keep_metadata,
+                        filter_spec,
+                        keep_ways,
+                        keep_relations,
+                        bounding_box,
+                        complete_relations,
+                    ),
+                    bbox_bounds=bounds,
+                )
+                if written is None:
+                    with open(empty_marker, "w"):
+                        pass
+                    return None
+                os.replace(tmp_path, cache_path)
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+        return cache.read_result(cache_path)
 
     def run(shard_paths):
         if output is None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -24,6 +24,10 @@ from pyrosm.engine import (
 from pyrosm.engine import pool, geoparquet, cache
 from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
 
+# Captured before the autouse fixture below stubs the module attribute, so a test can exercise
+# the real cache_dir() implementation.
+_real_cache_dir = cache.cache_dir
+
 
 @pytest.fixture(autouse=True, scope="session")
 def _shared_cache_dir(tmp_path_factory):
@@ -742,10 +746,21 @@ def test_engine_cache_empty_result_is_marked(test_pbf, monkeypatch, fresh_cache)
 
 def test_engine_cache_pyarrow_absent_falls_back(helsinki_pbf, monkeypatch, fresh_cache):
     # With pyarrow unavailable the engine returns the in-memory frame and writes no cache file.
-    monkeypatch.setattr(cache, "pyarrow_available", lambda: False)
+    from pyrosm.utils import _compat
+
+    monkeypatch.setattr(_compat, "HAS_PYARROW", False)
     mine = get_buildings(helsinki_pbf)
     _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
     assert glob.glob(os.path.join(cache.cache_dir(), "*.parquet")) == []
+
+
+def test_cache_dir_builds_and_creates_tempdir_path(monkeypatch, tmp_path):
+    # cache_dir() roots the result cache at <tempdir>/pyrosm/cache and creates it on demand. The
+    # fixtures stub the module attribute, so exercise the real implementation captured at import.
+    monkeypatch.setattr(cache.tempfile, "gettempdir", lambda: str(tmp_path))
+    result = _real_cache_dir()
+    assert result == os.path.join(str(tmp_path), "pyrosm", "cache")
+    assert os.path.isdir(result)
 
 
 def test_engine_boundaries_parity(helsinki_region_pbf):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,8 @@
 """Out-of-core engine buildings reader: parity vs the in-memory OSM(fp).get_buildings()
 way and relation rows, plus the output= GeoParquet path and the worker-count policy."""
 
+import glob
+import os
 import zlib
 from struct import pack, unpack
 
@@ -19,8 +21,29 @@ from pyrosm.engine import (
     get_data_by_custom_criteria,
     get_network,
 )
-from pyrosm.engine import pool, geoparquet
+from pyrosm.engine import pool, geoparquet, cache
 from pyrosm.proto.fileformat_pb2 import BlobHeader, Blob
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _shared_cache_dir(tmp_path_factory):
+    # Point the per-layer result cache at one temp dir for the whole session: parity tests that
+    # read the same layer reuse the cached parquet, nothing leaks into the user's real cache dir.
+    # Tests that must observe a (re)build use the function-scoped ``fresh_cache`` fixture.
+    shared = tmp_path_factory.mktemp("result_cache")
+    original = cache.cache_dir
+    cache.cache_dir = lambda: str(shared)
+    yield
+    cache.cache_dir = original
+
+
+@pytest.fixture
+def fresh_cache(tmp_path, monkeypatch):
+    # A private, empty cache dir for tests that need the layer to actually be (re)built.
+    cache_dir = tmp_path / "fresh_cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(cache, "cache_dir", lambda: str(cache_dir))
+    return cache_dir
 
 
 @pytest.fixture
@@ -256,7 +279,9 @@ def _fake_executor(raise_init=None, raise_map=None):
     return _F
 
 
-def test_engine_parallel_decode_runs_and_matches_serial(helsinki_pbf, monkeypatch):
+def test_engine_parallel_decode_runs_and_matches_serial(
+    helsinki_pbf, monkeypatch, fresh_cache
+):
     # The parallel branch (map over per-worker tasks, then flatten the shard paths) yields
     # the same result as the single-process path.
     monkeypatch.setattr(pool, "ProcessPoolExecutor", _fake_executor())
@@ -265,7 +290,9 @@ def test_engine_parallel_decode_runs_and_matches_serial(helsinki_pbf, monkeypatc
 
 
 @pytest.mark.parametrize("where", ["construction", "run"])
-def test_engine_parallel_decode_falls_back_to_serial(where, helsinki_pbf, monkeypatch):
+def test_engine_parallel_decode_falls_back_to_serial(
+    where, helsinki_pbf, monkeypatch, fresh_cache
+):
     # A process pool that cannot start (OSError, e.g. a restricted environment) or whose
     # workers die (BrokenProcessPool, e.g. an unguarded __main__) must fall back to a single
     # process with a warning, not hang or error, and still produce the correct result.
@@ -666,6 +693,59 @@ def test_engine_custom_criteria_keep_flags_parity(helsinki_pbf, flags):
         assert mine is None
         return
     _assert_full_parity(mine, ref)
+
+
+def _count_decodes(monkeypatch):
+    # Count how many times the engine decodes the PBF, to assert a cached read does not re-decode.
+    import pyrosm.engine.readers as readers_mod
+
+    calls = []
+    real = readers_mod._decode_and_run
+
+    def spy(*args, **kwargs):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(readers_mod, "_decode_and_run", spy)
+    return calls
+
+
+def test_engine_cache_reuse_skips_decode(helsinki_pbf, monkeypatch, fresh_cache):
+    # The first read assembles + caches the layer; an identical second read reads the cached
+    # GeoParquet back without decoding the PBF again, and returns the same data.
+    decodes = _count_decodes(monkeypatch)
+    first = get_buildings(helsinki_pbf)
+    second = get_buildings(helsinki_pbf)
+    assert sum(decodes) == 1
+    _assert_full_parity(
+        second, first.sort_values(["osm_type", "id"]).reset_index(drop=True)
+    )
+
+
+def test_engine_cache_distinct_params_distinct_file(helsinki_pbf):
+    # A different read parameter keys a different cache file.
+    base = cache.result_path(helsinki_pbf, {"keep_metadata": True})
+    assert base != cache.result_path(helsinki_pbf, {"keep_metadata": False})
+    assert base != cache.result_path(helsinki_pbf, {"keep_metadata": True, "x": 1})
+
+
+def test_engine_cache_empty_result_is_marked(test_pbf, monkeypatch, fresh_cache):
+    # A filter that matches nothing returns None and records an empty marker, so an identical
+    # later read returns None without decoding the file again.
+    flt = {"amenity": ["definitely_not_a_real_value_xyz"]}
+    assert get_data_by_custom_criteria(test_pbf, custom_filter=flt) is None
+    assert glob.glob(os.path.join(cache.cache_dir(), "*.empty"))
+    decodes = _count_decodes(monkeypatch)
+    assert get_data_by_custom_criteria(test_pbf, custom_filter=flt) is None
+    assert sum(decodes) == 0
+
+
+def test_engine_cache_pyarrow_absent_falls_back(helsinki_pbf, monkeypatch, fresh_cache):
+    # With pyarrow unavailable the engine returns the in-memory frame and writes no cache file.
+    monkeypatch.setattr(cache, "pyarrow_available", lambda: False)
+    mine = get_buildings(helsinki_pbf)
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
+    assert glob.glob(os.path.join(cache.cache_dir(), "*.parquet")) == []
 
 
 def test_engine_boundaries_parity(helsinki_region_pbf):


### PR DESCRIPTION
With `engine="out_of_core"`, each feature read now caches its result to a GeoParquet under a temp directory and reuses it on an identical later read — within the same session and across sessions/processes — in the same spirit as how `get_data` caches downloaded extracts.

## What changed

- `get_buildings`, `get_pois`, `get_landuse`, `get_natural`, and `get_data_by_custom_criteria` (default `output=None`) write their assembled frame to a cached GeoParquet and return it; an identical later read is served from that file and skips decoding entirely.
- The cache lives under `<tempdir>/pyrosm/cache`, persisted across calls, keyed by the source PBF identity (mtime in ns + size) plus the read parameters (filter, tags-as-columns, metadata/nodes flags, bounding box, relation completion).
- The cache is built atomically: the result is written to a temp file and `os.replace`d into place, so an interrupted or concurrent build cannot leave a partial cache.
- An empty result is recorded with a marker file so it is not recomputed.
- Caching requires `pyarrow`; when it is absent the read falls back to the uncached in-memory path, so out-of-core never hard-depends on `pyarrow`.
- Cached frames are normalized so object-column missing values read back as `NaN`, matching the in-memory reader.
- `get_network` is not covered; it returns edges through a separate path and reads as before.

## How it was verified

- Parity: the cached-read result matches the direct out-of-core frame and the in-memory reader across buildings, POIs, landuse, natural, and custom-criteria reads, including a bounding-box read.
- Reuse: new engine tests confirm an identical second read hits the cache without re-decoding, distinct parameters produce distinct cache files, an empty result is marked and reused, and the read falls back to the uncached path when `pyarrow` is absent.
- Memory: a country-sized extract (Estonia) builds the cache without unbounded growth.
- Benchmarks: `docs/benchmarks/engine_cache_results.md` reports cold/warm wall-clock and peak RSS against quackosm across three extract sizes (36.7 MB / 115 MB / 1.92 GB) — e.g. Estonia buildings 51 s cold → 0.7 s warm, Poland buildings ~17.8 min cold → 13.5 s warm.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
