### PR TITLE
Spill coarser shards to cut the out-of-core collect's per-file overhead

### DIFF
--- a/pyrosm/engine/decode.py
+++ b/pyrosm/engine/decode.py
@@ -1,9 +1,12 @@
 """Worker-side decode and spill.
 
-A worker decodes a contiguous run of blobs and spills each block to its own shard as it is
-decoded (so only one block's arrays are held in memory at a time). Each shard holds the node
-coordinates, the matching layer features (ways, point nodes and relations -- selected by
-filter-key presence) and *every* way (id + refs, for relation-member lookup).
+A worker decodes a contiguous run of blobs and accumulates the decoded blocks into a shard,
+spilling it once it reaches ``_SHARD_TARGET_BYTES`` (so a country file produces a few hundred
+shards rather than one per ~8k-element block -- far less per-file open/read overhead when
+collect re-reads them -- while peak memory stays bounded by one shard's worth of blocks).
+Each shard holds the node coordinates, the matching layer features (ways, point nodes and
+relations -- selected by filter-key presence) and *every* way (id + refs, for relation-member
+lookup).
 """
 
 from pathlib import Path
@@ -13,6 +16,16 @@ import numpy as np
 from pyrosm.primitive_block_decoder import decode_primitive_block
 from pyrosm.engine.blobs import _read_block
 from pyrosm.engine.bounding_box import _in_box_mask, _filter_features_to_box
+
+# Accumulate decoded blocks into a shard until it reaches roughly this many bytes, then spill.
+# Coarser shards amortise the per-file open/read overhead collect pays across thousands of
+# tiny per-block files; ~8 MB keeps the spill near the point past which that overhead stops
+# shrinking, while bounding a worker's in-flight memory to about one shard.
+_SHARD_TARGET_BYTES = 8_000_000
+
+# The CSR offset arrays in a shard dict: when several blocks' shard dicts are merged into one,
+# these are rebuilt from the concatenated per-row lengths (the flat arrays just concatenate).
+_OFFSET_KEYS = ("refs_off", "all_refs_off", "rel_memoff")
 
 # Per-worker globals, set by the pool initializer (or directly for the in-process path).
 # ``_OSM_KEYS`` holds the layer's filter keys (utf-8 bytes) used to pre-select elements;
@@ -401,17 +414,50 @@ def _decode_one_block(string_table, header, nodes, ways, relations):
     }
 
 
+def _merge_shards(blocks):
+    """Merge a batch of per-block shard dicts into the single shard dict a shard spanning those
+    blocks would hold: flat arrays concatenate; the CSR offset arrays are rebuilt from the
+    concatenated per-row lengths so the combined offsets stay correct. A single-block batch is
+    returned unchanged."""
+    if len(blocks) == 1:
+        return blocks[0]
+    merged = {}
+    for key in blocks[0]:
+        if key in _OFFSET_KEYS:
+            lengths = np.concatenate([np.diff(b[key]) for b in blocks])
+            merged[key] = _offsets_from_lengths(lengths.tolist())
+        else:
+            merged[key] = np.concatenate([b[key] for b in blocks])
+    return merged
+
+
 def _decode_batch(task):
-    """Worker: decode a contiguous run of blobs, spilling each block to its own shard as it
-    is decoded (so only one block's arrays are held in memory at a time, rather than the
-    whole batch), and return the list of shard paths."""
+    """Worker: decode a contiguous run of blobs, accumulating decoded blocks into a shard and
+    spilling it once it reaches ``_SHARD_TARGET_BYTES`` (so peak memory stays bounded by about
+    one shard's worth of blocks rather than the whole batch, while the file count -- and the
+    per-file overhead collect pays re-reading them -- drops by one to two orders of magnitude).
+    Returns the list of shard paths."""
     worker_id, blobs = task
     paths = []
+    pending = []
+    pending_bytes = 0
+
+    def flush():
+        nonlocal pending, pending_bytes
+        if not pending:
+            return
+        path = Path(_SHARD_DIR) / ("shard_%d_%d.npz" % (worker_id, len(paths)))
+        np.savez(path, **_merge_shards(pending))
+        paths.append(path)
+        pending, pending_bytes = [], 0
+
     with open(_FILEPATH, "rb") as f:
-        for seq, (offset, size) in enumerate(blobs):
+        for offset, size in blobs:
             data = _read_block(f, offset, size)
             arrays = _decode_one_block(*decode_primitive_block(data))
-            path = Path(_SHARD_DIR) / ("shard_%d_%d.npz" % (worker_id, seq))
-            np.savez(path, **arrays)
-            paths.append(path)
+            pending.append(arrays)
+            pending_bytes += sum(v.nbytes for v in arrays.values())
+            if pending_bytes >= _SHARD_TARGET_BYTES:
+                flush()
+    flush()
     return paths

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -401,6 +401,18 @@ def test_engine_run_pool_silent_fallback_without_warning(monkeypatch):
     assert [w for w in caught if issubclass(w.category, RuntimeWarning)] == []
 
 
+@pytest.mark.parametrize("target", [1, 8_000_000])
+def test_engine_decode_shard_target_parity(helsinki_pbf, monkeypatch, fresh_cache, target):
+    # The decode spill accumulates blocks into a shard until it reaches the byte target. A tiny
+    # target spills one shard per block (and exercises the empty final-flush guard); the normal
+    # target batches many blocks per shard. Either way the read matches the in-memory reader.
+    # fresh_cache forces a real decode rather than a cached result.
+    from pyrosm.engine import decode
+
+    monkeypatch.setattr(decode, "_SHARD_TARGET_BYTES", target)
+    _assert_full_parity(get_buildings(helsinki_pbf), OSM(helsinki_pbf).get_buildings())
+
+
 def test_engine_unguarded_module_read_does_not_hang(test_pbf, tmp_path):
     # A read at module level (no `if __name__ == "__main__":` guard) must not hang: the
     # spawned workers cannot re-import the entry point, so the decode falls back to a single


### PR DESCRIPTION
The out-of-core decode spilled **one shard per PrimitiveBlock** (~8k elements), so a country PBF produced tens of thousands of tiny (~0.2 MB) `.npz` files that the collect phase then re-read one at a time — and the per-file open/read overhead, not the actual gather work, dominated collect. Spilling **fewer, larger shards** removes most of that overhead while keeping the bounded-memory design.

### What changed

All in `pyrosm/engine/decode.py`:

- A `_SHARD_TARGET_BYTES` constant (~8 MB). `_decode_batch` now accumulates decoded per-block shard dicts and spills one shard once the accumulated array bytes reach the target, then resets — so a worker holds about one shard's worth of blocks in memory rather than the whole batch. A final flush writes the remainder.
- `_merge_shards` merges a batch's per-block shard dicts into the single dict a shard spanning those blocks would hold: the flat arrays concatenate, and the three CSR offset arrays (`refs_off`, `all_refs_off`, `rel_memoff`) are rebuilt from the concatenated per-row lengths via the existing `_offsets_from_lengths`, so the combined offsets stay correct without manual arithmetic. A single-block batch is returned unchanged.

`collect.py` is **unchanged** — it iterates the shard list and processes each shard's arrays the same way regardless of how many blocks a shard spans, which is why the output is byte-identical.

Peak memory per worker rises from ~one block to ~one shard (~8 MB) of decoded arrays plus a transient concatenation copy during the merge — a small, bounded increase that preserves the engine's bounded-memory promise (peak is bounded by the shard target, not the file size).

### Verification

The full out-of-core parity suite (out-of-core vs the in-memory reader across every layer, mode, bounding box, network type, relation case, parallel decode, and `keep_metadata` / `keep_other_tags`) is the correctness gate for the merge and stays green; a new test reads a layer with the byte target set tiny (one shard per block, exercising the empty final-flush) and at the normal target (many blocks per shard), both matching the in-memory reader.

Benchmark — Finland buildings (3.15 M ways): the spill drops from 12,788 shards to ~440 (median ~8 MB each), and the collect phase roughly halves — ~32 s → ~12 s serially (`_node_lookup` alone 18.6 s → ~8 s). Decode also speeds up from fewer file creates. The win also reaches the parallel collect path (each worker opens far fewer files), and it helps every country-scale read, not only the geometry+key case.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.