### PR TITLE
Use pathlib instead of os.path throughout pyrosm

### DIFF
--- a/pyrosm/data/__init__.py
+++ b/pyrosm/data/__init__.py
@@ -1,4 +1,5 @@
-import os
+from pathlib import Path
+
 from pyrosm.utils.download import download
 from pyrosm.data.geofabrik import (
     Africa,
@@ -34,7 +35,7 @@ __all__ = [
     "get_data_by_geocoding",
     "get_path",
 ]
-_module_path = os.path.dirname(__file__)
+_module_path = Path(__file__).parent
 _package_files = {"test_pbf": "test.osm.pbf", "helsinki_pbf": "Helsinki.osm.pbf"}
 
 # Static test data
@@ -236,7 +237,7 @@ def get_data(dataset, update=False, directory=None):
     dataset = dataset.lower().strip()
 
     if dataset in _package_files:
-        return os.path.abspath(os.path.join(_module_path, _package_files[dataset]))
+        return str((_module_path / _package_files[dataset]).resolve())
 
     elif dataset == "helsinki_region_pbf":
         return retrieve(_helsinki_region_pbf, update, directory)

--- a/pyrosm/data/geofabrik_index.py
+++ b/pyrosm/data/geofabrik_index.py
@@ -8,11 +8,11 @@ snapshot with ``scripts/update_geofabrik_index.py``.
 
 import gzip
 import json
-import os
 import ssl
 import tempfile
 import urllib.request
 import warnings
+from pathlib import Path
 
 import certifi
 import geopandas as gpd
@@ -20,7 +20,7 @@ import numpy as np
 from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 
-_INDEX_PATH = os.path.join(os.path.dirname(__file__), "geofabrik_index.geojson.gz")
+_INDEX_PATH = Path(__file__).parent / "geofabrik_index.geojson.gz"
 _INDEX_URL = "https://download.geofabrik.de/index-v1.json"
 
 # Rank covering extents by true size in an equal-area projection; lon/lat degree
@@ -137,8 +137,8 @@ def _bbox_filename(bounds):
 
 def _default_target_dir(directory):
     if directory is not None:
-        return directory
-    return os.path.join(tempfile.gettempdir(), "pyrosm")
+        return Path(directory)
+    return Path(tempfile.gettempdir()) / "pyrosm"
 
 
 def _download_optionally_crop(
@@ -156,14 +156,14 @@ def _download_optionally_crop(
     # Aliased so the ``download`` flag does not shadow the download function.
     from pyrosm.utils.download import download as _download_file
 
-    full_path = _download_file(url, os.path.basename(url), update, directory)
+    full_path = _download_file(url, Path(url).name, update, directory)
     if not crop:
         return full_path
 
     from pyrosm import OSM
 
-    target = output_path or os.path.join(_default_target_dir(directory), cropped_name)
-    os.makedirs(os.path.dirname(os.path.abspath(target)), exist_ok=True)
+    target = output_path or str(_default_target_dir(directory) / cropped_name)
+    Path(target).resolve().parent.mkdir(parents=True, exist_ok=True)
     return OSM(full_path, bounding_box=geom).to_pbf(output_path=target)
 
 

--- a/pyrosm/engine/cache.py
+++ b/pyrosm/engine/cache.py
@@ -13,14 +13,15 @@ no cache.
 import hashlib
 import os
 import tempfile
+from pathlib import Path
 
 from rapidjson import dumps
 
 
 def cache_dir():
     """The persistent result-cache directory (created on demand): ``<tempdir>/pyrosm/cache``."""
-    path = os.path.join(tempfile.gettempdir(), "pyrosm", "cache")
-    os.makedirs(path, exist_ok=True)
+    path = Path(tempfile.gettempdir()) / "pyrosm" / "cache"
+    path.mkdir(parents=True, exist_ok=True)
     return path
 
 
@@ -40,9 +41,10 @@ def result_path(filepath, key_params):
     """Deterministic per-layer result-cache path, keyed on the source file (path + modification
     time + size) and the read's parameters (the filter, tag columns, metadata/bbox/element-kind
     options). Identical reads share one cache file; any difference keys a new one."""
-    st = os.stat(filepath)
+    fp = Path(filepath)
+    st = fp.stat()
     key = {
-        "filepath": os.path.abspath(filepath),
+        "filepath": str(fp.resolve()),
         "mtime_ns": st.st_mtime_ns,
         "size": st.st_size,
         "params": _stable(key_params),
@@ -50,7 +52,7 @@ def result_path(filepath, key_params):
     digest = hashlib.sha1(
         dumps(key, sort_keys=True, default=str).encode("utf-8")
     ).hexdigest()[:16]
-    return os.path.join(cache_dir(), "result_%s.parquet" % digest)
+    return cache_dir() / ("result_%s.parquet" % digest)
 
 
 def read_result(cache_path):
@@ -74,12 +76,12 @@ def _temp_in(cache_path):
     replace so concurrent identical first-reads never share a temp file or observe a half-written
     cache."""
     fd, tmp_path = tempfile.mkstemp(
-        dir=os.path.dirname(cache_path),
-        prefix=os.path.basename(cache_path) + ".",
+        dir=cache_path.parent,
+        prefix=cache_path.name + ".",
         suffix=".tmp",
     )
     os.close(fd)
-    return tmp_path
+    return Path(tmp_path)
 
 
 def materialize(cache_path, build):
@@ -88,20 +90,19 @@ def materialize(cache_path, build):
     into place. An empty result is recorded with a ``.empty`` marker so an identical later read
     skips the rebuild. Returns the cached frame read back, or ``None`` for an empty (or
     already-marked-empty) result."""
-    empty_marker = cache_path + ".empty"
-    if os.path.exists(empty_marker):
+    empty_marker = cache_path.with_name(cache_path.name + ".empty")
+    if empty_marker.exists():
         return None
-    if not os.path.exists(cache_path):
+    if not cache_path.exists():
         tmp_path = _temp_in(cache_path)
         try:
             if not build(tmp_path):
-                with open(empty_marker, "w"):
-                    pass
+                empty_marker.touch()
                 return None
-            os.replace(tmp_path, cache_path)
+            tmp_path.replace(cache_path)
         finally:
-            if os.path.exists(tmp_path):
-                os.remove(tmp_path)
+            if tmp_path.exists():
+                tmp_path.unlink()
     return read_result(cache_path)
 
 
@@ -112,21 +113,20 @@ def materialize_pair(edges_path, nodes_path, build, read_nodes=read_result):
     ``.empty`` marker beside ``edges_path``. The node frame is read back with ``read_nodes`` (the
     edge frame with :func:`read_result`). Returns ``(nodes, edges)``, or ``(None, None)`` for an
     empty (or already-marked-empty) result."""
-    empty_marker = edges_path + ".empty"
-    if os.path.exists(empty_marker):
+    empty_marker = edges_path.with_name(edges_path.name + ".empty")
+    if empty_marker.exists():
         return None, None
-    if not (os.path.exists(edges_path) and os.path.exists(nodes_path)):
+    if not (edges_path.exists() and nodes_path.exists()):
         edges_tmp = _temp_in(edges_path)
         nodes_tmp = _temp_in(nodes_path)
         try:
             if not build(edges_tmp, nodes_tmp):
-                with open(empty_marker, "w"):
-                    pass
+                empty_marker.touch()
                 return None, None
-            os.replace(edges_tmp, edges_path)
-            os.replace(nodes_tmp, nodes_path)
+            edges_tmp.replace(edges_path)
+            nodes_tmp.replace(nodes_path)
         finally:
             for tmp in (edges_tmp, nodes_tmp):
-                if os.path.exists(tmp):
-                    os.remove(tmp)
+                if tmp.exists():
+                    tmp.unlink()
     return read_nodes(nodes_path), read_result(edges_path)

--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -6,7 +6,7 @@ coordinates, the matching layer features (ways, point nodes and relations -- sel
 filter-key presence) and *every* way (id + refs, for relation-member lookup).
 """
 
-import os
+from pathlib import Path
 
 import numpy as np
 
@@ -384,7 +384,7 @@ def _decode_batch(task):
         for seq, (offset, size) in enumerate(blobs):
             data = _read_block(f, offset, size)
             arrays = _decode_one_block(*decode_primitive_block(data))
-            path = os.path.join(_SHARD_DIR, "shard_%d_%d.npz" % (worker_id, seq))
+            path = Path(_SHARD_DIR) / ("shard_%d_%d.npz" % (worker_id, seq))
             np.savez(path, **arrays)
             paths.append(path)
     return paths

--- a/pyrosm/engine/geoparquet.py
+++ b/pyrosm/engine/geoparquet.py
@@ -8,9 +8,9 @@ union (by name) of every chunk's columns, so a tag column that first appears in 
 chunk is not dropped. Needs the optional pyarrow dependency.
 """
 
-import os
 import shutil
 import tempfile
+from pathlib import Path
 
 from pyrosm.engine.collect import _collect_layer
 from pyrosm.engine.assemble import _assemble_chunk
@@ -119,7 +119,7 @@ def _stream_layer_to_parquet(
         # Spill each chunk to its own parquet file (heterogeneous columns allowed).
         part_paths = []
         for table in chunk_tables():
-            part_path = os.path.join(part_dir, "part_%d.parquet" % len(part_paths))
+            part_path = Path(part_dir) / ("part_%d.parquet" % len(part_paths))
             pq.write_table(table, part_path)
             part_paths.append(part_path)
         if not part_paths:

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -6,6 +6,7 @@ import tempfile
 import warnings
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures.process import BrokenProcessPool
+from pathlib import Path
 
 from pyrosm.engine.blobs import _index_blobs
 from pyrosm.engine.decode import _init_worker, _decode_batch
@@ -19,7 +20,7 @@ def _auto_workers(filepath, n_blobs):
     """Pick a worker count for ``filepath``: single-core below the size threshold (where
     the process-spawn overhead dominates), otherwise a worker per CPU, capped at the blob
     count."""
-    if os.path.getsize(filepath) < _PARALLEL_MIN_FILE_BYTES:
+    if Path(filepath).stat().st_size < _PARALLEL_MIN_FILE_BYTES:
         return 1
     return max(1, min(os.cpu_count() or 1, n_blobs))
 

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -3,7 +3,7 @@ into per-worker shards selecting the layer's elements (and, for point layers, th
 nodes), then collects and assembles (or streams to GeoParquet) the requested layer. A
 ``bounding_box`` restricts the read to that area."""
 
-import os
+from pathlib import Path
 
 from rapidjson import dumps, loads
 
@@ -482,9 +482,10 @@ def _write_network_dir(result, dirpath):
     node_gdf, edges = result
     if edges is None:
         return None
-    os.makedirs(dirpath, exist_ok=True)
-    edges.to_parquet(os.path.join(dirpath, "edges.parquet"))
-    _write_nodes_parquet(node_gdf, os.path.join(dirpath, "nodes.parquet"))
+    out = Path(dirpath)
+    out.mkdir(parents=True, exist_ok=True)
+    edges.to_parquet(out / "edges.parquet")
+    _write_nodes_parquet(node_gdf, out / "nodes.parquet")
     return dirpath
 
 

--- a/pyrosm/pbf_export.pyx
+++ b/pyrosm/pbf_export.pyx
@@ -17,6 +17,7 @@ import os
 import shutil
 import tempfile
 import zlib
+from pathlib import Path
 from struct import pack, unpack
 
 import numpy as np
@@ -691,7 +692,7 @@ def _w_get_set(name):
     """Lazily load + cache the broadcast id set `name` from the temp dir."""
     s = _W_CACHE.get(name)
     if s is None:
-        arr = np.load(os.path.join(_W_TMPDIR, name + ".npy"))
+        arr = np.load(Path(_W_TMPDIR) / (name + ".npy"))
         s = _to_set(arr)
         _W_CACHE[name] = s
     return s
@@ -785,7 +786,7 @@ def _w_write(payload):
 
 cdef _broadcast(tmpdir, name, arr):
     """Write a kept-id array to the temp dir for the persistent workers to load."""
-    np.save(os.path.join(tmpdir, name + ".npy"), np.ascontiguousarray(arr, dtype=np.int64))
+    np.save(Path(tmpdir) / (name + ".npy"), np.ascontiguousarray(arr, dtype=np.int64))
 
 
 cdef _crop_pbf_parallel(source_path, output_path, bounds, keep_relations, workers,

--- a/pyrosm/utils/__init__.py
+++ b/pyrosm/utils/__init__.py
@@ -7,6 +7,7 @@ from google.protobuf.message import DecodeError
 import zlib
 from struct import unpack
 import os
+from pathlib import Path
 import geopandas as gpd
 import pandas as pd
 import warnings
@@ -146,7 +147,7 @@ def validate_input_file(filepath):
             f"Input data should be in Protobuf format (*.osm.pbf). "
             f"Found: {filepath.split('.')[-1]}"
         )
-    if not os.path.exists(filepath):
+    if not Path(filepath).exists():
         raise ValueError(f"File does not exist: " f"Found: {filepath}")
     return filepath
 

--- a/pyrosm/utils/download.py
+++ b/pyrosm/utils/download.py
@@ -1,9 +1,9 @@
 import urllib.request
 import tempfile
-import os
 import enum
 import shutil
 import ssl
+from pathlib import Path
 from urllib.error import HTTPError
 
 import certifi
@@ -28,30 +28,30 @@ def convert_unit(size_in_bytes, unit):
 
 
 def get_file_size(file_name, size_type=UNIT.MB):
-    size = os.path.getsize(file_name)
+    size = Path(file_name).stat().st_size
     return round(convert_unit(size, size_type), 2)
 
 
 def download(url, filename, update, target_dir):
     if target_dir is None:
-        temp_dir = tempfile.gettempdir()
-        target_dir = os.path.join(temp_dir, "pyrosm")
+        target_dir = Path(tempfile.gettempdir()) / "pyrosm"
     else:
-        if not os.path.isdir(target_dir):
+        target_dir = Path(target_dir)
+        if not target_dir.is_dir():
             raise ValueError(f"The provided directory does not exist: " f"{target_dir}")
 
-    filepath = os.path.abspath(os.path.join(target_dir, os.path.basename(filename)))
+    filepath = (target_dir / Path(filename).name).resolve()
 
-    if not os.path.exists(target_dir):
-        os.makedirs(target_dir)
+    if not target_dir.exists():
+        target_dir.mkdir(parents=True)
 
     # Check if file exists
     file_exists = False
-    if os.path.exists(filepath):
+    if filepath.exists():
         file_exists = True
 
     if update and file_exists:
-        os.remove(filepath)
+        filepath.unlink()
 
     # Download data to temp if it does not exist or if update is requested
     if update or file_exists is False:
@@ -80,7 +80,7 @@ def download(url, filename, update, target_dir):
                 "This is likely a temporary issue, try again later."
             )
         print(
-            f"Downloaded Protobuf data '{os.path.basename(filepath)}' "
+            f"Downloaded Protobuf data '{filepath.name}' "
             f"({filesize} MB) to:\n'{filepath}'"
         )
-    return filepath
+    return str(filepath)

--- a/setup.py
+++ b/setup.py
@@ -3,25 +3,23 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import io
-from os.path import dirname
-from os.path import join
-from os import path
+import os
+from pathlib import Path
 from setuptools import find_packages
 from setuptools import setup
-import os
 from Cython.Build import cythonize
 
 
 def read(*names, **kwargs):
     with io.open(
-        join(dirname(__file__), *names), encoding=kwargs.get("encoding", "utf8")
+        Path(__file__).parent.joinpath(*names), encoding=kwargs.get("encoding", "utf8")
     ) as fh:
         return fh.read()
 
 
 def read_long_description():
-    this_directory = path.abspath(path.dirname(__file__))
-    with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+    this_directory = Path(__file__).resolve().parent
+    with open(this_directory / "README.md", encoding="utf-8") as f:
         long_description = f.read()
     return long_description
 
@@ -49,7 +47,7 @@ if _linetrace:
     _directives["linetrace"] = True
     _directives["profile"] = True
 _ext_modules = cythonize(
-    os.path.join("pyrosm", "*.pyx"),
+    str(Path("pyrosm") / "*.pyx"),
     annotate=False,
     compiler_directives=_directives,
     force=_linetrace,

--- a/tests/test_building_parsing.py
+++ b/tests/test_building_parsing.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from pyrosm import get_data
 
@@ -22,9 +24,9 @@ def helsinki_history_pbf():
 
 @pytest.fixture
 def test_output_dir():
-    import os, tempfile
+    import tempfile
 
-    return os.path.join(tempfile.gettempdir(), "pyrosm_test_results")
+    return str(Path(tempfile.gettempdir()) / "pyrosm_test_results")
 
 
 def test_parsing_building_elements(test_pbf):
@@ -127,15 +129,14 @@ def test_parse_buildings_with_bbox(test_pbf):
 
 
 def test_saving_buildings_to_geopackage(test_pbf, test_output_dir):
-    import os
     from pyrosm import OSM
     import geopandas as gpd
     import shutil
 
-    if not os.path.exists(test_output_dir):
-        os.makedirs(test_output_dir)
+    if not Path(test_output_dir).exists():
+        Path(test_output_dir).mkdir(parents=True)
 
-    temp_path = os.path.join(test_output_dir, "pyrosm_test.gpkg")
+    temp_path = str(Path(test_output_dir) / "pyrosm_test.gpkg")
     osm = OSM(filepath=test_pbf)
     gdf = osm.get_buildings()
     gdf.to_file(temp_path, driver="GPKG")

--- a/tests/test_custom_filter.py
+++ b/tests/test_custom_filter.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from pyrosm import get_data
@@ -43,9 +45,9 @@ def default_filter():
 
 @pytest.fixture
 def test_output_dir():
-    import os, tempfile
+    import tempfile
 
-    return os.path.join(tempfile.gettempdir(), "pyrosm_test_results")
+    return str(Path(tempfile.gettempdir()) / "pyrosm_test_results")
 
 
 def test_get_data_by_custom_criteria_custom_filter(california_highway_motorway_pbf):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from pyrosm import get_data
 import sys
@@ -62,13 +64,12 @@ def bbbike_urls():
 @pytest.fixture
 def directory():
     import tempfile
-    import os
     import shutil
 
     temp_dir = tempfile.gettempdir()
-    target_dir = os.path.join(temp_dir, "pyrosm_dir")
-    if not os.path.exists(target_dir):
-        os.makedirs(target_dir)
+    target_dir = str(Path(temp_dir) / "pyrosm_dir")
+    if not Path(target_dir).exists():
+        Path(target_dir).mkdir(parents=True)
     yield target_dir
     # Remove after testing
     shutil.rmtree(target_dir)
@@ -93,54 +94,48 @@ def test_not_available():
 
 
 def test_test_data():
-    import os
-
     fp1 = get_data("test_pbf")
     fp2 = get_data("helsinki_pbf")
     fp3 = get_data("helsinki_region_pbf")
     fp4 = get_data("helsinki_history_pbf")
     fp5 = get_data("helsinki_test_history_pbf")
-    assert os.path.exists(fp1)
-    assert os.path.exists(fp2)
-    assert os.path.exists(fp3)
-    assert os.path.exists(fp4)
-    assert os.path.exists(fp5)
+    assert Path(fp1).exists()
+    assert Path(fp2).exists()
+    assert Path(fp3).exists()
+    assert Path(fp4).exists()
+    assert Path(fp5).exists()
 
 
 @run_downloads_only_once
 def test_geofabrik_download_to_temp():
     from pyrosm import get_data
-    import os
 
     fp = get_data("monaco", update=True)
-    assert os.path.exists(fp)
+    assert Path(fp).exists()
 
 
 @run_downloads_only_once
 def test_bbbike_download_to_temp():
     from pyrosm import get_data
-    import os
 
     fp = get_data("UlanBator", update=True)
-    assert os.path.exists(fp)
+    assert Path(fp).exists()
 
 
 @run_downloads_only_once
 def test_geofabrik_download_to_directory(directory):
     from pyrosm import get_data
-    import os
 
     fp = get_data("monaco", update=True, directory=directory)
-    assert os.path.exists(fp)
+    assert Path(fp).exists()
 
 
 @run_downloads_only_once
 def test_bbbike_download_to_directory(directory):
     from pyrosm import get_data
-    import os
 
     fp = get_data("UlanBator", update=True, directory=directory)
-    assert os.path.exists(fp)
+    assert Path(fp).exists()
 
 
 @pytest.mark.skipif("sys.version_info > (3,6)")

--- a/tests/test_data_by_bbox.py
+++ b/tests/test_data_by_bbox.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import geopandas as gpd
 import pytest
@@ -81,8 +82,8 @@ def test_accepts_bbox_input_forms(bbox):
 
 def test_crop_default_writes_bbox_named_file(mock_download):
     out = get_data_by_bbox(HELSINKI)  # crop=True, download=True (defaults)
-    assert os.path.basename(out) == "bbox_24.93_60.16_24.96_60.18.osm.pbf"
-    assert os.path.getsize(out) < os.path.getsize(mock_download)
+    assert Path(out).name == "bbox_24.93_60.16_24.96_60.18.osm.pbf"
+    assert Path(out).stat().st_size < Path(mock_download).stat().st_size
     assert pyrosm.OSM(out).get_buildings() is not None
 
 
@@ -94,13 +95,13 @@ def test_output_path_overrides_name(mock_download, tmp_path):
     target = str(tmp_path / "myclip.osm.pbf")
     out = get_data_by_bbox(HELSINKI, output_path=target)
     assert out == target
-    assert os.path.exists(target)
+    assert Path(target).exists()
 
 
 def test_directory_controls_output_location(mock_download, tmp_path):
     out = get_data_by_bbox(HELSINKI, directory=str(tmp_path))
-    assert os.path.dirname(out) == str(tmp_path)
-    assert os.path.basename(out) == "bbox_24.93_60.16_24.96_60.18.osm.pbf"
+    assert str(Path(out).parent) == str(tmp_path)
+    assert Path(out).name == "bbox_24.93_60.16_24.96_60.18.osm.pbf"
 
 
 def test_bbox_filename_format():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,8 +1,6 @@
 """Out-of-core engine buildings reader: parity vs the in-memory OSM(fp).get_buildings()
 way and relation rows, plus the output= GeoParquet path and the worker-count policy."""
 
-import glob
-import os
 import zlib
 from struct import pack, unpack
 
@@ -36,7 +34,7 @@ def _shared_cache_dir(tmp_path_factory):
     # Tests that must observe a (re)build use the function-scoped ``fresh_cache`` fixture.
     shared = tmp_path_factory.mktemp("result_cache")
     original = cache.cache_dir
-    cache.cache_dir = lambda: str(shared)
+    cache.cache_dir = lambda: shared
     yield
     cache.cache_dir = original
 
@@ -46,7 +44,7 @@ def fresh_cache(tmp_path, monkeypatch):
     # A private, empty cache dir for tests that need the layer to actually be (re)built.
     cache_dir = tmp_path / "fresh_cache"
     cache_dir.mkdir()
-    monkeypatch.setattr(cache, "cache_dir", lambda: str(cache_dir))
+    monkeypatch.setattr(cache, "cache_dir", lambda: cache_dir)
     return cache_dir
 
 
@@ -738,7 +736,7 @@ def test_engine_cache_empty_result_is_marked(test_pbf, monkeypatch, fresh_cache)
     # later read returns None without decoding the file again.
     flt = {"amenity": ["definitely_not_a_real_value_xyz"]}
     assert get_data_by_custom_criteria(test_pbf, custom_filter=flt) is None
-    assert glob.glob(os.path.join(cache.cache_dir(), "*.empty"))
+    assert list(cache.cache_dir().glob("*.empty"))
     decodes = _count_decodes(monkeypatch)
     assert get_data_by_custom_criteria(test_pbf, custom_filter=flt) is None
     assert sum(decodes) == 0
@@ -751,7 +749,7 @@ def test_engine_cache_pyarrow_absent_falls_back(helsinki_pbf, monkeypatch, fresh
     monkeypatch.setattr(_compat, "HAS_PYARROW", False)
     mine = get_buildings(helsinki_pbf)
     _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
-    assert glob.glob(os.path.join(cache.cache_dir(), "*.parquet")) == []
+    assert list(cache.cache_dir().glob("*.parquet")) == []
 
 
 def test_cache_dir_builds_and_creates_tempdir_path(monkeypatch, tmp_path):
@@ -759,8 +757,8 @@ def test_cache_dir_builds_and_creates_tempdir_path(monkeypatch, tmp_path):
     # fixtures stub the module attribute, so exercise the real implementation captured at import.
     monkeypatch.setattr(cache.tempfile, "gettempdir", lambda: str(tmp_path))
     result = _real_cache_dir()
-    assert result == os.path.join(str(tmp_path), "pyrosm", "cache")
-    assert os.path.isdir(result)
+    assert result == tmp_path / "pyrosm" / "cache"
+    assert result.is_dir()
 
 
 def test_engine_boundaries_parity(helsinki_region_pbf):
@@ -973,7 +971,7 @@ def test_engine_network_nodes_cache_reuse_skips_decode(
     n1, e1 = get_network(helsinki_pbf, network_type="driving", nodes=True)
     n2, e2 = get_network(helsinki_pbf, network_type="driving", nodes=True)
     assert sum(decodes) == 1
-    assert len(glob.glob(os.path.join(cache.cache_dir(), "*.parquet"))) == 2
+    assert len(list(cache.cache_dir().glob("*.parquet"))) == 2
     _assert_full_parity(e1, e2)
     _assert_full_parity(n1.assign(osm_type="node"), n2.assign(osm_type="node"))
 
@@ -981,9 +979,9 @@ def test_engine_network_nodes_cache_reuse_skips_decode(
 def test_engine_network_output_path_writes_edges(helsinki_pbf, tmp_path):
     # output= writes the edges to that GeoParquet and returns the path; the file matches the
     # in-memory network edges.
-    out = str(tmp_path / "network.parquet")
+    out = tmp_path / "network.parquet"
     ret = get_network(helsinki_pbf, network_type="driving", output=out)
-    assert ret == out and os.path.exists(out)
+    assert ret == out and out.exists()
     written = cache.read_result(out)
     ref = OSM(helsinki_pbf).get_network(network_type="driving")
     _assert_full_parity(written, ref)
@@ -994,18 +992,16 @@ def test_engine_network_output_dir_with_nodes(helsinki_pbf, tmp_path):
     # it; the two files reload equal to the in-memory (nodes, edges) tuple.
     from pyrosm.engine import readers
 
-    out = str(tmp_path / "net_dir")
+    out = tmp_path / "net_dir"
     ret = get_network(helsinki_pbf, network_type="driving", nodes=True, output=out)
     assert ret == out
-    assert os.path.exists(os.path.join(out, "edges.parquet"))
-    assert os.path.exists(os.path.join(out, "nodes.parquet"))
+    assert (out / "edges.parquet").exists()
+    assert (out / "nodes.parquet").exists()
     ref_nodes, ref_edges = OSM(helsinki_pbf).get_network(
         network_type="driving", nodes=True
     )
-    _assert_full_parity(
-        cache.read_result(os.path.join(out, "edges.parquet")), ref_edges
-    )
-    written_nodes = readers._read_nodes_parquet(os.path.join(out, "nodes.parquet"))
+    _assert_full_parity(cache.read_result(out / "edges.parquet"), ref_edges)
+    written_nodes = readers._read_nodes_parquet(out / "nodes.parquet")
     a = written_nodes.sort_values("id").reset_index(drop=True).assign(osm_type="node")
     b = ref_nodes.sort_values("id").reset_index(drop=True).assign(osm_type="node")
     _assert_full_parity(a, b)
@@ -1013,13 +1009,13 @@ def test_engine_network_output_dir_with_nodes(helsinki_pbf, tmp_path):
 
 def test_engine_network_output_dir_empty_returns_none(test_pbf, tmp_path):
     # An empty nodes=True read with output= writes nothing and returns None.
-    out = str(tmp_path / "empty_dir")
+    out = tmp_path / "empty_dir"
     flt = {"highway": ["definitely_not_a_real_highway_xyz"]}
     ret = get_network(
         test_pbf, custom_filter=flt, filter_type="keep", nodes=True, output=out
     )
     assert ret is None
-    assert not os.path.exists(out)
+    assert not out.exists()
 
 
 def test_engine_network_pyarrow_absent_falls_back(
@@ -1031,7 +1027,7 @@ def test_engine_network_pyarrow_absent_falls_back(
     monkeypatch.setattr(_compat, "HAS_PYARROW", False)
     mine = get_network(helsinki_pbf, network_type="driving")
     _assert_full_parity(mine, OSM(helsinki_pbf).get_network(network_type="driving"))
-    assert glob.glob(os.path.join(cache.cache_dir(), "*.parquet")) == []
+    assert list(cache.cache_dir().glob("*.parquet")) == []
 
 
 def test_engine_network_empty_result_is_marked(test_pbf, monkeypatch, fresh_cache):
@@ -1039,7 +1035,7 @@ def test_engine_network_empty_result_is_marked(test_pbf, monkeypatch, fresh_cach
     # identical later read returns None without decoding the file again.
     flt = {"highway": ["definitely_not_a_real_highway_xyz"]}
     assert get_network(test_pbf, custom_filter=flt, filter_type="keep") is None
-    assert glob.glob(os.path.join(cache.cache_dir(), "*.empty"))
+    assert list(cache.cache_dir().glob("*.empty"))
     decodes = _count_decodes(monkeypatch)
     assert get_network(test_pbf, custom_filter=flt, filter_type="keep") is None
     assert sum(decodes) == 0
@@ -1055,7 +1051,7 @@ def test_engine_network_nodes_empty_result_is_marked(
         test_pbf, custom_filter=flt, filter_type="keep", nodes=True
     )
     assert nodes is None and edges is None
-    assert glob.glob(os.path.join(cache.cache_dir(), "*.empty"))
+    assert list(cache.cache_dir().glob("*.empty"))
     decodes = _count_decodes(monkeypatch)
     again = get_network(test_pbf, custom_filter=flt, filter_type="keep", nodes=True)
     assert again == (None, None)

--- a/tests/test_geocode.py
+++ b/tests/test_geocode.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import pytest
 from shapely.geometry import box
@@ -161,8 +162,8 @@ def test_get_data_by_geocoding_crop_default_names_by_place(monkeypatch):
         lambda url, filename, update, directory: helsinki,
     )
     out = pyrosm.get_data_by_geocoding("Brighton and Hove, UK")
-    assert os.path.basename(out) == "brighton-and-hove-uk.osm.pbf"
-    assert os.path.getsize(out) < os.path.getsize(helsinki)
+    assert Path(out).name == "brighton-and-hove-uk.osm.pbf"
+    assert Path(out).stat().st_size < Path(helsinki).stat().st_size
     assert pyrosm.OSM(out).get_buildings() is not None
 
 

--- a/tests/test_network_parsing.py
+++ b/tests/test_network_parsing.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from pyrosm import get_data
 
@@ -22,9 +24,9 @@ def helsinki_history_pbf():
 
 @pytest.fixture
 def test_output_dir():
-    import os, tempfile
+    import tempfile
 
-    return os.path.join(tempfile.gettempdir(), "pyrosm_test_results")
+    return str(Path(tempfile.gettempdir()) / "pyrosm_test_results")
 
 
 def test_filter_network_by_walking(test_pbf):
@@ -232,16 +234,15 @@ def test_filter_network_by_all(test_pbf):
 
 
 def test_saving_network_to_shapefile(test_pbf, test_output_dir):
-    import os
     from pyrosm import OSM
     import geopandas as gpd
     import shutil
     import numpy as np
 
-    if not os.path.exists(test_output_dir):
-        os.makedirs(test_output_dir)
+    if not Path(test_output_dir).exists():
+        Path(test_output_dir).mkdir(parents=True)
 
-    temp_path = os.path.join(test_output_dir, "pyrosm_test.shp")
+    temp_path = str(Path(test_output_dir) / "pyrosm_test.shp")
     osm = OSM(filepath=test_pbf)
     gdf = osm.get_network(network_type="cycling")
     gdf.to_file(temp_path)

--- a/tests/test_pbf_export.py
+++ b/tests/test_pbf_export.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -76,7 +76,7 @@ def test_to_pbf_roundtrip_readable(helsinki_pbf):
     osm = OSM(helsinki_pbf, bounding_box=CROP_BBOX)
     out = osm.to_pbf()
     try:
-        assert os.path.exists(out)
+        assert Path(out).exists()
 
         cropped = OSM(out)
         net = cropped.get_network()
@@ -90,7 +90,7 @@ def test_to_pbf_roundtrip_readable(helsinki_pbf):
         ref = OSM(helsinki_pbf, bounding_box=CROP_BBOX).get_network()
         assert len(net) == len(ref)
     finally:
-        os.remove(out)
+        Path(out).unlink()
 
 
 def test_to_pbf_exact_selection_contract(helsinki_pbf):
@@ -110,7 +110,7 @@ def test_to_pbf_exact_selection_contract(helsinki_pbf):
         # Every in-bbox node is retained.
         assert nodes_in <= node_ids
     finally:
-        os.remove(out)
+        Path(out).unlink()
 
 
 def test_to_pbf_relation_selection(helsinki_pbf):
@@ -128,8 +128,8 @@ def test_to_pbf_relation_selection(helsinki_pbf):
         assert nodes_k == nodes_d
         assert ways_k == ways_d
     finally:
-        os.remove(out_keep)
-        os.remove(out_drop)
+        Path(out_keep).unlink()
+        Path(out_drop).unlink()
 
 
 def test_to_pbf_coordinate_fidelity(helsinki_pbf):
@@ -146,7 +146,7 @@ def test_to_pbf_coordinate_fidelity(helsinki_pbf):
         # allow ~1 cm just in case the grid offset/granularity differs per block.
         assert max_err < 1e-7
     finally:
-        os.remove(out)
+        Path(out).unlink()
 
 
 def test_to_pbf_given_path(helsinki_pbf, tmp_path):
@@ -154,7 +154,7 @@ def test_to_pbf_given_path(helsinki_pbf, tmp_path):
     osm = OSM(helsinki_pbf, bounding_box=CROP_BBOX)
     out = osm.to_pbf(target)
     assert out == target
-    assert os.path.exists(target)
+    assert Path(target).exists()
     assert OSM(out).get_network() is not None
 
 
@@ -175,8 +175,8 @@ def test_to_pbf_parallel_equals_sequential(helsinki_pbf):
             par_bytes = f.read()
         assert seq_bytes == par_bytes
     finally:
-        os.remove(out_seq)
-        os.remove(out_par)
+        Path(out_seq).unlink()
+        Path(out_par).unlink()
 
 
 def _write_multiblock_pbf(src_path, dst_path, replicas):
@@ -251,8 +251,8 @@ def test_to_pbf_parallel_multiblock(helsinki_pbf, tmp_path):
         net = OSM(out_par).get_network()
         assert net is not None and len(net) > 0
     finally:
-        os.remove(out_seq)
-        os.remove(out_par)
+        Path(out_seq).unlink()
+        Path(out_par).unlink()
 
 
 def test_to_pbf_osmium_cross_check(helsinki_pbf):
@@ -281,7 +281,7 @@ def test_to_pbf_osmium_cross_check(helsinki_pbf):
         assert counter.nodes == len(expected_nodes)
         assert counter.ways == len(expected_ways)
     finally:
-        os.remove(out)
+        Path(out).unlink()
 
 
 # ---------------------------------------------------------------------------
@@ -306,8 +306,8 @@ def test_to_pbf_compact_defaults_to_unchanged_output(helsinki_pbf):
             false_bytes = f.read()
         assert default_bytes == false_bytes
     finally:
-        os.remove(out_default)
-        os.remove(out_false)
+        Path(out_default).unlink()
+        Path(out_false).unlink()
 
 
 def test_to_pbf_default_copies_source_string_tables(helsinki_pbf):
@@ -321,7 +321,7 @@ def test_to_pbf_default_copies_source_string_tables(helsinki_pbf):
         for table in _block_string_tables(out):
             assert tuple(table) in source_tables
     finally:
-        os.remove(out)
+        Path(out).unlink()
 
 
 def test_to_pbf_compact_data_is_identical(helsinki_pbf):
@@ -349,8 +349,8 @@ def test_to_pbf_compact_data_is_identical(helsinki_pbf):
                 right = b[col].astype(object).where(b[col].notna(), None).tolist()
                 assert left == right, col
     finally:
-        os.remove(out_false)
-        os.remove(out_true)
+        Path(out_false).unlink()
+        Path(out_true).unlink()
 
 
 def test_to_pbf_compact_shrinks_string_tables(helsinki_pbf):
@@ -369,10 +369,10 @@ def test_to_pbf_compact_shrinks_string_tables(helsinki_pbf):
             total_false += len(default_table)
             total_true += len(compact_table)
         assert total_true < total_false
-        assert os.path.getsize(out_true) < os.path.getsize(out_false)
+        assert Path(out_true).stat().st_size < Path(out_false).stat().st_size
     finally:
-        os.remove(out_false)
-        os.remove(out_true)
+        Path(out_false).unlink()
+        Path(out_true).unlink()
 
 
 def test_to_pbf_compact_parallel_multiblock(helsinki_pbf, tmp_path):
@@ -391,8 +391,8 @@ def test_to_pbf_compact_parallel_multiblock(helsinki_pbf, tmp_path):
         assert seq_bytes == par_bytes
         assert OSM(out_par).get_network() is not None
     finally:
-        os.remove(out_seq)
-        os.remove(out_par)
+        Path(out_seq).unlink()
+        Path(out_par).unlink()
 
 
 def test_to_pbf_compact_preserves_user_metadata(tmp_path):
@@ -457,7 +457,9 @@ def test_to_pbf_compact_preserves_user_metadata(tmp_path):
         return result
 
     meta_false, meta_true = meta(out_false), meta(out_true)
-    assert os.path.getsize(out_true) < os.path.getsize(out_false)  # compaction ran
+    assert (
+        Path(out_true).stat().st_size < Path(out_false).stat().st_size
+    )  # compaction ran
     assert meta_false == meta_true  # user/uid/version identical, incl. user names
     assert meta_true[("w", 1)][0] == "way_mapper"
     assert meta_true[("n", 1)][0] == "inside_mapper"
@@ -554,8 +556,8 @@ def test_to_pbf_repack_defaults_to_unchanged_output(helsinki_pbf):
             b = f.read()
         assert a == b
     finally:
-        os.remove(out_default)
-        os.remove(out_false)
+        Path(out_default).unlink()
+        Path(out_false).unlink()
 
 
 def test_to_pbf_repack_data_is_identical(helsinki_pbf):
@@ -582,8 +584,8 @@ def test_to_pbf_repack_data_is_identical(helsinki_pbf):
                 right = b[col].astype(object).where(b[col].notna(), None).tolist()
                 assert left == right, col
     finally:
-        os.remove(out_off)
-        os.remove(out_on)
+        Path(out_off).unlink()
+        Path(out_on).unlink()
 
 
 def test_to_pbf_repack_is_smaller_and_denser(helsinki_pbf):
@@ -592,7 +594,7 @@ def test_to_pbf_repack_is_smaller_and_denser(helsinki_pbf):
     out_off = osm.to_pbf(repack=False)
     out_on = osm.to_pbf(repack=True)
     try:
-        assert os.path.getsize(out_on) < os.path.getsize(out_off)
+        assert Path(out_on).stat().st_size < Path(out_off).stat().st_size
         nb_off, nn_off = _block_fill(out_off)
         nb_on, nn_on = _block_fill(out_on)
         assert nn_off == nn_on  # same node count
@@ -608,8 +610,8 @@ def test_to_pbf_repack_is_smaller_and_denser(helsinki_pbf):
         _H().apply_file(out_on)  # re-readable by osmium
         assert counter[0] > 0
     finally:
-        os.remove(out_off)
-        os.remove(out_on)
+        Path(out_off).unlink()
+        Path(out_on).unlink()
 
 
 def test_to_pbf_repack_coordinates_exact(helsinki_pbf):
@@ -624,7 +626,7 @@ def test_to_pbf_repack_coordinates_exact(helsinki_pbf):
             max_err = max(max_err, abs(ox - x), abs(oy - y))
         assert max_err < 1e-7
     finally:
-        os.remove(out)
+        Path(out).unlink()
 
 
 def test_to_pbf_repack_preserves_metadata(tmp_path):
@@ -655,7 +657,9 @@ def test_to_pbf_repack_preserves_metadata(tmp_path):
         return result
 
     m_off, m_on = meta(out_off), meta(out_on)
-    assert os.path.getsize(out_on) < os.path.getsize(out_off)  # re-pack actually ran
+    assert (
+        Path(out_on).stat().st_size < Path(out_off).stat().st_size
+    )  # re-pack actually ran
     assert m_off == m_on
     assert m_on[("w", 1)][0] == "way_mapper"
     assert m_on[("n", 1)][0] == "inside_mapper"
@@ -703,9 +707,9 @@ def test_to_pbf_repack_deterministic_and_overrides_compact(helsinki_pbf):
         assert ab == bb  # deterministic across runs
         assert ab == cb  # compact ignored when repack=True
     finally:
-        os.remove(a)
-        os.remove(b)
-        os.remove(c)
+        Path(a).unlink()
+        Path(b).unlink()
+        Path(c).unlink()
 
 
 def _frame_pbf_blob(out, btype, msg):
@@ -1012,7 +1016,7 @@ def test_write_pbf_api(helsinki_pbf, tmp_path):
     edges = osm.get_network()
     single = str(tmp_path / "single.osm.pbf")
     assert osm.write_pbf(edges, single) == single
-    assert os.path.exists(single)
+    assert Path(single).exists()
 
     as_list = str(tmp_path / "list.osm.pbf")
     osm.write_pbf([edges], as_list)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,6 +1,7 @@
 """Regression tests guarding against specific bugs reappearing."""
 
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -899,7 +900,6 @@ def test_download_builds_ssl_context_from_certifi(tmp_path, monkeypatch):
     ssl.SSLError [ASN1: NOT_ENOUGH_DATA] (a CPython bug on a malformed store
     entry), which aborted every download-backed test on the windows runners."""
     import io
-    import os
     import ssl
 
     import certifi
@@ -931,7 +931,7 @@ def test_download_builds_ssl_context_from_certifi(tmp_path, monkeypatch):
     # The CA bundle came from certifi, and that context was handed to urlopen.
     assert captured["cafile"] == certifi.where()
     assert isinstance(captured["context"], ssl.SSLContext)
-    assert os.path.exists(out)
+    assert Path(out).exists()
 
 
 def test_tags_to_keep_restricts_tag_columns():
@@ -1202,7 +1202,6 @@ def test_get_data_dispatch_and_lazy_attrs(monkeypatch):
     the name-normalisation variants (spaces, underscores, dashes) and the
     not-available error -- plus the deprecated get_path alias and the lazy
     pyrosm.data attribute loader."""
-    import os
     import pyrosm.data as data
 
     # Non-string input is rejected up front.
@@ -1214,7 +1213,7 @@ def test_get_data_dispatch_and_lazy_attrs(monkeypatch):
         data.get_data("not_a_real_place_xyz")
 
     # Bundled data is returned as a local path, no download.
-    assert os.path.exists(data.get_data("test_pbf"))
+    assert Path(data.get_data("test_pbf")).exists()
 
     # Stub the network so the retrieve-backed branches (and retrieve itself) run
     # offline; capture the resolved filename for each.
@@ -1247,7 +1246,7 @@ def test_get_data_dispatch_and_lazy_attrs(monkeypatch):
 
     # get_path is the deprecated alias for get_data.
     with pytest.warns(DeprecationWarning, match="get_path"):
-        assert os.path.exists(data.get_path("test_pbf"))
+        assert Path(data.get_path("test_pbf")).exists()
 
     # The optional geo helpers are exposed lazily via module __getattr__.
     assert callable(data.get_data_by_bbox)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -934,6 +934,38 @@ def test_download_builds_ssl_context_from_certifi(tmp_path, monkeypatch):
     assert Path(out).exists()
 
 
+def test_download_rejects_nonexistent_target_dir(tmp_path):
+    """download(target_dir=...) raises when the given directory does not exist."""
+    from pyrosm.utils import download as dl
+
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(ValueError, match="does not exist"):
+        dl.download(
+            "https://example.invalid/x.osm.pbf", "x.osm.pbf", False, str(missing)
+        )
+
+
+def test_download_update_removes_existing_file(tmp_path, monkeypatch):
+    """download(update=True) unlinks the cached file before re-fetching."""
+    import io
+
+    from pyrosm.utils import download as dl
+
+    target = tmp_path / "x.osm.pbf"
+    target.write_bytes(b"old")
+    fresh = b"x" * 50000  # large enough that download's empty-file guard passes
+
+    monkeypatch.setattr(dl.ssl, "create_default_context", lambda *a, **k: None)
+    monkeypatch.setattr(
+        dl.urllib.request, "urlopen", lambda url, context=None: io.BytesIO(fresh)
+    )
+
+    out = dl.download(
+        "https://example.invalid/x.osm.pbf", "x.osm.pbf", True, str(tmp_path)
+    )
+    assert Path(out).read_bytes() == fresh
+
+
 def test_tags_to_keep_restricts_tag_columns():
     """#87 — get_*(tags_to_keep=[...]) materializes only the requested OSM tag
     keys as columns (replacing the default tag-column set), leaving rows,


### PR DESCRIPTION
Replace `os.path` path handling with `pathlib.Path` across pyrosm, per the project convention.

## What changed

- Path operations now use `pathlib.Path`: `os.path.join` → `/`, `os.path.exists`/`isdir`/`isfile` → `.exists()`/`.is_dir()`/`.is_file()`, `os.path.dirname`/`basename` → `.parent`/`.name`, `os.path.abspath` → `.resolve()`, `os.path.getsize` → `.stat().st_size`, `os.makedirs(..., exist_ok=True)` → `.mkdir(parents=True, exist_ok=True)`, `os.remove` → `.unlink()`, `os.replace` → `Path.replace`, and `glob.glob(...)` → `Path.glob(...)`.
- Scope: the out-of-core engine (`cache.py`, `readers.py`, `decode.py`, `geoparquet.py`, `pool.py`), the data/download path (`data/__init__.py`, `data/geofabrik_index.py`, `utils/__init__.py`, `utils/download.py`), `pbf_export.pyx`, `setup.py`, and the test suite.
- `os` is retained only for non-path operations (`os.close` on a raw `tempfile.mkstemp` fd, `os.cpu_count`, `os.environ`, `os.PathLike`/`os.fspath`).
- Public filepath return values (`get_data`, `download`) stay `str`, so they continue to flow unchanged into pyrosm's existing string-based filepath handling.

Only the path-construction/inspection calls are swapped for their pathlib equivalents; there are no functional behavior changes.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
