### PR TITLE
Add how-to-cite documentation (Zenodo DOI) and CITATION.cff

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,14 @@
+{
+  "title": "pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames",
+  "description": "Pyrosm is a Python library for reading OpenStreetMap data from Protocolbuffer Binary Format (PBF) files into GeoPandas GeoDataFrames. It is fast and memory-efficient and can extract street networks, buildings, points of interest, landuse, natural features, and administrative boundaries -- or any custom-filtered data -- from local PBF dumps. In addition, pyrosm can download extracts, crop them to a smaller area, write and modify PBF files, as well as export street networks to igraph, NetworkX, or Pandarm graphs.",
+  "creators": [
+    {
+      "name": "Tenkanen, Henrikki",
+      "affiliation": "GIST Lab, Department of Built Environment, Aalto University",
+      "orcid": "0000-0002-0918-4710"
+    }
+  ],
+  "keywords": ["OpenStreetMap", "GIS", "geospatial", "Python"],
+  "upload_type": "software",
+  "access_right": "open"
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,20 +1,20 @@
 cff-version: 1.2.0
 message: "If you use pyrosm, please cite it using the metadata below."
-title: "pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame"
-abstract: "Pyrosm is a Python library for reading OpenStreetMap data from Protocolbuffer Binary Format (PBF) files into GeoPandas GeoDataFrames."
+title: "pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames"
+abstract: "Pyrosm is a Python library for reading OpenStreetMap data from Protocolbuffer Binary Format (PBF) files into GeoPandas GeoDataFrames. It is fast and memory-efficient and can extract street networks, buildings, points of interest, landuse, natural features, and administrative boundaries -- or any custom-filtered data -- from local PBF dumps. In addition, pyrosm can download extracts, crop them to a smaller area, write and modify PBF files, as well as export street networks to igraph, NetworkX, or Pandarm graphs."
 type: software
 authors:
   - family-names: Tenkanen
     given-names: Henrikki
     email: henrikki.tenkanen@aalto.fi
-    affiliation: "Aalto University"
+    affiliation: "GIST Lab, Department of Built Environment, Aalto University"
 identifiers:
   - type: doi
     value: 10.5281/zenodo.3755057
     description: "Concept DOI that always resolves to the latest version"
 doi: 10.5281/zenodo.3755057
 version: 0.10.0
-date-released: "2026-06-25"
+date-released: "2026-06-26"
 license: MIT
 repository-code: "https://github.com/pyrosm/pyrosm"
 url: "https://pyrosm.readthedocs.io/"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,27 @@
+cff-version: 1.2.0
+message: "If you use pyrosm, please cite it using the metadata below."
+title: "pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame"
+abstract: "Pyrosm is a Python library for reading OpenStreetMap data from Protocolbuffer Binary Format (PBF) files into GeoPandas GeoDataFrames."
+type: software
+authors:
+  - family-names: Tenkanen
+    given-names: Henrikki
+    email: henrikki.tenkanen@aalto.fi
+    affiliation: "Aalto University"
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.3755057
+    description: "Concept DOI that always resolves to the latest version"
+doi: 10.5281/zenodo.3755057
+version: 0.10.0
+date-released: "2026-06-25"
+license: MIT
+repository-code: "https://github.com/pyrosm/pyrosm"
+url: "https://pyrosm.readthedocs.io/"
+keywords:
+  - OpenStreetMap
+  - OSM
+  - PBF
+  - GeoPandas
+  - GIS
+  - Python

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ You can run tests with `pytest` by executing:
 
 ## Citing pyrosm
 
-If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version):
+If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version). An example citation for the pyrosm version 0.10.0 is as follows:
 
-> Tenkanen, H. *pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame*. Zenodo. https://doi.org/10.5281/zenodo.3755057
+> Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames*. (v0.10.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 A BibTeX entry and version-specific DOIs are available in the [documentation](https://pyrosm.readthedocs.io/en/latest/citation.html) and on the [Zenodo record](https://doi.org/10.5281/zenodo.3755057).
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ You can run tests with `pytest` by executing:
   `$ pytest . -v` 
   
 
+## Citing pyrosm
+
+If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version):
+
+> Tenkanen, H. *pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame*. Zenodo. https://doi.org/10.5281/zenodo.3755057
+
+A BibTeX entry and version-specific DOIs are available in the [documentation](https://pyrosm.readthedocs.io/en/latest/citation.html) and on the [Zenodo record](https://doi.org/10.5281/zenodo.3755057).
+
 ## License and copyright
 
 Pyrosm is licensed under MIT (see [license](LICENSE)). 

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,43 @@
+How to cite pyrosm
+==================
+
+If you use **pyrosm** in academic research, reports, or other published work, please cite it.
+Citing the software helps others find it and gives credit for the development effort.
+
+Pyrosm is archived on `Zenodo <https://doi.org/10.5281/zenodo.3755057>`__, which provides a
+permanent, citable DOI.
+
+.. note::
+
+   The DOI **10.5281/zenodo.3755057** always resolves to the *latest* version of pyrosm (the
+   "all versions" concept DOI). The Zenodo record also mints a separate DOI for each individual
+   release, so you can cite the exact version you used if you prefer.
+
+Recommended citation
+--------------------
+
+   Tenkanen, H. (2026). *pyrosm: A Python tool to parse OSM data from Protobuf format into
+   GeoDataFrame* (version 0.10.0). Zenodo. https://doi.org/10.5281/zenodo.3755057
+
+BibTeX
+------
+
+.. code-block:: bibtex
+
+   @software{tenkanen_pyrosm,
+     author    = {Tenkanen, Henrikki},
+     title     = {{pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame}},
+     year      = {2026},
+     version   = {0.10.0},
+     publisher = {Zenodo},
+     doi       = {10.5281/zenodo.3755057},
+     url       = {https://doi.org/10.5281/zenodo.3755057}
+   }
+
+Citing the data
+---------------
+
+When you publish results based on OpenStreetMap data read with pyrosm, please also acknowledge
+the data sources: © `OpenStreetMap <https://www.openstreetmap.org/copyright>`__ contributors,
+with extracts distributed by `Geofabrik <http://www.geofabrik.de/>`__ and
+`BBBike <https://download.bbbike.org>`__.

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -16,8 +16,8 @@ permanent, citable DOI.
 Recommended citation
 --------------------
 
-   Tenkanen, H. (2026). *pyrosm: A Python tool to parse OSM data from Protobuf format into
-   GeoDataFrame* (version 0.10.0). Zenodo. https://doi.org/10.5281/zenodo.3755057
+   Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
+   with GeoDataFrames*. (v0.10.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 BibTeX
 ------
@@ -26,7 +26,7 @@ BibTeX
 
    @software{tenkanen_pyrosm,
      author    = {Tenkanen, Henrikki},
-     title     = {{pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame}},
+     title     = {{pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames}},
      year      = {2026},
      version   = {0.10.0},
      publisher = {Zenodo},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,8 +60,8 @@ Citation
 If you use pyrosm in your work, please cite it. Pyrosm is archived on
 `Zenodo <https://doi.org/10.5281/zenodo.3755057>`__ with a citable DOI:
 
-    Tenkanen, H. *pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame*.
-    Zenodo. https://doi.org/10.5281/zenodo.3755057
+    Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
+    with GeoDataFrames*. (v0.10.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 See :doc:`How to cite pyrosm <citation>` for the full reference and a BibTeX entry.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,17 @@ Pyrosm is licensed under MIT (see `license <https://github.com/HTenkanen/pyrosm/
 Data © `Geofabrik GmbH <http://www.geofabrik.de/>`__, `BBBike <https://download.bbbike.org>`__ and `OpenStreetMap Contributors <http://www.openstreetmap.org>`__.
 All data from the `OpenStreetMap <https://www.openstreetmap.org>`__ is licensed under the `OpenStreetMap License <https://www.openstreetmap.org/copyright>`__.
 
+Citation
+--------
+
+If you use pyrosm in your work, please cite it. Pyrosm is archived on
+`Zenodo <https://doi.org/10.5281/zenodo.3755057>`__ with a citable DOI:
+
+    Tenkanen, H. *pyrosm: A Python tool to parse OSM data from Protobuf format into GeoDataFrame*.
+    Zenodo. https://doi.org/10.5281/zenodo.3755057
+
+See :doc:`How to cite pyrosm <citation>` for the full reference and a BibTeX entry.
+
 Getting started
 ---------------
 
@@ -76,6 +87,7 @@ Getting started
     :caption: Reference Guide
 
     Reference to All Attributes and Methods <reference>
+    How to cite <citation>
     Changelog <changelog>
 
 Indices and tables

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -123,7 +123,9 @@
    "source": [
     "## Read a street network\n",
     "\n",
-    "Initialise the `OSM` reader with a file path, then read a network for a given travel mode:"
+    "Initialise the `OSM` reader with a file path, then read a network for a given travel mode:\n",
+    "\n",
+    "> **Working with large files?** By default the reader loads the whole file in memory. For large extracts (whole countries or even continents), initialise the reader with the opt-in out-of-core engine — `OSM(fp, engine=\"out_of_core\", workers=\"auto\")` — which streams the file with bounded memory and decodes in parallel, returning an identical result. See [Reading large datasets with the out-of-core engine](reading_osm_data.ipynb#Reading-large-datasets-with-the-out-of-core-engine) for details."
    ]
   },
   {


### PR DESCRIPTION
Adds documentation on how to cite pyrosm, referring to the Zenodo archive (DOI `10.5281/zenodo.3755057`).

## Changes
- **`docs/citation.rst`** — new "How to cite pyrosm" page: the Zenodo DOI, recommended citation, a BibTeX entry, and a data-attribution note. Added to the Reference Guide toctree in `docs/index.rst`.
- **`docs/index.rst`** — a "Citation" section on the front page with the one-line reference and a link to the citation page.
- **`README.md`** — a "Citing pyrosm" section with the formatted citation and links to the documentation page and the Zenodo record.
- **`CITATION.cff`** — repository citation metadata (CFF 1.2.0) so GitHub shows a native "Cite this repository" button: author Henrikki Tenkanen (Aalto University), DOI `10.5281/zenodo.3755057`, version 0.10.0, released 2026-06-25, MIT.
- **`docs/quickstart.ipynb`** — in the "Read a street network" section, a text-only note that large extracts can be read with the opt-in out-of-core engine (`OSM(fp, engine="out_of_core", workers="auto")`), linking to the "Reading large datasets with the out-of-core engine" section of `reading_osm_data.ipynb`. No code cell added.

## Verification
- `CITATION.cff` parses as valid CFF 1.2.0 YAML.
- `docs/citation.rst` section underlines are well-formed.
- `docs/quickstart.ipynb` passes `nbformat` validation.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
