### PR TITLE
Skip the dropped leftover-JSON build in keep_other_tags=False reads

### DIFF
--- a/pyrosm/engine/assemble.py
+++ b/pyrosm/engine/assemble.py
@@ -34,7 +34,7 @@ def _assemble_chunk(
     from pyrosm.frames import prepare_geodataframe
 
     ways = (
-        _ways_arrays(way_records, tags_as_columns, keep_metadata)
+        _ways_arrays(way_records, tags_as_columns, keep_metadata, keep_other_tags)
         if way_records
         else None
     )
@@ -52,8 +52,8 @@ def _assemble_chunk(
     if gdf is not None and "nodes" in gdf.columns:
         gdf = gdf.drop(columns=["nodes"])
     # keep_other_tags=False (minimal-tags mode): drop the JSON 'tags' column of leftover tags
-    # so the result holds only the requested tags_as_columns. Usually a no-op -- the decode
-    # resolved only the requested keys, so no leftover column was built.
+    # so the result holds only the requested tags_as_columns. _ways_arrays already skips
+    # building it for ways; this also covers a 'tags' column that a relation chunk produced.
     if not keep_other_tags and gdf is not None and "tags" in gdf.columns:
         gdf = gdf.drop(columns=["tags"])
     return gdf

--- a/pyrosm/engine/collect.py
+++ b/pyrosm/engine/collect.py
@@ -484,7 +484,7 @@ def _restrict_relations_to_box(relations, present_ids):
     return kept, member_ids
 
 
-def _ways_arrays(cols, tags_as_columns, keep_metadata):
+def _ways_arrays(cols, tags_as_columns, keep_metadata, keep_other_tags=True):
     """Convert the standalone way columns (from :func:`_collect_kept_ways`) into the
     ``way_elements`` dict (all occurring tag columns + the JSON ``tags`` column + metadata)
     pyrosm's assembly expects, matching the in-memory reader column for column.
@@ -497,7 +497,12 @@ def _ways_arrays(cols, tags_as_columns, keep_metadata):
     columns plus that JSON column run through pyrosm's own ``columns_to_arrays`` (per-key
     dtypes, all-None drop), so they are byte-identical to the in-memory reader; ``id`` and the
     kept metadata go through the same conversion, and ``nodes`` is attached directly as the
-    per-way node-ref arrays (it only feeds geometry and is dropped before output)."""
+    per-way node-ref arrays (it only feeds geometry and is dropped before output).
+
+    With ``keep_other_tags=False`` the leftover JSON ``tags`` column is dropped by the caller,
+    so it is not built at all here -- only the requested tag columns are filled. This skips a
+    per-way ``rapidjson.dumps`` (the metadata/leftover serialisation) that would otherwise be
+    discarded, which is a noticeable saving on country-scale minimal-tags reads."""
     ids, nodes, tags = cols["id"], cols["nodes"], cols["tags"]
     version, timestamp, visible = cols["version"], cols["timestamp"], cols["visible"]
     n = len(ids)
@@ -512,25 +517,27 @@ def _ways_arrays(cols, tags_as_columns, keep_metadata):
     timestamp_col = "timestamp" in column_set
     visible_col = "visible" in column_set
 
-    # One pass over the tag dicts: fill the requested tag columns (None where absent) and the
-    # leftover JSON, replicating explode_way_tags + way_records_to_arrays field ordering.
+    # One pass over the tag dicts: fill the requested tag columns (None where absent) and --
+    # only when the leftover JSON is kept -- the ``tags`` column, replicating explode_way_tags
+    # + way_records_to_arrays field ordering. ``other is None`` is the skip-leftovers sentinel.
     col_lists = {k: [None] * n for k in tag_cols}
     leftover = [None] * n
     has_leftover = False
     for i in range(n):
         tag = tags[i]
-        other = {}
-        if not version_col:
-            other["version"] = int(version[i])
-        if not timestamp_col:
-            other["timestamp"] = int(timestamp[i])
-        if not visible_col:
-            other["visible"] = bool(visible[i])
+        other = {} if keep_other_tags else None
+        if other is not None:
+            if not version_col:
+                other["version"] = int(version[i])
+            if not timestamp_col:
+                other["timestamp"] = int(timestamp[i])
+            if not visible_col:
+                other["visible"] = bool(visible[i])
         for k, v in tag.items():
             key = "id_tag" if k == "id" else k
             if key in tag_col_set:
                 col_lists[key][i] = v
-            else:
+            elif other is not None:
                 other[key] = v
         if other:
             leftover[i] = dumps(other)


### PR DESCRIPTION
In a `keep_other_tags=False` out-of-core read (the minimal-tags / geometry+key path), `_ways_arrays` still built the per-way leftover JSON `tags` column — including a `rapidjson.dumps` for the metadata fields not promoted to columns (e.g. `visible`) — which `_assemble_chunk` then dropped, since that mode returns only the requested columns. The build was pure waste.

### What changed

`_ways_arrays` takes the existing `keep_other_tags` flag and, when it is `False`, fills only the requested tag columns and skips constructing/serialising the leftover JSON entirely (the `tags` column is dropped downstream regardless). The default `keep_other_tags=True` path is unchanged — the leftover JSON is built exactly as before. The `_assemble_chunk` post-drop of a `tags` column stays as the cover for a relation chunk that still produces one.

### Verification

The out-of-core engine's `keep_other_tags=False` parity tests are unchanged — the returned frame (columns, values, geometry) is identical, since the skipped column was being dropped anyway. Profiling a country-scale minimal buildings read (Finland, 3.15 M ways) shows the per-way `rapidjson.dumps` eliminated and `_ways_arrays` roughly halved (per-chunk function calls drop from ~1.54 M to ~0.79 M), trimming a second or so of the serial assembly on that read.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.