### PR TITLE
Parallelize the out-of-core collect phase

### DIFF
--- a/pyrosm/_arrays.pyx
+++ b/pyrosm/_arrays.pyx
@@ -105,6 +105,14 @@ cdef convert_to_arrays_and_drop_empty(data):
 
     return arrays
 
+cpdef columns_to_arrays(data):
+    """Python entry to convert a ``{column: value-list}`` dict into the harmonized numpy
+    arrays (dropping all-None columns, applying the per-key dtypes) used to build a
+    GeoDataFrame -- the same conversion ``way_records_to_arrays`` runs, exposed so an
+    alternative reader can feed pre-split columns directly instead of rebuilding per-element
+    records first."""
+    return convert_to_arrays_and_drop_empty(data)
+
 cpdef concatenate_dicts_of_arrays(dict_list_of_arrays):
     cdef str k
 

--- a/pyrosm/engine/assemble.py
+++ b/pyrosm/engine/assemble.py
@@ -4,7 +4,6 @@ tag and geometry pipeline, so the output matches the in-memory reader column-for
 
 import numpy as np
 
-from pyrosm.data_filter import element_should_be_kept
 from pyrosm.engine.bounding_box import _in_box_nodes
 from pyrosm.engine.collect import (
     _ways_arrays,
@@ -70,8 +69,10 @@ def _assemble_layer(
     bounding_box=None,
     complete_relations=False,
     keep_other_tags=True,
+    workers=1,
 ):
-    """Assemble all matching nodes, ways and relations into one in-memory GeoDataFrame."""
+    """Assemble all matching nodes, ways and relations into one in-memory GeoDataFrame.
+    ``workers > 1`` runs the collect phase across a process pool."""
     collected = _collect_layer(
         shard_paths,
         tags_as_columns,
@@ -81,6 +82,7 @@ def _assemble_layer(
         keep_relations,
         bounding_box,
         complete_relations,
+        workers=workers,
     )
     if collected is None:
         return None
@@ -107,6 +109,7 @@ def _assemble_network(
     segments,
     bounding_box,
     filepath=None,
+    workers=1,
 ):
     """Assemble the matching highway ways as a network (LineString edges + a ``length``
     column) through pyrosm's ``parse_network`` path. Returns ``(edges, nodes)``; ``nodes``
@@ -114,25 +117,29 @@ def _assemble_network(
     (``get_network(nodes=True)``), which needs the node tags + metadata, so the coordinate
     store is gathered with a second pass over ``filepath`` rather than the lean shard lookup.
     A ``None`` ``data_filter`` (network types ``all`` / ``driving_psv``) keeps every highway
-    way."""
+    way. ``workers > 1`` runs the way read and (when ``segments`` is False) the node gather
+    across a process pool."""
     from pyrosm.frames import prepare_geodataframe
+    from pyrosm.engine.collect import _keep_fn
 
-    osm_keys, data_filter, filter_type = filter_spec
-
-    def keep(tag):
-        return data_filter is None or element_should_be_kept(
-            tag, osm_keys, data_filter, filter_type
-        )
+    keep = _keep_fn(filter_spec)
 
     in_box = _in_box_nodes(shard_paths) if bounding_box is not None else None
-    kept = _collect_kept_ways(shard_paths, np.empty(0, np.int64), keep, in_box)
+    kept = _collect_kept_ways(
+        shard_paths,
+        np.empty(0, np.int64),
+        keep,
+        in_box,
+        workers=workers,
+        filter_spec=filter_spec,
+    )
     if kept is None:
         return None, None
     needed = _needed_node_ids(kept, None)
     if segments:
         node_coordinates = _gather_node_records(filepath, needed, keep_metadata)
     else:
-        node_coordinates = _node_lookup(shard_paths, needed)
+        node_coordinates = _node_lookup(shard_paths, needed, workers)
     ways = _ways_arrays(kept, tags_as_columns, keep_metadata)
     edges, node_gdf = prepare_geodataframe(
         None,

--- a/pyrosm/engine/collect.py
+++ b/pyrosm/engine/collect.py
@@ -7,9 +7,10 @@ filter so peak memory stays bounded by the working set.
 """
 
 import numpy as np
+from rapidjson import dumps
 
-from pyrosm._arrays import way_records_to_arrays
-from pyrosm.tagparser import explode_way_tags, explode_node_tag_array
+from pyrosm._arrays import columns_to_arrays
+from pyrosm.tagparser import explode_node_tag_array
 from pyrosm.data_filter import element_should_be_kept
 from pyrosm.engine.decode import _object_array
 from pyrosm.engine.bounding_box import _in_box_nodes
@@ -21,30 +22,71 @@ _MEMBER_TYPE = {0: b"node", 1: b"way", 2: b"relation"}
 # way id -- mixing types in the lookup would attach or drop the wrong way.
 _WAY_MEMBER = 1
 
+# The standalone-way columns are carried as a dict of parallel arrays (id / nodes / tags /
+# metadata) rather than a list of per-way dicts: the shards already hold them columnar, so
+# this skips building millions of intermediate dicts (and the per-way ``.tolist()`` on the
+# node refs) on the way to the assembly's column arrays. ``nodes`` is an object array whose
+# entries are each way's int64 node-ref array.
+_WAY_COLUMNS = ("id", "nodes", "tags", "version", "timestamp", "visible")
 
-def _collect_matching_ways(shard_paths):
-    """Read the spilled matching ways back as pyrosm-shaped way records (``id``,
-    ``version``, ``timestamp``, ``visible``, ``nodes``, ``tags``)."""
-    records = []
+
+def _read_way_columns(shard_paths):
+    """Read the spilled matching ways back as a dict of parallel arrays (the columns in
+    ``_WAY_COLUMNS``). ``None`` if no shard holds a way."""
+    ids, nodes_list, tags, vers, tss, viss = [], [], [], [], [], []
     for path in shard_paths:
         z = np.load(path, allow_pickle=True)
         wid = z["way_id"]
         if len(wid) == 0:
             continue
-        off, refs, tags = z["refs_off"], z["refs"], z["way_tags"]
-        ver, ts, vis = z["way_version"], z["way_timestamp"], z["way_visible"]
-        for i in range(len(wid)):
-            records.append(
-                {
-                    "id": int(wid[i]),
-                    "version": int(ver[i]),
-                    "timestamp": int(ts[i]),
-                    "visible": bool(vis[i]),
-                    "nodes": refs[off[i] : off[i + 1]].tolist(),
-                    "tags": tags[i],
-                }
-            )
-    return records
+        off, refs = z["refs_off"], z["refs"]
+        ids.append(wid)
+        # Per-way node-ref arrays (views into the shard's flat refs); no per-way list build.
+        nodes_list.extend(np.split(refs, off[1:-1]) if len(wid) > 1 else [refs])
+        tags.append(z["way_tags"])
+        vers.append(z["way_version"])
+        tss.append(z["way_timestamp"])
+        viss.append(z["way_visible"])
+    if not ids:
+        return None
+    all_ids = np.concatenate(ids)
+    nodes = np.empty(len(all_ids), dtype=object)
+    nodes[:] = nodes_list
+    return {
+        "id": all_ids,
+        "nodes": nodes,
+        "tags": np.concatenate(tags),
+        "version": np.concatenate(vers),
+        "timestamp": np.concatenate(tss),
+        # bool to match the in-memory reader and the node features' visible column (the shard
+        # spills it as an int; a bool ``visible`` column keeps the GeoParquet schema union
+        # consistent across the node and way chunks).
+        "visible": np.concatenate(viss).astype(bool),
+    }
+
+
+def _num_ways(cols):
+    """Number of standalone ways in a way-column dict."""
+    return len(cols["id"])
+
+
+def _slice_way_columns(cols, start, stop):
+    """A row slice ``[start:stop]`` of every column -- the chunking the GeoParquet streamer
+    uses in place of slicing a list of records."""
+    return {k: v[start:stop] for k, v in cols.items()}
+
+
+def _concat_way_columns(parts):
+    """Concatenate per-partition way-column dicts (from :func:`_read_way_columns`) back into
+    one, preserving order -- the parallel way read partitions the shards into contiguous
+    ordered ranges, so concatenating the parts in order reproduces the serial shard order.
+    ``None`` if every part is empty."""
+    parts = [p for p in parts if p is not None]
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    return {k: np.concatenate([p[k] for p in parts]) for k in _WAY_COLUMNS}
 
 
 def _collect_node_features(shard_paths, tags_as_columns, keep_metadata, keep):
@@ -89,9 +131,76 @@ def _collect_node_features(shard_paths, tags_as_columns, keep_metadata, keep):
     return node_arrays
 
 
-def _node_lookup(shard_paths, needed):
-    """Gather only the coordinates of ``needed`` node ids from the shards (bounded
-    memory) and wrap them in a ``NodeLocations`` for geometry assembly."""
+def _gather_node_shards(shard_subset, needed):
+    """Gather the coordinates of the ``needed`` (sorted) node ids that a subset of shards
+    holds. Returns ``(pos, lon, lat)``: ``pos`` indexes into ``needed`` for the ids found, and
+    ``lon`` / ``lat`` their coordinates. The per-shard searchsorted lookup is the same work
+    the serial gather does; splitting the shards across workers is what parallelises it.
+    """
+    n = len(needed)
+    pos_parts, lon_parts, lat_parts = [], [], []
+    for path in shard_subset:
+        z = np.load(path, allow_pickle=True)
+        nid = z["node_id"]
+        if len(nid) == 0:
+            continue
+        pos = np.clip(np.searchsorted(needed, nid), 0, n - 1)
+        hit = needed[pos] == nid
+        if hit.any():
+            pos_parts.append(pos[hit])
+            lon_parts.append(z["node_lon"][hit])
+            lat_parts.append(z["node_lat"][hit])
+    if not pos_parts:
+        return np.empty(0, np.int64), np.empty(0), np.empty(0)
+    return (
+        np.concatenate(pos_parts),
+        np.concatenate(lon_parts),
+        np.concatenate(lat_parts),
+    )
+
+
+def _scatter_node_coords(parts, needed):
+    """Scatter the per-partition ``(pos, lon, lat)`` gathers into one coordinate store for
+    ``needed``, dropping ids no shard held (left ``NaN``). Order-independent: each hit is
+    written at its own ``needed`` position, so the partitions may arrive in any order.
+    """
+    import pandas as pd
+
+    from pyrosm.node_lookup import NodeLocations
+
+    lon = np.full(len(needed), np.nan)
+    lat = np.full(len(needed), np.nan)
+    for pos, lon_part, lat_part in parts:
+        lon[pos] = lon_part
+        lat[pos] = lat_part
+    present = ~np.isnan(lon)
+    return NodeLocations(
+        pd.DataFrame({"id": needed[present], "lon": lon[present], "lat": lat[present]})
+    )
+
+
+# Worker-side state for the parallel node gather: the sorted ``needed`` array, shared
+# read-only via a memory-mapped ``.npy`` so the OS page cache backs it across workers rather
+# than pickling it to each.
+_GATHER_NEEDED = None
+
+
+def _init_node_gather(needed_path):
+    global _GATHER_NEEDED
+    _GATHER_NEEDED = np.load(needed_path, mmap_mode="r")
+
+
+def _node_gather_worker(shard_subset):
+    return _gather_node_shards(shard_subset, _GATHER_NEEDED)
+
+
+def _node_lookup(shard_paths, needed, workers=1):
+    """Gather only the coordinates of ``needed`` node ids from the shards (bounded memory) and
+    wrap them in a ``NodeLocations`` for geometry assembly. With ``workers > 1`` the shards are
+    split across a process pool -- each worker gathers its shards against ``needed`` (shared
+    read-only via a memory-mapped ``.npy``) and the hits are scattered back -- which
+    parallelises the dominant per-shard decompress + searchsorted work; ``workers == 1`` runs
+    the same gather in this process."""
     import pandas as pd
 
     from pyrosm.node_lookup import NodeLocations
@@ -103,22 +212,20 @@ def _node_lookup(shard_paths, needed):
             pd.DataFrame({"id": empty, "lon": np.empty(0), "lat": np.empty(0)})
         )
 
-    lon = np.full(len(needed), np.nan)
-    lat = np.full(len(needed), np.nan)
-    for path in shard_paths:
-        z = np.load(path, allow_pickle=True)
-        nid = z["node_id"]
-        if len(nid) == 0:
-            continue
-        pos = np.clip(np.searchsorted(needed, nid), 0, len(needed) - 1)
-        hit = needed[pos] == nid
-        lon[pos[hit]] = z["node_lon"][hit]
-        lat[pos[hit]] = z["node_lat"][hit]
-    present = ~np.isnan(lon)
-    coords = pd.DataFrame(
-        {"id": needed[present], "lon": lon[present], "lat": lat[present]}
-    )
-    return NodeLocations(coords)
+    if workers > 1:
+        from pathlib import Path
+
+        from pyrosm.engine.pool import _run_pool
+
+        needed_path = str(Path(shard_paths[0]).parent / "needed.npy")
+        np.save(needed_path, needed)
+        partitions = [shard_paths[i::workers] for i in range(workers)]
+        parts, _ = _run_pool(
+            _node_gather_worker, partitions, workers, _init_node_gather, (needed_path,)
+        )
+        return _scatter_node_coords(parts, needed)
+
+    return _scatter_node_coords([_gather_node_shards(shard_paths, needed)], needed)
 
 
 # Node-record column dtypes for the graph-export gather (id/coords + element metadata).
@@ -176,24 +283,95 @@ def _gather_node_records(filepath, node_ids, keep_metadata):
     return NodeLocations(pd.DataFrame(frame))
 
 
-def _collect_kept_ways(shard_paths, exclude_ids, keep, in_box=None):
-    """The standalone way records to output: the spilled candidates refined by the exact
-    value filter ``keep``, then -- when reading a bounding box -- restricted to ways with at
-    least one node inside it (kept whole, so geometry is not cut at the edge), and finally
-    with the relation member ways dropped (pyrosm assigns those to the relation, so they are
-    not standalone way rows)."""
-    records = [r for r in _collect_matching_ways(shard_paths) if keep(r["tags"])]
+def _filter_way_columns(cols, exclude_ids, keep, in_box):
+    """Refine read way columns down to the standalone ways to output: the candidates passing
+    the exact value filter ``keep``, then -- when reading a bounding box -- restricted to ways
+    with at least one node inside it (kept whole, so geometry is not cut at the edge), and
+    finally with the relation member ways (``exclude_ids``) dropped (pyrosm assigns those to
+    the relation, so they are not standalone way rows). Filtering is a single ordered mask, so
+    the surviving rows keep their input order. ``None`` if nothing survives."""
+    if cols is None:
+        return None
+    tags = cols["tags"]
+    mask = np.fromiter((keep(t) for t in tags), dtype=bool, count=len(tags))
     if in_box is not None:
         inside = set(in_box.tolist())
-        records = [r for r in records if not inside.isdisjoint(r["nodes"])]
-    if not records:
-        return None
+        nodes = cols["nodes"]
+        for i in np.nonzero(mask)[0]:
+            if inside.isdisjoint(nodes[i].tolist()):
+                mask[i] = False
     if len(exclude_ids):
-        exclude = set(exclude_ids.tolist())
-        records = [r for r in records if r["id"] not in exclude]
-        if not records:
-            return None
-    return records
+        mask &= ~np.isin(cols["id"], exclude_ids)
+    if not mask.any():
+        return None
+    return {k: v[mask] for k, v in cols.items()}
+
+
+def _keep_fn(filter_spec):
+    """The exact value-filter predicate for a layer: keep an element whose resolved tags pass
+    ``filter_spec`` = ``(osm_keys, data_filter, filter_type)``. A ``None`` ``data_filter``
+    (network ``all`` / ``driving_psv``) keeps every candidate. Rebuilt from the picklable
+    ``filter_spec`` inside each parallel worker, so the serial and parallel reads filter
+    identically."""
+    osm_keys, data_filter, filter_type = filter_spec
+
+    def keep(tag):
+        return data_filter is None or element_should_be_kept(
+            tag, osm_keys, data_filter, filter_type
+        )
+
+    return keep
+
+
+def _contiguous_partitions(items, workers):
+    """Split ``items`` into ``workers`` contiguous (non-strided) blocks, dropping empties --
+    so concatenating the per-block results in order reproduces the serial order."""
+    per = (len(items) + workers - 1) // workers
+    blocks = [items[i * per : (i + 1) * per] for i in range(workers)]
+    return [b for b in blocks if b]
+
+
+# Worker-side state for the parallel standalone-way read: the value-filter predicate plus the
+# relation-member exclusion set and the bounding-box node set, set once per worker.
+_WAY_COLLECT_STATE = None
+
+
+def _init_way_collect(filter_spec, exclude_ids, in_box):
+    global _WAY_COLLECT_STATE
+    _WAY_COLLECT_STATE = (_keep_fn(filter_spec), exclude_ids, in_box)
+
+
+def _way_collect_worker(shard_subset):
+    keep, exclude_ids, in_box = _WAY_COLLECT_STATE
+    return _filter_way_columns(
+        _read_way_columns(shard_subset), exclude_ids, keep, in_box
+    )
+
+
+def _collect_kept_ways(
+    shard_paths, exclude_ids, keep, in_box=None, workers=1, filter_spec=None
+):
+    """The standalone way columns to output: read the spilled candidates and refine them by
+    the value filter, the bounding box, and the relation-member exclusion (see
+    :func:`_filter_way_columns`). With ``workers > 1`` (and a ``filter_spec`` to rebuild the
+    predicate worker-side) the shards are split into contiguous ordered ranges across a process
+    pool and the per-range columns concatenated back in order -- identical rows in identical
+    order to the serial read. ``None`` if nothing survives."""
+    if workers > 1 and filter_spec is not None:
+        from pyrosm.engine.pool import _run_pool
+
+        partitions = _contiguous_partitions(shard_paths, workers)
+        parts, _ = _run_pool(
+            _way_collect_worker,
+            partitions,
+            workers,
+            _init_way_collect,
+            (filter_spec, exclude_ids, in_box),
+        )
+        return _concat_way_columns(parts)
+    return _filter_way_columns(
+        _read_way_columns(shard_paths), exclude_ids, keep, in_box
+    )
 
 
 def _collect_relations(shard_paths, keep):
@@ -306,15 +484,73 @@ def _restrict_relations_to_box(relations, present_ids):
     return kept, member_ids
 
 
-def _ways_arrays(records, tags_as_columns, keep_metadata):
-    """Convert way records into the ``way_elements`` dict (all occurring tag columns + the
-    JSON ``tags`` column + metadata) pyrosm's assembly expects, reusing pyrosm's own
-    tag-explosion so the columns match the in-memory reader. Consumes (explodes) the
-    records. The augmentation mirrors ``get_osm_ways_and_relations``."""
-    augmented = list(tags_as_columns) + ["id", "nodes"]
+def _ways_arrays(cols, tags_as_columns, keep_metadata):
+    """Convert the standalone way columns (from :func:`_collect_kept_ways`) into the
+    ``way_elements`` dict (all occurring tag columns + the JSON ``tags`` column + metadata)
+    pyrosm's assembly expects, matching the in-memory reader column for column.
+
+    Routing mirrors ``explode_way_tags`` + ``way_records_to_arrays`` directly on the columns:
+    the requested ``tags_as_columns`` become their own columns; every other tag -- and the
+    metadata fields not promoted to a column (``version``/``timestamp`` without
+    ``keep_metadata``, ``visible`` unless requested) -- goes into the JSON ``tags`` column in
+    the same field order; a tag literally keyed ``id`` is surfaced as ``id_tag``. The tag
+    columns plus that JSON column run through pyrosm's own ``columns_to_arrays`` (per-key
+    dtypes, all-None drop), so they are byte-identical to the in-memory reader; ``id`` and the
+    kept metadata go through the same conversion, and ``nodes`` is attached directly as the
+    per-way node-ref arrays (it only feeds geometry and is dropped before output)."""
+    ids, nodes, tags = cols["id"], cols["nodes"], cols["tags"]
+    version, timestamp, visible = cols["version"], cols["timestamp"], cols["visible"]
+    n = len(ids)
+    column_keys = list(dict.fromkeys(list(tags_as_columns) + ["id", "nodes"]))
     if keep_metadata:
-        augmented += ["timestamp", "version"]
-    return way_records_to_arrays(explode_way_tags(records), augmented)
+        column_keys += ["timestamp", "version"]
+    column_set = set(column_keys)
+    structural = ("id", "nodes", "version", "timestamp", "visible")
+    tag_cols = [k for k in column_keys if k not in structural]
+    tag_col_set = set(tag_cols)
+    version_col = "version" in column_set
+    timestamp_col = "timestamp" in column_set
+    visible_col = "visible" in column_set
+
+    # One pass over the tag dicts: fill the requested tag columns (None where absent) and the
+    # leftover JSON, replicating explode_way_tags + way_records_to_arrays field ordering.
+    col_lists = {k: [None] * n for k in tag_cols}
+    leftover = [None] * n
+    has_leftover = False
+    for i in range(n):
+        tag = tags[i]
+        other = {}
+        if not version_col:
+            other["version"] = int(version[i])
+        if not timestamp_col:
+            other["timestamp"] = int(timestamp[i])
+        if not visible_col:
+            other["visible"] = bool(visible[i])
+        for k, v in tag.items():
+            key = "id_tag" if k == "id" else k
+            if key in tag_col_set:
+                col_lists[key][i] = v
+            else:
+                other[key] = v
+        if other:
+            leftover[i] = dumps(other)
+            has_leftover = True
+
+    # Tag columns, id, and kept metadata go through pyrosm's own conversion (per-key dtypes,
+    # all-None drop) so they match the in-memory reader; nodes are attached as arrays after.
+    data = dict(col_lists)
+    data["id"] = ids
+    if version_col:
+        data["version"] = version
+    if timestamp_col:
+        data["timestamp"] = timestamp
+    if visible_col:
+        data["visible"] = visible
+    if has_leftover:
+        data["tags"] = leftover
+    ways = columns_to_arrays(data)
+    ways["nodes"] = nodes
+    return ways
 
 
 def _needed_node_ids(kept, relation_ways):
@@ -327,7 +563,7 @@ def _needed_node_ids(kept, relation_ways):
 
     refs = []
     if kept is not None:
-        refs.extend(r["nodes"] for r in kept)
+        refs.extend(kept["nodes"])
     if relation_ways is not None:
         refs.extend(relation_ways["nodes"])
     if not refs:
@@ -346,6 +582,7 @@ def _collect_layer(
     keep_relations=True,
     bounding_box=None,
     complete_relations=False,
+    workers=1,
 ):
     """Shared collection for both output modes: node features, standalone ways, relations,
     their member ways and the node coordinates the ways/relations reference. ``filter_spec``
@@ -353,12 +590,11 @@ def _collect_layer(
     refined here by pyrosm's exact value filter. ``keep_ways`` / ``keep_relations`` drop
     those element kinds from the output (``get_data_by_custom_criteria``). With a
     ``bounding_box`` only in-box ways/nodes are kept; relation member ways are likewise
-    restricted to in-box (partial geometry) unless ``complete_relations``. ``None`` if there
-    is nothing to assemble."""
-    osm_keys, data_filter, filter_type = filter_spec
-
-    def keep(tag):
-        return element_should_be_kept(tag, osm_keys, data_filter, filter_type)
+    restricted to in-box (partial geometry) unless ``complete_relations``. ``workers > 1``
+    splits the standalone-way read and the node-coordinate gather (the dominant costs) across a
+    process pool; the comparatively small relation and node-feature reads stay serial.
+    ``None`` if there is nothing to assemble."""
+    keep = _keep_fn(filter_spec)
 
     in_box = _in_box_nodes(shard_paths) if bounding_box is not None else None
     if keep_relations:
@@ -384,12 +620,23 @@ def _collect_layer(
         # been members stay as standalone ways (matching get_data_by_custom_criteria).
         relations, relation_ways, member_ids = None, None, np.empty(0, np.int64)
     kept = (
-        _collect_kept_ways(shard_paths, member_ids, keep, in_box) if keep_ways else None
+        _collect_kept_ways(
+            shard_paths,
+            member_ids,
+            keep,
+            in_box,
+            workers=workers,
+            filter_spec=filter_spec,
+        )
+        if keep_ways
+        else None
     )
     node_features = _collect_node_features(
         shard_paths, tags_as_columns, keep_metadata, keep
     )
     if kept is None and relations is None and node_features is None:
         return None
-    node_coordinates = _node_lookup(shard_paths, _needed_node_ids(kept, relation_ways))
+    node_coordinates = _node_lookup(
+        shard_paths, _needed_node_ids(kept, relation_ways), workers
+    )
     return node_features, kept, relations, relation_ways, node_coordinates

--- a/pyrosm/engine/collect.py
+++ b/pyrosm/engine/collect.py
@@ -319,7 +319,12 @@ def _ways_arrays(records, tags_as_columns, keep_metadata):
 
 def _needed_node_ids(kept, relation_ways):
     """The unique node ids referenced by the kept standalone ways and the relation
-    member ways -- the only coordinates the gather has to pull off disk."""
+    member ways -- the only coordinates the gather has to pull off disk. Returned sorted
+    (the node gather's searchsorted lookup needs it ordered); the unique set is built with
+    pandas' hashtable rather than ``np.unique``'s sort, which is markedly faster on the
+    tens of millions of refs a country-scale read produces."""
+    import pandas as pd
+
     refs = []
     if kept is not None:
         refs.extend(r["nodes"] for r in kept)
@@ -327,7 +332,9 @@ def _needed_node_ids(kept, relation_ways):
         refs.extend(relation_ways["nodes"])
     if not refs:
         return np.empty(0, np.int64)
-    return np.unique(np.concatenate(refs))
+    unique = pd.unique(np.concatenate(refs))
+    unique.sort()
+    return unique
 
 
 def _collect_layer(

--- a/pyrosm/engine/geoparquet.py
+++ b/pyrosm/engine/geoparquet.py
@@ -12,7 +12,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from pyrosm.engine.collect import _collect_layer
+from pyrosm.engine.collect import _collect_layer, _num_ways, _slice_way_columns
 from pyrosm.engine.assemble import _assemble_chunk
 
 # Assemble and write this many ways per chunk, so the output frame is never fully
@@ -62,11 +62,12 @@ def _stream_layer_to_parquet(
     bounding_box=None,
     complete_relations=False,
     keep_other_tags=True,
+    workers=1,
 ):
     """Stream the layer (point nodes, then ways in chunks, then relations) to a GeoParquet
     at ``output``, spilling each chunk to its own temporary parquet file and then combining
     the files under the union of their schemas. Returns the path, or ``None`` if there was
-    nothing to write."""
+    nothing to write. ``workers > 1`` runs the collect phase across a process pool."""
     import pyarrow.parquet as pq
     from geopandas.io.arrow import _geopandas_to_arrow
 
@@ -79,6 +80,7 @@ def _stream_layer_to_parquet(
         keep_relations,
         bounding_box,
         complete_relations,
+        workers=workers,
     )
     if collected is None:
         return None
@@ -107,8 +109,10 @@ def _stream_layer_to_parquet(
             if table is not None:
                 yield table
         if kept is not None:
-            for start in range(0, len(kept), chunk_size):
-                table = to_table(way_records=kept[start : start + chunk_size])
+            for start in range(0, _num_ways(kept), chunk_size):
+                table = to_table(
+                    way_records=_slice_way_columns(kept, start, start + chunk_size)
+                )
                 if table is not None:
                     yield table
         if relations is not None:

--- a/pyrosm/engine/pool.py
+++ b/pyrosm/engine/pool.py
@@ -38,11 +38,40 @@ def _cap_workers(workers):
     return workers
 
 
-def _decode_serial(tasks, init_args):
-    """Decode every task in this process (the single-process path and the parallel
-    fallback). Returns the flat list of shard paths."""
-    _init_worker(*init_args)
-    return [path for task in tasks for path in _decode_batch(task)]
+def _run_pool(func, tasks, workers, initializer, initargs, fallback_warning=None):
+    """Map ``func`` over ``tasks`` across a process pool of ``workers`` (each worker process
+    initialised with ``initializer(*initargs)``); return ``(results, pool_ok)`` -- the
+    per-task results in task order, and whether the pool actually ran.
+
+    ``workers == 1`` runs every task in this process (no pool, ``pool_ok`` False). A pool that
+    cannot start (``OSError`` in an environment that forbids pools) or whose workers die on
+    start (``BrokenProcessPool`` -- e.g. a read not guarded by ``if __name__ == "__main__":``,
+    so each spawned worker re-imports and re-runs the entry point) falls back to a single
+    process and reports ``pool_ok`` False, so a later phase can stay serial instead of
+    re-attempting a pool that cannot start. ``fallback_warning`` (when given) is emitted on
+    that fallback; passing ``None`` keeps a downstream phase from warning a second time after
+    the decode already did."""
+    if workers == 1:
+        initializer(*initargs)
+        return [func(task) for task in tasks], False
+    try:
+        with ProcessPoolExecutor(
+            max_workers=workers, initializer=initializer, initargs=initargs
+        ) as pool:
+            return list(pool.map(func, tasks)), True
+    except (BrokenProcessPool, OSError):
+        if fallback_warning is not None:
+            warnings.warn(fallback_warning, RuntimeWarning, stacklevel=2)
+        initializer(*initargs)
+        return [func(task) for task in tasks], False
+
+
+_DECODE_FALLBACK_WARNING = (
+    "Parallel decoding could not start and fell back to a single process. This happens when "
+    'the read is not inside an `if __name__ == "__main__":` block (the worker processes '
+    "cannot re-import the entry point), or in environments that forbid process pools. Guard "
+    "the entry point, or pass workers=1 to silence this."
+)
 
 
 def _decode_all(
@@ -55,15 +84,10 @@ def _decode_all(
     bbox_bounds=None,
     requested_tag_keys=None,
 ):
-    """Decode every data blob into per-block shards (each worker spills one shard per block
-    as it is decoded); return the flat list of shard paths.
-
-    Parallel decoding uses a process pool. ``ProcessPoolExecutor`` reports a broken pool
-    instead of endlessly respawning dead workers (which would hang), so two failure modes
-    fall back to a single process with a warning rather than hanging or erroring: the read
-    running in a module not guarded by ``if __name__ == "__main__":`` (each spawned worker
-    re-imports and re-runs it, so the workers die on start), and environments that forbid
-    creating a process pool at all."""
+    """Decode every data blob into per-block shards (each worker spills one shard per block as
+    it is decoded). Returns ``(shard_paths, pool_ok)`` -- the flat list of shard paths and
+    whether the decode pool ran (so the collect phase can mirror it instead of re-attempting a
+    pool that could not start)."""
     n = len(blobs)
     per = (n + workers - 1) // workers
     tasks = [
@@ -79,23 +103,10 @@ def _decode_all(
         bbox_bounds,
         requested_tag_keys,
     )
-    if workers == 1:
-        return _decode_serial(tasks, init_args)
-    try:
-        with ProcessPoolExecutor(
-            max_workers=workers, initializer=_init_worker, initargs=init_args
-        ) as pool:
-            return [path for paths in pool.map(_decode_batch, tasks) for path in paths]
-    except (BrokenProcessPool, OSError):
-        warnings.warn(
-            "Parallel decoding could not start and fell back to a single process. This "
-            'happens when the read is not inside an `if __name__ == "__main__":` block (the '
-            "worker processes cannot re-import the entry point), or in environments that "
-            "forbid process pools. Guard the entry point, or pass workers=1 to silence this.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
-        return _decode_serial(tasks, init_args)
+    results, pool_ok = _run_pool(
+        _decode_batch, tasks, workers, _init_worker, init_args, _DECODE_FALLBACK_WARNING
+    )
+    return [path for paths in results for path in paths], pool_ok
 
 
 def _decode_and_run(
@@ -107,8 +118,12 @@ def _decode_and_run(
     bbox_bounds=None,
     requested_tag_keys=None,
 ):
-    """Index + parallel-decode ``filepath`` into a temp shard dir, call ``run(shard_paths)``
-    and clean up. The shared front half of every public read."""
+    """Index + parallel-decode ``filepath`` into a temp shard dir, call
+    ``run(shard_paths, collect_workers)`` and clean up. The shared front half of every public
+    read. ``collect_workers`` is the worker count the collect phase should use: the resolved
+    decode worker count when the decode pool ran, otherwise 1 -- so after a decode fallback
+    (unguarded entry point or a pool-forbidden environment) the collect phase stays serial
+    instead of re-attempting a pool that cannot start (and warning a second time)."""
     data_blobs = [
         (offset, size)
         for (blob_type, offset, size) in _index_blobs(filepath)
@@ -122,7 +137,7 @@ def _decode_and_run(
         workers = _cap_workers(workers)
     shard_dir = tempfile.mkdtemp(prefix="pyrosm_ooc_")
     try:
-        shard_paths = _decode_all(
+        shard_paths, pool_ok = _decode_all(
             filepath,
             data_blobs,
             workers,
@@ -132,6 +147,7 @@ def _decode_and_run(
             bbox_bounds,
             requested_tag_keys,
         )
-        return run(shard_paths)
+        collect_workers = workers if pool_ok else 1
+        return run(shard_paths, collect_workers)
     finally:
         shutil.rmtree(shard_dir, ignore_errors=True)

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -96,7 +96,7 @@ def _get_layer(
                 osm_key_bytes,
                 include_nodes,
                 workers,
-                lambda shard_paths: geoparquet._stream_layer_to_parquet(
+                lambda shard_paths, collect_workers: geoparquet._stream_layer_to_parquet(
                     shard_paths,
                     tmp_path,
                     geoparquet._OUTPUT_CHUNK_SIZE,
@@ -108,6 +108,7 @@ def _get_layer(
                     bounding_box,
                     complete_relations,
                     keep_other_tags=keep_other_tags,
+                    workers=collect_workers,
                 ),
                 bbox_bounds=bounds,
                 requested_tag_keys=requested_tag_keys,
@@ -115,7 +116,7 @@ def _get_layer(
             is not None,
         )
 
-    def run(shard_paths):
+    def run(shard_paths, collect_workers):
         if output is None:
             return _assemble_layer(
                 shard_paths,
@@ -127,6 +128,7 @@ def _get_layer(
                 bounding_box,
                 complete_relations,
                 keep_other_tags=keep_other_tags,
+                workers=collect_workers,
             )
         return geoparquet._stream_layer_to_parquet(
             shard_paths,
@@ -140,6 +142,7 @@ def _get_layer(
             bounding_box,
             complete_relations,
             keep_other_tags=keep_other_tags,
+            workers=collect_workers,
         )
 
     return _decode_and_run(
@@ -589,7 +592,7 @@ def get_network(
     if output is not None:
         _compat.require_pyarrow()
 
-    def assemble(shard_paths):
+    def assemble(shard_paths, collect_workers):
         edges, node_gdf = _assemble_network(
             shard_paths,
             tags_as_columns,
@@ -598,6 +601,7 @@ def get_network(
             nodes,
             bounding_box,
             filepath=filepath,
+            workers=collect_workers,
         )
         return (node_gdf, edges) if nodes else edges
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -291,6 +291,97 @@ def test_engine_parallel_decode_falls_back_to_serial(
     _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
 
 
+def _make_way_partition(ids):
+    # A standalone-way column dict (as _collect_kept_ways returns) for `ids`, one node ref each.
+    nodes = np.empty(len(ids), dtype=object)
+    for i, wid in enumerate(ids):
+        nodes[i] = np.array([wid * 10], np.int64)
+    return {
+        "id": np.array(ids, np.int64),
+        "nodes": nodes,
+        "tags": np.array([{} for _ in ids], dtype=object),
+        "version": np.array([1] * len(ids), np.int64),
+        "timestamp": np.array([1] * len(ids), np.int64),
+        "visible": np.array([True] * len(ids)),
+    }
+
+
+def test_engine_concat_way_columns_preserves_order_and_skips_none():
+    # The parallel way read concatenates contiguous per-worker partitions; the combine must
+    # keep them in worker order (= serial shard order) and skip empty (None) partitions.
+    from pyrosm.engine.collect import _concat_way_columns
+
+    p1 = _make_way_partition([1, 2])
+    p2 = _make_way_partition([3, 4])
+    out = _concat_way_columns([p1, None, p2])
+    assert list(out["id"]) == [1, 2, 3, 4]
+    assert [n.tolist() for n in out["nodes"]] == [[10], [20], [30], [40]]
+    assert _concat_way_columns([None, None]) is None
+    assert _concat_way_columns([p1]) is p1  # single partition returned as-is
+
+
+def test_engine_scatter_node_coords_combines_partitions():
+    # The pooled node gather returns per-partition (pos, lon, lat) into `needed`; the scatter
+    # must place each hit at its needed position and drop ids no partition held.
+    from pyrosm.engine.collect import _scatter_node_coords
+
+    needed = np.array([10, 20, 30, 40], np.int64)
+    part_a = (np.array([0, 2]), np.array([1.0, 3.0]), np.array([1.5, 3.5]))
+    part_b = (np.array([1]), np.array([2.0]), np.array([2.5]))
+    nc = _scatter_node_coords([part_a, part_b], needed)
+    idx, lon, lat = nc.gather(needed)
+    # id 40 (position 3) was in no partition -> absent.
+    assert (idx >= 0).tolist() == [True, True, True, False]
+    assert lon[:3].tolist() == [1.0, 2.0, 3.0]
+    assert lat[:3].tolist() == [1.5, 2.5, 3.5]
+
+
+@pytest.mark.parametrize("read", ["buildings", "pois", "network"])
+def test_engine_parallel_collect_matches_serial(read, helsinki_pbf, monkeypatch):
+    # The parallel collect path (contiguous way-shard ranges concatenated in order + the pooled
+    # node-coordinate gather) must yield exactly the serial result -- same rows in the same
+    # order -- and match the in-memory reader. HAS_PYARROW=False bypasses the result cache so
+    # both reads actually run; the fake executor runs the pools in-process.
+    from pyrosm.utils import _compat
+
+    monkeypatch.setattr(_compat, "HAS_PYARROW", False)
+    monkeypatch.setattr(pool.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(pool, "ProcessPoolExecutor", _fake_executor())
+
+    fn = {"buildings": get_buildings, "pois": get_pois, "network": get_network}[read]
+    ref = {
+        "buildings": lambda: OSM(helsinki_pbf).get_buildings(),
+        "pois": lambda: OSM(helsinki_pbf).get_pois(),
+        "network": lambda: OSM(helsinki_pbf).get_network(),
+    }[read]()
+
+    parallel = fn(helsinki_pbf, workers=3)
+    serial = fn(helsinki_pbf, workers=1)
+    # Identical rows in identical order (the ordering contract), not just the same set.
+    assert list(parallel["id"]) == list(serial["id"])
+    assert parallel.geometry.geom_equals_exact(serial.geometry, tolerance=0).all()
+    _assert_full_parity(parallel, ref)
+
+
+def test_engine_collect_stays_serial_after_decode_fallback(
+    helsinki_pbf, monkeypatch, fresh_cache
+):
+    # When the decode pool cannot start, the collect phase must run serial too (not re-attempt
+    # a pool that cannot start) and emit no second fallback warning -- exactly one warning, the
+    # decode's, and the result still matches the in-memory reader. fresh_cache forces the read
+    # to decode rather than serve a cached result.
+    import warnings as _warnings
+
+    monkeypatch.setattr(pool.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(pool, "ProcessPoolExecutor", _fake_executor(raise_init=OSError))
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        mine = get_buildings(helsinki_pbf, workers=3)
+    fallbacks = [w for w in caught if "single process" in str(w.message)]
+    assert len(fallbacks) == 1
+    _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
+
+
 def test_engine_unguarded_module_read_does_not_hang(test_pbf, tmp_path):
     # A read at module level (no `if __name__ == "__main__":` guard) must not hang: the
     # spawned workers cannot re-import the entry point, so the decode falls back to a single
@@ -432,7 +523,7 @@ def test_engine_matching_ways_early_returns():
 
 def test_engine_collect_empty_and_edge_shards(tmp_path):
     from pyrosm.engine.collect import (
-        _collect_matching_ways,
+        _read_way_columns,
         _collect_kept_ways,
         _collect_node_features,
         _node_lookup,
@@ -450,7 +541,7 @@ def test_engine_collect_empty_and_edge_shards(tmp_path):
 
     empty = str(tmp_path / "empty.npz")
     _write_shard(empty)
-    assert _collect_matching_ways([empty]) == []
+    assert _read_way_columns([empty]) is None
     assert _collect_kept_ways([empty], np.empty(0, np.int64), keep_all) is None
     assert _collect_node_features([empty], [], True, keep_all) is None
     assert _node_lookup([empty], np.array([1, 2], np.int64)) is not None
@@ -519,7 +610,7 @@ def test_engine_stream_parquet_chunk_table_branches(
     data_blobs = [(o, s) for (t, o, s) in _index_blobs(helsinki_pbf) if t == "OSMData"]
     shard_dir = tempfile.mkdtemp()
     try:
-        shards = _decode_all(
+        shards, _ = _decode_all(
             helsinki_pbf, data_blobs, 1, shard_dir, [b"building"], False
         )
         node_features, kept, relations, relation_ways, nc = _collect_layer(
@@ -545,16 +636,16 @@ def test_engine_stream_parquet_chunk_table_branches(
         # ways only (no relations): relation branch skipped.
         assert write((None, kept, None, None, nc)) is not None
         # a way referencing an absent node assembles empty -> no parts -> None.
-        absent = [
-            {
-                "id": -1,
-                "version": 1,
-                "timestamp": 1,
-                "visible": True,
-                "nodes": [10**18],
-                "tags": {"building": "yes"},
-            }
-        ]
+        absent_nodes = np.empty(1, dtype=object)
+        absent_nodes[0] = np.array([10**18], np.int64)
+        absent = {
+            "id": np.array([-1], np.int64),
+            "nodes": absent_nodes,
+            "tags": np.array([{"building": "yes"}], dtype=object),
+            "version": np.array([1], np.int64),
+            "timestamp": np.array([1], np.int64),
+            "visible": np.array([True]),
+        }
         assert write((None, absent, None, None, nc)) is None
         # a relation whose member ways are all absent assembles empty -> chunk skipped.
         empty_ways = {"id": np.empty(0, np.int64), "nodes": np.empty(0, dtype=object)}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -382,6 +382,25 @@ def test_engine_collect_stays_serial_after_decode_fallback(
     _assert_full_parity(mine, OSM(helsinki_pbf).get_buildings())
 
 
+def test_engine_run_pool_silent_fallback_without_warning(monkeypatch):
+    # _run_pool with no fallback_warning (the collect phase's call) must fall back to a single
+    # process *silently* when the pool cannot start -- the decode already warned, so a later
+    # phase does not warn a second time. Still runs every task and reports pool_ok=False.
+    import warnings as _warnings
+
+    monkeypatch.setattr(pool, "ProcessPoolExecutor", _fake_executor(raise_init=OSError))
+    inits = []
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        results, pool_ok = pool._run_pool(
+            lambda t: t * 2, [1, 2, 3], 3, lambda: inits.append(1), ()
+        )
+    assert results == [2, 4, 6]
+    assert pool_ok is False
+    assert inits == [1]  # initializer ran once for the serial fallback
+    assert [w for w in caught if issubclass(w.category, RuntimeWarning)] == []
+
+
 def test_engine_unguarded_module_read_does_not_hang(test_pbf, tmp_path):
     # A read at module level (no `if __name__ == "__main__":` guard) must not hang: the
     # spawned workers cannot re-import the entry point, so the decode falls back to a single


### PR DESCRIPTION
Parallelizes the out-of-core engine's **collect** phase (reading the spilled shards back into way/node records and gathering the referenced node coordinates), which was single-process while decode already used a pool, and replaces the per-way dict round-trip with array-native columns. On a country-scale read this is the dominant remaining serial cost.

### What changed

- **Array-native way records.** The standalone ways are carried from the shards as a dict of parallel arrays (`id` / `nodes` / `tags` / metadata) instead of a list of per-way dicts, skipping the build of millions of intermediate dicts and the per-way `.tolist()` on the node refs. The tag/metadata routing (requested tag columns, the JSON `tags` leftover, `id`→`id_tag`, all-None drop, per-key dtypes) reuses pyrosm's own column conversion — newly exposed as `_arrays.columns_to_arrays` — so the output stays column-for-column and value-for-value identical to the in-memory reader.
- **Faster needed-id set.** The unique referenced-node-id set uses pandas' hashtable (`pd.unique` + sort) instead of `np.unique`'s sort, returning the same sorted array the coordinate gather's `searchsorted` needs.
- **Parallel node-coordinate gather.** With more than one worker the node shards are split across a process pool; each worker gathers its shards against the sorted needed-id array (shared read-only via a memory-mapped `.npy`) and the hits are scattered back. The gather is order-independent (each hit is written at its own needed position).
- **Parallel standalone-way read.** The way shards are split into contiguous, ordered ranges across the pool, the value filter and array-native conversion run per range, and the per-range columns are concatenated strictly in worker order — identical rows in identical order to the serial read.
- **Pool plumbing.** A single pool helper (factored out of decode) maps a function over a process pool with the existing single-process fallback. The decode reports whether its pool actually ran; the collect phase mirrors that effective worker count, so after a decode fallback (an unguarded entry point or a pool-forbidden environment) collect runs serial without re-attempting a pool and without a second fallback warning. Small files (a single worker) stay fully serial.

### Verification

- Parity against the in-memory reader across the engine suite — buildings, landuse, natural, pois, boundaries, relations, every network type, bounding boxes, and the `keep_metadata` / `keep_other_tags` modes — comparing columns, values (including the JSON `tags` strings) and exact geometry. New tests assert the parallel collect path yields the same rows in the same order as the serial read for an area layer with relations, a point layer with nodes, and the network, and that collect stays serial (one fallback warning) when the decode pool cannot start; the combine and scatter helpers are unit-tested directly.
- Small-file timing on the Helsinki region (serial, the path small files take), median of repeated runs with the cache cleared each time: buildings ~1.14× and the road network ~1.18× faster than before, since the array-native collect removes per-element overhead — so the change does not regress small files.
- The parallel node-coordinate gather measured ~3.65× over the serial gather in a standalone prototype on a country extract (Finland, 10 cores), with the gathered coordinates byte-identical to the serial path.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.