### PR TITLE
Allow downloading whole-continent extracts with get_data

### DIFF
--- a/pyrosm/data/__init__.py
+++ b/pyrosm/data/__init__.py
@@ -165,6 +165,12 @@ def _find_sources(name):
     """
     found = []
     for source, available in sources.available.items():
+        # Continent-level whole-extract download: the source key itself names the
+        # extract (e.g. 'south_america' -> south-america-latest.osm.pbf), so a
+        # whole continent can be downloaded, not just its sub-regions. The 'cities'
+        # and 'subregions' groupings carry no continent file and are skipped.
+        if name == source and source not in ("cities", "subregions"):
+            found.append((source, sources.__dict__[source].continent))
         # Cities are kept as CamelCase, so need to make lower
         if source == "cities":
             if name in [src.lower() for src in available]:

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -83,3 +83,17 @@ def test_search_source_resolves_known_names(name, fragment):
 def test_search_source_unknown_name_raises():
     with pytest.raises((ValueError, KeyError)):
         search_source("not_a_real_place_xyz")
+
+
+@pytest.mark.parametrize("continent", CONTINENTS)
+def test_continent_whole_extract_resolves(continent):
+    # The continent name itself resolves to the whole-continent Geofabrik extract
+    # (e.g. 'south_america' -> south-america-latest.osm.pbf), so get_data(continent)
+    # downloads the entire continent rather than raising. The name is also reachable
+    # through get_data's resolution (present in the source index).
+    from pyrosm.data import sources as _sources
+
+    rec = search_source(continent)
+    assert isinstance(rec, dict)
+    assert rec["url"].endswith(continent.replace("_", "-") + "-latest.osm.pbf")
+    assert continent in _sources._all_sources


### PR DESCRIPTION
`get_data("south_america")` (and every other continent name) raised `ValueError: Could not retrieve url for '<continent>'` even though the whole-continent extract URL was already present in the source objects (`sources.<continent>.continent`). The name resolver `_find_sources` only matched a query against each region's list of countries, never the continent key itself, so continents were reachable as data but not downloadable through the public `get_data` / `search_source` API.

### What changed

`_find_sources` now also matches the continent key and returns that continent's `.continent` download record (the `*-latest.osm.pbf` whole-continent extract). The `cities` and `subregions` groupings are skipped — they carry no continent file, and their accessors raise `KeyError` rather than `AttributeError` so they cannot be probed with `getattr`.

```python
get_data("south_america")    # -> south-america-latest.osm.pbf
get_data("south america")    # space / hyphen / case variants resolve via the existing normalisation
get_data("europe")           # every continent works the same way
```

Individual country, sub-region and city downloads are unchanged; the continent key cannot collide with a country name, so no lookup becomes ambiguous.

### Verification

New parametrised tests assert each of the eight continents resolves through `search_source` to its `<continent>-latest.osm.pbf` extract and is present in the source index that `get_data` resolves against (offline — no network I/O). The existing country / sub-region / city resolution tests are unchanged.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.