### PR TITLE
Add configurable worker count to the out-of-core engine

### DIFF
--- a/docs/reading_osm_data.ipynb
+++ b/docs/reading_osm_data.ipynb
@@ -1349,37 +1349,28 @@
    "source": [
     "## Reading large datasets with the out-of-core engine\n",
     "\n",
-    "By default the `OSM` reader loads the whole PBF into memory (`engine=\"in_memory\"`), which is fast and convenient for city- and region-sized extracts. For larger files — up to whole countries — pyrosm also ships an **out-of-core** engine that decodes the PBF in a streaming, parallel fashion and keeps peak memory bounded. Select it with the `engine` parameter when you create the reader; every `get_*` method (and options such as `custom_filter` and `bounding_box`) works exactly as before and returns the same GeoDataFrames:"
+    "By default the `OSM` reader loads the whole PBF into memory (`engine=\"in_memory\"`), which is fast and convenient for city- and region-sized extracts. For larger files — up to whole countries — pyrosm also ships an **out-of-core** engine that decodes the PBF in a streaming fashion and keeps peak memory bounded. Select it with the `engine` parameter when you create the reader; every `get_*` method (and options such as `custom_filter` and `bounding_box`) works exactly as before and returns the same GeoDataFrames:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "4fe0595f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloaded Protobuf data 'finland-latest.osm.pbf' (692.08 MB) to:\n",
-      "'/private/var/folders/f2/pgp09jl542zffhtrt2hx8zhh0000gp/T/pyrosm/finland-latest.osm.pbf'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from pyrosm import OSM, get_data\n",
     "\n",
     "fp = get_data(\"finland\")\n",
     "\n",
     "# Opt into the out-of-core engine\n",
-    "osm = OSM(fp, engine=\"out_of_core\")\n",
+    "osm = OSM(fp, engine=\"out_of_core\", workers=\"auto\")\n",
     "buildings = osm.get_buildings()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "a3b1c911",
    "metadata": {},
    "outputs": [
@@ -1389,7 +1380,7 @@
        "(3145871, 43)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1402,13 +1393,7 @@
    "cell_type": "markdown",
    "id": "b63dcf46",
    "metadata": {},
-   "source": [
-    "**Which engine should I use?** Keep the default `engine=\"in_memory\"` for small and medium extracts, where it is fastest. Reach for `engine=\"out_of_core\"` on large extracts (e.g. whole-country files) where reading everything into memory at once is impractical — it trades a little per-call overhead for a much lower memory ceiling.\n",
-    "\n",
-    "**Result caching.** With `engine=\"out_of_core\"`, each layer's result is written once to a GeoParquet file under a temporary directory, keyed by the source file and the read's parameters. Reading the same layer again — even in a later Python session — reuses that cached file instead of re-decoding the PBF, so repeat reads are near-instant. Caching uses the optional [`pyarrow`](https://arrow.apache.org/docs/python/) package; if `pyarrow` is not installed the out-of-core reader still works, but returns an in-memory GeoDataFrame without caching.\n",
-    "\n",
-    "**Parallel reads need an `if __name__ == \"__main__\":` guard.** On larger files the out-of-core engine decodes across several worker processes. On macOS and Windows those workers are *spawned*, which re-imports the entry module, so a parallel read in a standalone script must run under a `__main__` guard — otherwise the workers cannot re-import the entry point and the read silently falls back to a single process (with a warning):\n"
-   ]
+   "source": "**Which engine should I use?** Keep the default `engine=\"in_memory\"` for small and medium extracts, where it is fastest. Reach for `engine=\"out_of_core\"` on large extracts (e.g. whole-country files) where reading everything into memory at once is impractical — it trades a little per-call overhead for a much lower memory ceiling.\n\n**Result caching.** With `engine=\"out_of_core\"`, each layer's result is written once to a GeoParquet file under a temporary directory, keyed by the source file and the read's parameters. Reading the same layer again — even in a later Python session — reuses that cached file instead of re-decoding the PBF, so repeat reads are near-instant. Caching uses the optional [`pyarrow`](https://arrow.apache.org/docs/python/) package; if `pyarrow` is not installed the out-of-core reader still works, but returns an in-memory GeoDataFrame without caching.\n\n**Reading in parallel.** By default the out-of-core engine decodes on a single core, and the first read reports how many CPU cores are available. The simplest way to speed up a large read is `workers=\"auto\"`, which lets pyrosm choose the worker count automatically — a single core for small files and multiple cores for large ones; pass `workers=N` for an explicit count (capped at the number of CPU cores your computer has).\n\nReading in parallel means pyrosm splits the work across several helper processes that run at the same time. On macOS and Windows, Python starts each helper by re-running your script from the top, so when you launch a parallel read from a standalone script you need to place it inside an `if __name__ == \"__main__\":` block. This is a standard Python guard that runs the code *only* when the file is launched directly, which stops each helper from starting its own read as it loads. Forgetting the guard is not fatal — pyrosm simply falls back to reading on a single core and prints a warning:"
   },
   {
    "cell_type": "markdown",
@@ -1419,7 +1404,7 @@
     "from pyrosm import OSM\n",
     "\n",
     "if __name__ == \"__main__\":\n",
-    "    osm = OSM(\"finland-latest.osm.pbf\", engine=\"out_of_core\")\n",
+    "    osm = OSM(\"finland-latest.osm.pbf\", engine=\"out_of_core\", workers=\"auto\")\n",
     "    buildings = osm.get_buildings()\n",
     "\n",
     "```"
@@ -1430,7 +1415,7 @@
    "id": "e2b4952c",
    "metadata": {},
    "source": [
-    "This only matters for scripts that read large files in parallel; interactive sessions (Jupyter, the REPL) and small files that decode in a single process are unaffected."
+    "Forgetting the guard is not fatal — pyrosm simply falls back to reading on a single core and prints a warning. The guard matters only when a read actually runs in parallel (e.g. `workers=\"auto\"` on a large file, or an explicit `workers` > 1) from a standalone script (e.g. `my_analysis.py`); the default single-core read and interactive sessions such as running the code inside a Jupyter Notebook do not need a guard."
    ]
   }
  ],

--- a/pyrosm/engine/__init__.py
+++ b/pyrosm/engine/__init__.py
@@ -10,13 +10,15 @@ set rather than the whole file.
 The public ``get_*`` readers re-exported here mirror the in-memory reader's output
 column-for-column.
 
-Parallel reading and the ``__main__`` guard: files above ~70 MB are decoded in parallel
-worker processes. On macOS and Windows the workers start with ``spawn`` and re-import the
-program's entry point, so a read that runs at import time must be placed under an
-``if __name__ == "__main__":`` guard to decode in parallel. Without the guard the read
-still completes -- it falls back to a single process and emits a warning -- but it is not
-parallel. On Linux (``fork``) no guard is needed. Pass ``workers=1`` to read in a single
-process unconditionally.
+Parallel reading and the ``__main__`` guard: the engine reads on a single core by default.
+Pass ``workers="auto"`` to choose the count automatically (a single core for small files,
+one per CPU core for larger files), or ``workers=N`` for an explicit count (reduced to the
+CPU-core count, with a warning, if it exceeds it). On macOS and
+Windows those workers start with ``spawn`` and re-import the program's entry point, so a
+parallel read that runs at import time must be placed under an ``if __name__ == "__main__":``
+guard. Without the guard a parallel read still completes -- it falls back to a single process
+and emits a warning -- but it is not parallel. On Linux (``fork``) no guard is needed; the
+default single-core read needs none anywhere.
 """
 
 from pyrosm.engine.readers import (

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -1,4 +1,4 @@
-"""Worker-count policy and parallel-decode orchestration for decoding blobs."""
+"""Worker-count resolution and parallel-decode orchestration for decoding blobs."""
 
 import os
 import shutil
@@ -11,18 +11,31 @@ from pathlib import Path
 from pyrosm.engine.blobs import _index_blobs
 from pyrosm.engine.decode import _init_worker, _decode_batch
 
-# Parallelising the decode only pays off above this file size; smaller files decode in a
-# single process, where the process-spawn overhead would otherwise dominate.
+# ``workers="auto"`` decodes in parallel only for files at or above this size.
 _PARALLEL_MIN_FILE_BYTES = 70_000_000  # ~70 MB
 
 
 def _auto_workers(filepath, n_blobs):
-    """Pick a worker count for ``filepath``: single-core below the size threshold (where
-    the process-spawn overhead dominates), otherwise a worker per CPU, capped at the blob
-    count."""
+    """Worker count for ``workers="auto"``: a single core for files below ~70 MB, otherwise
+    one worker per available CPU core, capped at the number of data blobs."""
     if Path(filepath).stat().st_size < _PARALLEL_MIN_FILE_BYTES:
         return 1
     return max(1, min(os.cpu_count() or 1, n_blobs))
+
+
+def _cap_workers(workers):
+    """Cap an explicit worker count at the host's CPU-core count, warning when it exceeds
+    them."""
+    n_cores = os.cpu_count() or 1
+    if workers > n_cores:
+        warnings.warn(
+            f"workers={workers} exceeds the {n_cores} CPU cores available on this "
+            f"machine; reading with {n_cores} workers instead.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return n_cores
+    return workers
 
 
 def _decode_serial(tasks, init_args):
@@ -82,7 +95,11 @@ def _decode_and_run(
         if blob_type == "OSMData"
     ]
     if workers is None:
+        workers = 1
+    elif isinstance(workers, str) and workers.lower() == "auto":
         workers = _auto_workers(filepath, len(data_blobs))
+    else:
+        workers = _cap_workers(workers)
     shard_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_")
     try:
         shard_paths = _decode_all(

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -42,9 +42,10 @@ def _get_layer(
 
     Returns an in-memory GeoDataFrame, or -- when ``output`` is a path -- streams the layer
     to a chunked GeoParquet there and returns the path (needs the optional ``pyarrow``).
-    ``workers`` defaults to one for small files and otherwise to a worker per CPU; on
-    macOS/Windows a parallel read must run under an ``if __name__ == "__main__":`` guard
-    (otherwise it falls back to one process with a warning) -- see the package docstring.
+    ``workers`` defaults to a single process; pass ``workers=N`` for N processes or
+    ``workers="auto"`` to choose automatically by file size (on macOS/Windows a parallel read
+    must run under an ``if __name__ == "__main__":`` guard, otherwise it falls back to one
+    process with a warning) -- see the package docstring.
     """
     if output is not None:
         _compat.require_pyarrow()

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -13,9 +13,12 @@ from pyrosm.utils import (
     validate_bounding_box,
     validate_input_file,
     validate_graph_type,
+    validate_engine,
+    validate_workers,
     get_bounding_box,
     get_unix_time,
     warn_about_timestamp_not_set,
+    warn_about_single_core,
 )
 from pyrosm.utils.download import get_file_size
 from shapely.geometry import (
@@ -33,6 +36,10 @@ from pyrosm.networks import get_network_data
 from pyrosm.pois import get_poi_data
 from pyrosm.user_defined import get_user_defined_data
 from pyrosm.graphs import to_networkx, to_igraph, to_pandana, to_pandarm
+
+# Aliased so the module does not collide with the ``engine`` constructor
+# parameter / ``self.engine`` attribute of the same name.
+from pyrosm import engine as engine_backend
 
 
 class OSM:
@@ -75,18 +82,19 @@ class OSM:
         file into memory. `'out_of_core'` decodes the file in a single streaming
         pass with bounded peak memory, spilling intermediate data to disk.
 
-        The out-of-core backend reads large files (above ~70 MB) using parallel
-        worker processes. On macOS and Windows those workers start with `spawn`,
-        which re-imports the program's entry point, so to read in parallel the
-        `OSM(...)` read must run under an `if __name__ == "__main__":` guard::
+        The out-of-core backend reads on a single core by default. To decode in
+        parallel pass `workers="auto"` (or an explicit `workers=N`); see below. The
+        worker processes start with `spawn` on macOS and Windows, which re-imports
+        the program's entry point, so a parallel `OSM(...)` read must run under an
+        `if __name__ == "__main__":` guard::
 
             if __name__ == "__main__":
-                osm = OSM(fp, engine="out_of_core")
+                osm = OSM(fp, engine="out_of_core", workers="auto")
                 buildings = osm.get_buildings()
 
-        Without the guard the read still completes -- it falls back to a single
-        process and warns -- but it is not parallel. On Linux (`fork`) no guard is
-        needed.
+        Without the guard a parallel read still completes -- it falls back to a
+        single process and warns -- but it is not parallel. On Linux (`fork`) no
+        guard is needed, and the default single-core read needs no guard anywhere.
 
         History reads -- an `.osh.pbf` file, or any feature call with a
         `timestamp` -- are served by the in-memory reader even when
@@ -94,6 +102,18 @@ class OSM:
         at/before the timestamp uses pyrosm's `get_latest_version`, which pandas
         evaluates eagerly over the whole multi-version frame, so history is read
         in memory.
+
+    workers : int | str (default: None)
+        Number of worker processes the `'out_of_core'` engine uses to decode the
+        file. By default (`None`) the engine reads on a single core, and the first
+        out-of-core read reports how many CPU cores are available and how to opt
+        into parallelism. Pass `workers="auto"` to let pyrosm choose the count
+        automatically -- a single core for small files and one worker per CPU core
+        for larger files -- or `workers=N` for an explicit count (a count above the
+        available CPU cores is reduced to the core count, with a warning). Parallel
+        reads need the `if __name__ == "__main__":` guard on macOS/Windows; pass
+        `workers=1` to read on a single core silently. Has no effect on the
+        `'in_memory'` engine.
     """
 
     allowed_bbox_types = [
@@ -111,6 +131,7 @@ class OSM:
         keep_metadata=True,
         complete_relations=False,
         engine="in_memory",
+        workers=None,
     ):
         # Check input file
         self.filepath = validate_input_file(filepath)
@@ -123,9 +144,9 @@ class OSM:
             raise ValueError("'complete_relations' should be a boolean.")
         self.complete_relations = complete_relations
 
-        if engine not in ("in_memory", "out_of_core"):
-            raise ValueError("'engine' should be either 'in_memory' or 'out_of_core'.")
-        self.engine = engine
+        self.engine = validate_engine(engine)
+        self.workers = validate_workers(workers)
+        self._single_core_notice_emitted = False
 
         # Check if file contains history
         self._osh_file = False
@@ -191,19 +212,22 @@ class OSM:
         return self.engine == "out_of_core" and timestamp is None and not self._osh_file
 
     def _read_engine(self, reader, with_relations=True, **kwargs):
-        """Route a feature read to the out-of-core engine reader of the given name, threading
-        the constructor-level ``bounding_box`` / ``keep_metadata`` (and ``complete_relations``
-        for the layer readers). Only non-history reads reach here; history reads use the
-        in-memory path (see :meth:`_use_engine`)."""
-        # Import the package qualified so the 'engine' name does not shadow the constructor
-        # parameter of the same name.
-        from pyrosm import engine as engine_backend
-
+        """Route a feature read to the given out-of-core engine reader, threading the
+        constructor-level ``bounding_box`` / ``keep_metadata`` / ``workers`` (and
+        ``complete_relations`` for the layer readers). Only non-history reads reach here;
+        history reads use the in-memory path (see :meth:`_use_engine`)."""
+        workers = self.workers
+        if workers is None:
+            workers = 1
+            if not self._single_core_notice_emitted:
+                self._single_core_notice_emitted = True
+                warn_about_single_core()
         kwargs["bounding_box"] = self.bounding_box
         kwargs["keep_metadata"] = self.keep_metadata
+        kwargs["workers"] = workers
         if with_relations:
             kwargs["complete_relations"] = self.complete_relations
-        return getattr(engine_backend, reader)(self.filepath, **kwargs)
+        return reader(self.filepath, **kwargs)
 
     def _get_pbf_elements(self, bounding_box):
         (
@@ -374,7 +398,7 @@ class OSM:
         """
         if self._use_engine(timestamp):
             return self._read_engine(
-                "get_network",
+                engine_backend.get_network,
                 with_relations=False,
                 network_type=network_type,
                 extra_attributes=extra_attributes,
@@ -500,7 +524,7 @@ class OSM:
         """
         if self._use_engine(timestamp):
             return self._read_engine(
-                "get_buildings",
+                engine_backend.get_buildings,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -589,7 +613,7 @@ class OSM:
 
         if self._use_engine(timestamp):
             return self._read_engine(
-                "get_landuse",
+                engine_backend.get_landuse,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -679,7 +703,7 @@ class OSM:
 
         if self._use_engine(timestamp):
             return self._read_engine(
-                "get_natural",
+                engine_backend.get_natural,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -783,7 +807,7 @@ class OSM:
 
         if self._use_engine(timestamp):
             return self._read_engine(
-                "get_boundaries",
+                engine_backend.get_boundaries,
                 boundary_type=boundary_type,
                 name=name,
                 custom_filter=custom_filter,
@@ -911,7 +935,7 @@ class OSM:
         """
         if self._use_engine(timestamp):
             return self._read_engine(
-                "get_pois",
+                engine_backend.get_pois,
                 custom_filter=custom_filter,
                 extra_attributes=extra_attributes,
                 tags_to_keep=tags_to_keep,
@@ -1038,7 +1062,7 @@ class OSM:
                     "custom_filter."
                 )
             return self._read_engine(
-                "get_data_by_custom_criteria",
+                engine_backend.get_data_by_custom_criteria,
                 custom_filter=custom_filter,
                 osm_keys_to_keep=osm_keys_to_keep,
                 filter_type=filter_type,

--- a/pyrosm/utils/__init__.py
+++ b/pyrosm/utils/__init__.py
@@ -164,6 +164,24 @@ def validate_graph_type(graph_type):
     return graph_type
 
 
+def validate_engine(engine):
+    if engine not in ("in_memory", "out_of_core"):
+        raise ValueError("'engine' should be either 'in_memory' or 'out_of_core'.")
+    return engine
+
+
+def validate_workers(workers):
+    if isinstance(workers, str):
+        if workers.lower() != "auto":
+            raise ValueError("'workers' should be a positive integer, 'auto', or None.")
+        return "auto"
+    if workers is not None and (
+        not isinstance(workers, int) or isinstance(workers, bool) or workers < 1
+    ):
+        raise ValueError("'workers' should be a positive integer, 'auto', or None.")
+    return workers
+
+
 def validate_node_gdf(nodes):
     if not isinstance(nodes, gpd.GeoDataFrame):
         raise ValueError(f"'nodes' should be a GeoDataFrame, got '{type(nodes)}'.")
@@ -302,4 +320,24 @@ def warn_about_timestamp_not_set(unix_time):
         f"Reading OSH.PBF file without user-defined timestamp. Using the current UTC"
         f" time as timestamp: {unix_time_to_datetime(unix_time)}",
         UserWarning,
+    )
+
+
+def warn_about_single_core():
+    """Warn that the out-of-core engine is reading on a single core and how to opt into
+    parallelism; reports the available CPU count and is a no-op on a single-core host.
+    """
+    n_cores = os.cpu_count() or 1
+    if n_cores <= 1:
+        return
+    warnings.warn(
+        "The out-of-core engine is reading on a single core. This machine has "
+        f"{n_cores} CPU cores available; pass workers='auto' to "
+        "OSM(..., engine='out_of_core') to let pyrosm choose automatically whether the "
+        "file benefits from multiple cores or a single one, or set workers=N for an "
+        "explicit count. Parallel reads spawn worker processes on macOS/Windows, so run "
+        'them under an `if __name__ == "__main__":` guard. Pass workers=1 to silence '
+        "this message.",
+        UserWarning,
+        stacklevel=4,
     )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -236,25 +236,6 @@ def test_engine_output_requires_pyarrow(helsinki_pbf, tmp_path, monkeypatch):
         get_buildings(helsinki_pbf, output=str(tmp_path / "x.parquet"))
 
 
-def test_auto_workers_decides_on_file_size_not_blob_count(tmp_path):
-    # The default worker count is chosen by file size: parallelising only pays off above
-    # ~70 MB, and blob count must not force a pool for a small file (sparse files give a
-    # size without occupying disk).
-    import os
-
-    small = tmp_path / "small.osm.pbf"
-    small.touch()
-    os.truncate(small, pool._PARALLEL_MIN_FILE_BYTES - 1)
-    assert pool._auto_workers(str(small), 10_000) == 1
-
-    big = tmp_path / "big.osm.pbf"
-    big.touch()
-    os.truncate(big, pool._PARALLEL_MIN_FILE_BYTES + 1)
-    cpus = os.cpu_count() or 1
-    assert pool._auto_workers(str(big), 10_000) == cpus
-    assert pool._auto_workers(str(big), 2) == min(cpus, 2)
-
-
 def _fake_executor(raise_init=None, raise_map=None):
     """A ProcessPoolExecutor stand-in that runs map() in-process, optionally raising at
     construction or at map() to exercise the parallel branch and its fallback without real
@@ -1436,6 +1417,165 @@ def test_osm_engine_validation_and_unsupported_combos(helsinki_pbf):
         ooc.get_buildings(timestamp="2021-01-01 00:00:00")
     with pytest.raises(NotImplementedError):
         ooc.get_data_by_custom_criteria(custom_filter=None)
+
+
+def test_osm_workers_validation(test_pbf):
+    # The constructor-level worker count must be a positive integer, "auto", or None.
+    for bad in (0, -1, 1.5, True, "2", "bogus"):
+        with pytest.raises(ValueError, match="workers"):
+            OSM(test_pbf, workers=bad)
+    assert OSM(test_pbf).workers is None
+    assert OSM(test_pbf, workers=2).workers == 2
+    assert OSM(test_pbf, workers="auto").workers == "auto"
+    assert OSM(test_pbf, workers="AUTO").workers == "auto"  # normalized
+
+
+def test_osm_out_of_core_default_single_core_notice_and_workers(
+    helsinki_pbf, monkeypatch, fresh_cache
+):
+    # Without an explicit workers count the read uses a single worker and warns once,
+    # reporting the available CPU count; the result still matches the in-memory reader.
+    import warnings as _warnings
+    from pyrosm import utils as utils_mod
+    import pyrosm.engine.readers as readers_mod
+
+    monkeypatch.setattr(utils_mod.os, "cpu_count", lambda: 4)
+    captured = []
+    real = readers_mod._decode_and_run
+
+    def spy(filepath, osm_key_bytes, include_nodes, workers, run, **kwargs):
+        captured.append(workers)
+        return real(filepath, osm_key_bytes, include_nodes, workers, run, **kwargs)
+
+    monkeypatch.setattr(readers_mod, "_decode_and_run", spy)
+    osm = OSM(helsinki_pbf, engine="out_of_core")
+    with pytest.warns(UserWarning, match="single core") as record:
+        mine = osm.get_buildings()
+    assert captured == [1]
+    msg = str(record[0].message)
+    assert "4 CPU cores" in msg and "workers='auto'" in msg
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
+    # The notice is emitted only once per reader.
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        osm.get_buildings()
+    assert not [w for w in caught if "single core" in str(w.message)]
+
+
+def test_osm_out_of_core_explicit_workers_threaded_and_silent(
+    helsinki_pbf, monkeypatch, fresh_cache
+):
+    # An explicit workers count reaches the engine decode unchanged and suppresses the
+    # single-core notice; the read still matches the in-memory reader.
+    import warnings as _warnings
+    from pyrosm import utils as utils_mod
+    import pyrosm.engine.readers as readers_mod
+
+    monkeypatch.setattr(utils_mod.os, "cpu_count", lambda: 4)
+    captured = []
+    real = readers_mod._decode_and_run
+
+    def spy(filepath, osm_key_bytes, include_nodes, workers, run, **kwargs):
+        captured.append(workers)
+        return real(filepath, osm_key_bytes, include_nodes, workers, run, **kwargs)
+
+    monkeypatch.setattr(readers_mod, "_decode_and_run", spy)
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        mine = OSM(helsinki_pbf, engine="out_of_core", workers=1).get_buildings()
+    assert captured == [1]
+    assert not [w for w in caught if "single core" in str(w.message)]
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
+
+
+def test_osm_out_of_core_auto_workers_threaded_and_silent(
+    helsinki_pbf, monkeypatch, fresh_cache
+):
+    # workers="auto" reaches the engine unchanged (resolved there) and emits no single-core
+    # notice; the read still matches the in-memory reader. The bundled file is below the size
+    # threshold, so "auto" resolves to a single core (no worker processes are spawned).
+    import warnings as _warnings
+    import pyrosm.engine.readers as readers_mod
+
+    captured = []
+    real = readers_mod._decode_and_run
+
+    def spy(filepath, osm_key_bytes, include_nodes, workers, run, **kwargs):
+        captured.append(workers)
+        return real(filepath, osm_key_bytes, include_nodes, workers, run, **kwargs)
+
+    monkeypatch.setattr(readers_mod, "_decode_and_run", spy)
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        mine = OSM(helsinki_pbf, engine="out_of_core", workers="auto").get_buildings()
+    assert captured == ["auto"]
+    assert not [w for w in caught if "single core" in str(w.message)]
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
+
+
+def test_auto_workers_picks_single_core_for_small_files(tmp_path, monkeypatch):
+    # "auto" reads small files on a single core; above the size threshold it uses one worker
+    # per CPU core, capped at the data-blob count.
+    import os
+
+    monkeypatch.setattr(pool.os, "cpu_count", lambda: 8)
+    small = tmp_path / "small.osm.pbf"
+    small.touch()
+    os.truncate(small, pool._PARALLEL_MIN_FILE_BYTES - 1)
+    assert pool._auto_workers(str(small), 10_000) == 1
+
+    big = tmp_path / "big.osm.pbf"
+    big.touch()
+    os.truncate(big, pool._PARALLEL_MIN_FILE_BYTES + 1)
+    assert pool._auto_workers(str(big), 10_000) == 8  # cpu-bound
+    assert pool._auto_workers(str(big), 3) == 3  # blob-bound
+
+
+def test_cap_workers_reduces_above_cpu_count(monkeypatch):
+    # More workers than CPU cores is reduced to the core count with a warning; counts at or
+    # below the core count pass through unchanged and silently.
+    import warnings as _warnings
+
+    monkeypatch.setattr(pool.os, "cpu_count", lambda: 4)
+    with pytest.warns(UserWarning, match="exceeds the 4 CPU cores"):
+        assert pool._cap_workers(10) == 4
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        assert pool._cap_workers(4) == 4
+        assert pool._cap_workers(1) == 1
+
+
+def test_osm_out_of_core_single_core_host_no_notice(
+    helsinki_pbf, monkeypatch, fresh_cache
+):
+    # On a single-core host there is nothing to parallelize, so no notice is emitted.
+    import warnings as _warnings
+    from pyrosm import utils as utils_mod
+
+    monkeypatch.setattr(utils_mod.os, "cpu_count", lambda: 1)
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        OSM(helsinki_pbf, engine="out_of_core").get_buildings()
+    assert not [w for w in caught if "single core" in str(w.message)]
+
+
+def test_osm_out_of_core_excess_workers_capped(helsinki_pbf, monkeypatch, fresh_cache):
+    # An explicit worker count above the CPU-core count is reduced to the core count, with a
+    # warning; the read still matches the in-memory reader.
+    monkeypatch.setattr(pool.os, "cpu_count", lambda: 2)
+    monkeypatch.setattr(pool, "ProcessPoolExecutor", _fake_executor())
+    captured = []
+    real = pool._decode_all
+
+    def spy(filepath, blobs, workers, *args, **kwargs):
+        captured.append(workers)
+        return real(filepath, blobs, workers, *args, **kwargs)
+
+    monkeypatch.setattr(pool, "_decode_all", spy)
+    with pytest.warns(UserWarning, match="exceeds the 2 CPU cores"):
+        mine = OSM(helsinki_pbf, engine="out_of_core", workers=50).get_buildings()
+    assert captured == [2]
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
 
 
 def test_osm_out_of_core_network_nodes_parity(helsinki_pbf):


### PR DESCRIPTION
## What changed

`OSM(filepath, engine="out_of_core")` now accepts a `workers` parameter controlling how the out-of-core engine decodes the file:

- `workers=None` (default) reads on a single core. The first out-of-core read emits a one-time notice reporting how many CPU cores are available and how to opt into parallelism.
- `workers="auto"` (case-insensitive) chooses the count automatically: a single core for files below ~70 MB, otherwise one worker per CPU core, capped at the number of data blobs.
- `workers=N` decodes with N worker processes. A value above the number of CPU cores is reduced to the core count, with a warning.
- The value is validated as `None`, a positive integer, or `"auto"`.

The out-of-core engine reads on a single core by default; parallelism is opt-in via `workers`.

Other changes in the out-of-core path:

- The feature methods route to the engine readers by passing the reader function directly, replacing the previous name-based `getattr` dispatch.
- The `engine` and `workers` validation and the single-core notice live in `pyrosm/utils/__init__.py`, alongside the existing `validate_*` / `warn_about_*` helpers.

## Documentation

- The `OSM` constructor docstrings (the `engine` and `workers` parameters), the `pyrosm.engine` package docstring, and the `_get_layer` reader docstring describe the single-core default, `workers="auto"` / `workers=N`, the CPU-core cap, and the `if __name__ == "__main__":` guard required for parallel reads on macOS/Windows.
- The "Reading large datasets with the out-of-core engine" section of `docs/reading_osm_data.ipynb` covers the same, with the parallel-read guard explained in plain language.

## Tests

Added and updated tests in `tests/test_engine.py` covering: the `workers` validation and `"auto"` normalisation; that the constructor `workers` reaches the engine decode; the single-core notice (emitted once, reporting the CPU count, suppressed by an explicit count and on single-core hosts); the `"auto"` file-size policy; and the CPU-core cap and its warning. The existing out-of-core parity tests continue to assert column-for-column equality with the in-memory reader.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
