### PR TITLE
Add keep_other_tags option to out-of-core get_data_by_custom_criteria

### DIFF
--- a/pyrosm/engine/assemble.py
+++ b/pyrosm/engine/assemble.py
@@ -26,6 +26,7 @@ def _assemble_chunk(
     nodes=None,
     bounding_box=None,
     complete_relations=False,
+    keep_other_tags=True,
 ):
     """Build one GeoDataFrame from node, way and/or relation elements using pyrosm's own
     tag + geometry pipeline (full columns, missing-node handling, polygon/linestring
@@ -51,6 +52,11 @@ def _assemble_chunk(
     )
     if gdf is not None and "nodes" in gdf.columns:
         gdf = gdf.drop(columns=["nodes"])
+    # keep_other_tags=False (minimal-tags mode): drop the JSON 'tags' column of leftover tags
+    # so the result holds only the requested tags_as_columns. Usually a no-op -- the decode
+    # resolved only the requested keys, so no leftover column was built.
+    if not keep_other_tags and gdf is not None and "tags" in gdf.columns:
+        gdf = gdf.drop(columns=["tags"])
     return gdf
 
 
@@ -63,6 +69,7 @@ def _assemble_layer(
     keep_relations=True,
     bounding_box=None,
     complete_relations=False,
+    keep_other_tags=True,
 ):
     """Assemble all matching nodes, ways and relations into one in-memory GeoDataFrame."""
     collected = _collect_layer(
@@ -88,6 +95,7 @@ def _assemble_layer(
         nodes=node_features,
         bounding_box=bounding_box,
         complete_relations=complete_relations,
+        keep_other_tags=keep_other_tags,
     )
 
 

--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -23,15 +23,22 @@ _SHARD_DIR = None
 _OSM_KEYS = None
 _INCLUDE_NODES = True
 _BBOX_BOUNDS = None
+# When not None, the only tag keys (utf-8 bytes) to resolve into the element tag dicts
+# (the ``keep_other_tags=False`` minimal-tags mode); None resolves every tag.
+_REQUESTED_TAG_KEYS = None
 
 
-def _init_worker(filepath, shard_dir, osm_keys, include_nodes, bbox_bounds):
+def _init_worker(
+    filepath, shard_dir, osm_keys, include_nodes, bbox_bounds, requested_tag_keys=None
+):
     global _FILEPATH, _SHARD_DIR, _OSM_KEYS, _INCLUDE_NODES, _BBOX_BOUNDS
+    global _REQUESTED_TAG_KEYS
     _FILEPATH = filepath
     _SHARD_DIR = shard_dir
     _OSM_KEYS = osm_keys
     _INCLUDE_NODES = include_nodes
     _BBOX_BOUNDS = bbox_bounds
+    _REQUESTED_TAG_KEYS = requested_tag_keys
 
 
 def _key_indices(string_table, osm_keys):
@@ -40,15 +47,27 @@ def _key_indices(string_table, osm_keys):
     return [string_table.index(k) for k in osm_keys if k in string_table]
 
 
-def _resolve_tags(string_table, keys, vals, start, end):
+def _resolve_tags(string_table, keys, vals, start, end, keep_indices=None):
     """The ``{key: value}`` tag dict for one element, resolved through the string table
-    (decoded to str, as pyrosm's protobuf path produces)."""
+    (decoded to str, as pyrosm's protobuf path produces). When ``keep_indices`` is given,
+    only the pairs whose key is one of those string-table indices are resolved -- the
+    ``keep_other_tags=False`` minimal-tags mode that skips the unwanted tags entirely.
+    """
     return {
         string_table[keys[p]]
         .decode("utf-8", "replace"): string_table[vals[p]]
         .decode("utf-8", "replace")
         for p in range(start, end)
+        if keep_indices is None or keys[p] in keep_indices
     }
+
+
+def _requested_keep_indices(string_table):
+    """The string-table indices for ``_REQUESTED_TAG_KEYS`` (the minimal-tags keep set) in
+    this block, or ``None`` when every tag should be resolved."""
+    if _REQUESTED_TAG_KEYS is None:
+        return None
+    return set(_key_indices(string_table, _REQUESTED_TAG_KEYS))
 
 
 def _matching_ways(string_table, ways, osm_keys):
@@ -69,11 +88,14 @@ def _matching_ways(string_table, ways, osm_keys):
     # a way may carry several filter keys, so de-duplicate.
     way_index = np.unique(np.searchsorted(tags_off, key_positions, side="right") - 1)
     refs, refs_off = ways["refs"], ways["refs_off"]
+    keep_indices = _requested_keep_indices(string_table)
     return {
         "id": ways["id"][way_index],
         "refs": [refs[refs_off[i] : refs_off[i + 1]] for i in way_index],
         "tags": [
-            _resolve_tags(string_table, keys, vals, tags_off[i], tags_off[i + 1])
+            _resolve_tags(
+                string_table, keys, vals, tags_off[i], tags_off[i + 1], keep_indices
+            )
             for i in way_index
         ],
         "version": ways["version"][way_index],
@@ -94,6 +116,7 @@ def _matching_nodes(string_table, nodes, osm_keys, node_lon, node_lat):
     keys_vals = nodes["keys_vals"]
     if not key_indices or len(keys_vals) == 0:
         return None
+    keep_indices = _requested_keep_indices(string_table)
     ids = nodes["id"]
     idx, tags = [], []
     p, end = 0, len(keys_vals)
@@ -115,6 +138,7 @@ def _matching_nodes(string_table, nodes, osm_keys, node_lon, node_lat):
                     .decode("utf-8", "replace"): string_table[v]
                     .decode("utf-8", "replace")
                     for k, v in pairs
+                    if keep_indices is None or k in keep_indices
                 }
             )
     if not idx:
@@ -223,13 +247,16 @@ def _layer_relations(string_table, relations, osm_keys):
         relations["roles"],
         relations["members_off"],
     )
+    keep_indices = _requested_keep_indices(string_table)
     for i in rel_index:
         s, e = moff[i], moff[i + 1]
         member_role = np.array(
             [string_table[r].decode("utf-8", "replace") for r in roles[s:e]],
             dtype=object,
         )
-        tags = _resolve_tags(string_table, keys, vals, tags_off[i], tags_off[i + 1])
+        tags = _resolve_tags(
+            string_table, keys, vals, tags_off[i], tags_off[i + 1], keep_indices
+        )
         yield {
             "id": ids[i],
             "memid": memids[s:e],

--- a/pyrosm/engine/geoparquet.py
+++ b/pyrosm/engine/geoparquet.py
@@ -61,6 +61,7 @@ def _stream_layer_to_parquet(
     keep_relations,
     bounding_box=None,
     complete_relations=False,
+    keep_other_tags=True,
 ):
     """Stream the layer (point nodes, then ways in chunks, then relations) to a GeoParquet
     at ``output``, spilling each chunk to its own temporary parquet file and then combining
@@ -94,6 +95,7 @@ def _stream_layer_to_parquet(
             nodes=nodes,
             bounding_box=bounding_box,
             complete_relations=complete_relations,
+            keep_other_tags=keep_other_tags,
         )
         if gdf is None or len(gdf) == 0:
             return None

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -46,7 +46,14 @@ def _decode_serial(tasks, init_args):
 
 
 def _decode_all(
-    filepath, blobs, workers, shard_dir, osm_keys, include_nodes, bbox_bounds=None
+    filepath,
+    blobs,
+    workers,
+    shard_dir,
+    osm_keys,
+    include_nodes,
+    bbox_bounds=None,
+    requested_tag_keys=None,
 ):
     """Decode every data blob into per-block shards (each worker spills one shard per block
     as it is decoded); return the flat list of shard paths.
@@ -64,7 +71,14 @@ def _decode_all(
         for i in range(workers)
         if blobs[i * per : (i + 1) * per]
     ]
-    init_args = (filepath, shard_dir, osm_keys, include_nodes, bbox_bounds)
+    init_args = (
+        filepath,
+        shard_dir,
+        osm_keys,
+        include_nodes,
+        bbox_bounds,
+        requested_tag_keys,
+    )
     if workers == 1:
         return _decode_serial(tasks, init_args)
     try:
@@ -85,7 +99,13 @@ def _decode_all(
 
 
 def _decode_and_run(
-    filepath, osm_key_bytes, include_nodes, workers, run, bbox_bounds=None
+    filepath,
+    osm_key_bytes,
+    include_nodes,
+    workers,
+    run,
+    bbox_bounds=None,
+    requested_tag_keys=None,
 ):
     """Index + parallel-decode ``filepath`` into a temp shard dir, call ``run(shard_paths)``
     and clean up. The shared front half of every public read."""
@@ -110,6 +130,7 @@ def _decode_and_run(
             osm_key_bytes,
             include_nodes,
             bbox_bounds,
+            requested_tag_keys,
         )
         return run(shard_paths)
     finally:

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -14,6 +14,12 @@ from pyrosm.engine.bounding_box import _bbox_bounds, _normalize_bounding_box
 from pyrosm.engine.assemble import _assemble_layer, _assemble_network
 from pyrosm.engine import cache, geoparquet
 
+# Tags the geometry assembly reads straight from an element's tag dict (not from the exploded
+# columns): ``relations.pyx`` consults ``type`` (multipolygon/boundary) and ``area`` to decide
+# how to build a relation's geometry. They are always resolved under ``keep_other_tags=False`` so
+# relation geometries match the full read, then dropped with the other leftovers.
+_GEOMETRY_TAG_KEYS = ("type", "area")
+
 
 def _get_layer(
     filepath,
@@ -29,6 +35,7 @@ def _get_layer(
     osm_keys=None,
     bounding_box=None,
     complete_relations=False,
+    keep_other_tags=True,
 ):
     """Read a layer: decode the file in parallel selecting the elements that carry any of
     the filter keys (``osm_keys`` if given, else ``custom_filter``'s keys; and, when
@@ -54,6 +61,13 @@ def _get_layer(
         osm_keys = derived_keys
     filter_spec = (osm_keys, data_filter, filter_type)
     osm_key_bytes = [k.encode("utf-8") for k in osm_keys]
+    # keep_other_tags=False: the workers resolve only the requested tag keys -- the output
+    # columns (tags_as_columns) plus the filter keys (so the value filter still has what it
+    # checks). None lets them resolve every tag (the default).
+    requested_tag_keys = None
+    if not keep_other_tags:
+        wanted = list(tags_as_columns) + list(osm_keys) + list(_GEOMETRY_TAG_KEYS)
+        requested_tag_keys = [k.encode("utf-8") for k in dict.fromkeys(wanted)]
     bounding_box = _normalize_bounding_box(bounding_box)
     bounds = _bbox_bounds(bounding_box)
 
@@ -72,6 +86,7 @@ def _get_layer(
             "keep_relations": keep_relations,
             "bounding_box": bounding_box,
             "complete_relations": complete_relations,
+            "keep_other_tags": keep_other_tags,
         }
         cache_path = cache.result_path(filepath, key_params)
         return cache.materialize(
@@ -92,8 +107,10 @@ def _get_layer(
                     keep_relations,
                     bounding_box,
                     complete_relations,
+                    keep_other_tags=keep_other_tags,
                 ),
                 bbox_bounds=bounds,
+                requested_tag_keys=requested_tag_keys,
             )
             is not None,
         )
@@ -109,6 +126,7 @@ def _get_layer(
                 keep_relations,
                 bounding_box,
                 complete_relations,
+                keep_other_tags=keep_other_tags,
             )
         return geoparquet._stream_layer_to_parquet(
             shard_paths,
@@ -121,10 +139,17 @@ def _get_layer(
             keep_relations,
             bounding_box,
             complete_relations,
+            keep_other_tags=keep_other_tags,
         )
 
     return _decode_and_run(
-        filepath, osm_key_bytes, include_nodes, workers, run, bbox_bounds=bounds
+        filepath,
+        osm_key_bytes,
+        include_nodes,
+        workers,
+        run,
+        bbox_bounds=bounds,
+        requested_tag_keys=requested_tag_keys,
     )
 
 
@@ -361,13 +386,16 @@ def get_data_by_custom_criteria(
     workers=None,
     output=None,
     keep_metadata=True,
+    keep_other_tags=True,
 ):
     """Read OSM elements matching an arbitrary ``custom_filter`` from ``filepath`` with the
     out-of-core engine, with the same columns as
     ``OSM(...).get_data_by_custom_criteria(...)``. ``osm_keys_to_keep`` (if given) is the
     set of keys filtered on; ``keep_nodes`` / ``keep_ways`` / ``keep_relations`` select
-    which element kinds are returned; ``extra_attributes`` adds further tag columns. See
-    :func:`_get_layer` for the other keyword arguments."""
+    which element kinds are returned; ``extra_attributes`` adds further tag columns.
+    ``keep_other_tags=False`` resolves only the requested tags (``tags_as_columns`` plus the
+    filter keys) and drops the JSON ``tags`` column of leftovers, so the read does minimal
+    tag work. See :func:`_get_layer` for the other keyword arguments."""
     from pyrosm.config import Conf
     from pyrosm.utils import (
         validate_custom_filter,
@@ -409,6 +437,7 @@ def get_data_by_custom_criteria(
         osm_keys=osm_keys_to_keep,
         bounding_box=bounding_box,
         complete_relations=complete_relations,
+        keep_other_tags=keep_other_tags,
     )
 
 

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -1003,6 +1003,7 @@ class OSM:
         keep_ways=True,
         keep_relations=True,
         extra_attributes=None,
+        keep_other_tags=True,
         timestamp=None,
     ):
         """
@@ -1042,6 +1043,14 @@ class OSM:
         extra_attributes : list (optional)
             Additional OSM tag keys that will be converted into columns in the resulting GeoDataFrame.
 
+        keep_other_tags : bool
+            By default (``True``) every tag is parsed: ``tags_as_columns`` become their own
+            columns and the rest are kept in a JSON ``tags`` column. ``False`` resolves only
+            the requested tags (``tags_as_columns`` plus the filter keys) and drops the JSON
+            ``tags`` column, so the read does minimal tag work (a stray tag literally keyed
+            ``id`` is not surfaced as ``id_tag`` in this mode). Only supported by the
+            out-of-core engine (``OSM(..., engine='out_of_core')``).
+
         timestamp: str | datetime | int
             If provided, the data from given moment of time will be returned. The time should be provided in UTC.
             Note: This functionality only works with OSH.PBF files that can be downloaded manually e.g. from Geofabrik
@@ -1071,6 +1080,16 @@ class OSM:
                 keep_ways=keep_ways,
                 keep_relations=keep_relations,
                 extra_attributes=extra_attributes,
+                keep_other_tags=keep_other_tags,
+            )
+
+        # keep_other_tags=False only skips tag work in the out-of-core decode; the in-memory
+        # reader resolves every tag once and caches it for reuse across layers, so it cannot
+        # honour the minimal-tags mode.
+        if keep_other_tags is False:
+            raise ValueError(
+                "keep_other_tags=False is only supported by the out-of-core engine; "
+                "construct OSM(..., engine='out_of_core')."
             )
 
         # custom_filter=None means "return everything": keep every tagged element

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -678,6 +678,77 @@ def test_engine_custom_criteria_keep_flags_parity(helsinki_pbf, flags):
     _assert_full_parity(mine, ref)
 
 
+def test_engine_custom_criteria_keep_other_tags_false_minimal(helsinki_pbf):
+    # keep_other_tags=False returns the same elements but only the requested column(s) -- the
+    # JSON 'tags' column of leftover tags is dropped, and the rest is identical.
+    flt = {"building": True}
+    full = get_data_by_custom_criteria(
+        helsinki_pbf, custom_filter=flt, tags_as_columns=["building"], keep_other_tags=True
+    )
+    minimal = get_data_by_custom_criteria(
+        helsinki_pbf, custom_filter=flt, tags_as_columns=["building"], keep_other_tags=False
+    )
+    assert full is not None and minimal is not None
+    assert "tags" in full.columns and "tags" not in minimal.columns
+    # Same columns apart from the dropped 'tags' column, and the same elements in order.
+    assert set(full.columns) - {"tags"} == set(minimal.columns)
+    assert minimal["id"].tolist() == full["id"].tolist()
+    assert minimal["building"].fillna("").tolist() == full["building"].fillna("").tolist()
+    assert minimal.geometry.geom_type.tolist() == full.geometry.geom_type.tolist()
+
+
+def test_engine_custom_criteria_keep_other_tags_false_value_filter(helsinki_pbf):
+    # A value filter whose key is NOT a requested column still filters correctly: the filter
+    # key is resolved so the value filter works, then dropped (no 'tags' and no filter-key
+    # column in the result).
+    flt = {"amenity": ["restaurant", "cafe", "pub"]}
+    minimal = get_data_by_custom_criteria(
+        helsinki_pbf, custom_filter=flt, tags_as_columns=["name"], keep_other_tags=False
+    )
+    ref = get_data_by_custom_criteria(helsinki_pbf, custom_filter=flt)
+    assert minimal is not None and len(minimal) > 0
+    assert set(minimal["id"]) == set(ref["id"])  # the value filter still selects the same rows
+    assert "tags" not in minimal.columns
+    assert "amenity" not in minimal.columns
+    assert "name" in minimal.columns
+
+
+def test_engine_custom_criteria_keep_other_tags_default_unchanged(helsinki_pbf):
+    # The default (keep_other_tags=True) is identical to not passing it at all.
+    flt = {"building": True}
+    default = get_data_by_custom_criteria(helsinki_pbf, custom_filter=flt)
+    explicit = get_data_by_custom_criteria(
+        helsinki_pbf, custom_filter=flt, keep_other_tags=True
+    )
+    _assert_full_parity(default, explicit)
+
+
+def test_osm_custom_criteria_keep_other_tags_in_memory_rejected(helsinki_pbf):
+    # The in-memory reader caches all tags for reuse across layers, so it cannot honour the
+    # minimal-tags mode and rejects it.
+    osm = OSM(helsinki_pbf)
+    with pytest.raises(ValueError, match="only supported by the out-of-core engine"):
+        osm.get_data_by_custom_criteria({"building": True}, keep_other_tags=False)
+    # The default value leaves the in-memory path working.
+    assert (
+        osm.get_data_by_custom_criteria({"building": True}, keep_other_tags=True) is not None
+    )
+
+
+def test_engine_custom_criteria_keep_other_tags_cache_isolation(helsinki_pbf, fresh_cache):
+    # keep_other_tags is part of the result-cache key, so a minimal read does not serve (or get
+    # served by) a full-tags cached result.
+    flt = {"building": True}
+    full = get_data_by_custom_criteria(
+        helsinki_pbf, custom_filter=flt, tags_as_columns=["building"], keep_other_tags=True
+    )
+    minimal = get_data_by_custom_criteria(
+        helsinki_pbf, custom_filter=flt, tags_as_columns=["building"], keep_other_tags=False
+    )
+    assert "tags" in full.columns
+    assert "tags" not in minimal.columns
+
+
 def _count_decodes(monkeypatch):
     # Count how many times the engine decodes the PBF, to assert a cached read does not re-decode.
     import pyrosm.engine.readers as readers_mod


### PR DESCRIPTION
Adds an opt-in `keep_other_tags` parameter (default `True`) to `get_data_by_custom_criteria`. With `keep_other_tags=False`, the **out-of-core engine** resolves only the requested tags instead of every tag on each matched element, and returns a GeoDataFrame with no JSON `tags` column for the leftovers — so a caller can read "geometry + the requested key(s)" while skipping the long-tail tag parsing.

### Behaviour

- `keep_other_tags=True` (default) is unchanged: every tag is parsed, `tags_as_columns` become their own columns and the rest land in the JSON `tags` column.
- `keep_other_tags=False` resolves only the union of `tags_as_columns`, the filter keys, and the geometry-critical `type` / `area` tags. The filter keys keep value filtering correct; `type` / `area` keep relation (multipolygon/boundary) geometry identical to the full read. Anything resolved that is not a requested column (e.g. a filter-only key) is dropped together with the `tags` column, so the result holds exactly the requested columns. A stray tag literally keyed `id` is not surfaced as `id_tag` in this mode.
- Only the out-of-core engine supports it. The in-memory reader resolves all tags once and caches them for reuse across layers, so `keep_other_tags=False` raises a `ValueError` there pointing the caller at `engine="out_of_core"`.
- The per-layer result-cache key includes `keep_other_tags`, so a minimal read does not serve, or get served by, a full-tags cached result.

### Implementation

Threaded through `pyrosm.py` (public parameter + engine routing) → `engine/readers.py` (compute the requested-key set, extend the cache key) → `engine/pool.py` (hand the keys to the workers) → `engine/decode.py` (resolve only the requested keys in `_resolve_tags` / `_matching_nodes` / `_layer_relations`) → `engine/assemble.py` and `engine/geoparquet.py` (drop the leftover `tags` column). All Python — no Cython change, no rebuild.

### Verification

New tests in `tests/test_engine.py` assert: minimal output equals the full output minus the `tags` column (same elements, geometries and values, including a building relation); a value filter whose key is not a requested column still selects the right rows and yields no `tags` or filter-key column; the default path is identical to not passing the flag; the in-memory engine raises on the flag; and the result cache keeps the two modes separate.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
