### PR TITLE
Set v0.10.0 changelog date to Jun 26, 2026

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v0.10.0 (Jun 25, 2026)
+v0.10.0 (Jun 26, 2026)
 ----------------------
 
 This release adds an opt-in out-of-core ("streaming") reading engine that decodes large PBF files in a single streaming pass with bounded memory -- the decode, the node-coordinate gather and the standalone-way read all run in parallel across a worker pool, and each layer's result is cached automatically -- making whole-country and even whole-continent extracts readable quickly on modest machines without running out of memory (tested on Macbook Air with 24 GB of RAM). ``get_data`` can now also download whole-continent extracts. The default in-memory reader is unchanged.


### PR DESCRIPTION
Updates the v0.10.0 release date in `docs/changelog.rst` from Jun 25 to **Jun 26, 2026**, matching `CITATION.cff` (`date-released: 2026-06-26`) and the release date, ahead of tagging v0.10.0.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
