### PR TITLE
Install pyrosm on Read the Docs so the API reference renders

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,12 @@ build:
 python:
     install:
         - requirements: docs/requirements.txt
+        # Install (and compile) pyrosm itself so autodoc imports the real
+        # package -- its compiled Cython extensions and runtime deps -- instead
+        # of relying on mocks. Build deps come from pyproject.toml's
+        # build-system requires.
+        - method: pip
+          path: .
 
 sphinx:
     configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,20 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-
-import os
-import sys
-
-# Make the pyrosm source importable for autodoc without installing/compiling
-# the package. The compiled Cython modules are mocked below, so autodoc reads
-# docstrings straight from the pure-Python wrappers in the repo.
-sys.path.insert(0, os.path.abspath(".."))
-
 # -- Project information -----------------------------------------------------
 from datetime import datetime
 
@@ -51,29 +37,10 @@ extensions = [
 # cells can use admonitions/directives that also render cleanly in the notebook UI.
 myst_enable_extensions = ["colon_fence"]
 
-# pyrosm is not installed for the docs build; mock its compiled Cython
-# extensions, binary deps, and the generated protobuf message modules so autodoc
-# can import the pure-Python wrappers and read their docstrings without compiling
-# anything. The pyrosm.proto.*_pb2 modules build real protobuf descriptors at
-# import time, which fails when google.protobuf is mocked, so they are mocked too
-# (otherwise importing pyrosm.utils -> pyrosm.data/pyrosm.pyrosm fails and the
-# whole API reference renders empty).
-autodoc_mock_imports = [
-    "pyrosm._arrays",
-    "pyrosm.data_filter",
-    "pyrosm.data_manager",
-    "pyrosm.delta_compression",
-    "pyrosm.frames",
-    "pyrosm.geometry",
-    "pyrosm.graph_export",
-    "pyrosm.pbfreader",
-    "pyrosm.relations",
-    "pyrosm.tagparser",
-    "pyrosm.proto.fileformat_pb2",
-    "pyrosm.proto.osmformat_pb2",
-    "google.protobuf",
-    "cykhash",
-]
+# pyrosm is installed (and compiled) by the Read the Docs build via
+# ``.readthedocs.yml`` (``python.install`` runs ``pip install .``), so autodoc
+# imports the real package and reads docstrings straight from it -- no mocking
+# of the compiled Cython extensions or binary deps is needed.
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,11 @@
 # Documentation toolchain for Read the Docs (Sphinx + MyST-NB).
 #
-# Notebooks are rendered from their stored outputs (execution is disabled in
-# conf.py), so the doc build does NOT run pyrosm and does NOT need the compiled
-# package. The only consumer of pyrosm is the autodoc API reference, whose
-# compiled Cython modules are mocked via autodoc_mock_imports in conf.py.
-# Hence pyrosm itself is intentionally NOT installed here (no from-source
-# compilation, no protobuf runtime, no build toolchain required).
+# pyrosm itself is installed (and compiled) by the Read the Docs build via
+# `.readthedocs.yml` (`python.install` runs `pip install .`), so autodoc imports
+# the real package and its runtime dependencies (pandas, geopandas, shapely,
+# numpy, rapidjson, ...) come from that install. Only the Sphinx toolchain is
+# listed here. Notebooks are rendered from their stored outputs (execution is
+# disabled in conf.py).
 
 # Sphinx + MyST-NB Markdown/notebook rendering
 myst-nb>=1.0,<2.0
@@ -17,9 +17,3 @@ sphinx-design>=0.5,<1.0
 # Provides the ipython_console_highlighting and ipython_directive Sphinx
 # extensions referenced in conf.py.
 ipython>=8.0
-
-# Pure-Python runtime imports pulled in when autodoc imports the pyrosm
-# wrappers (the compiled modules are mocked, these are not).
-pandas
-geopandas
-shapely>=2.0


### PR DESCRIPTION
Fixes the empty API reference page (`reference.html`) on Read the Docs.

## Problem
The API reference rendered empty: autodoc could not import `pyrosm.pyrosm.OSM`, so the whole class (and the `pyrosm.data` functions on the same import chain) produced no output.

## Cause
The docs build did not install pyrosm and instead mocked its compiled Cython modules via `autodoc_mock_imports`, importing the source from a `sys.path` hack. v0.10.0's out-of-core engine added module-level imports that the mock setup did not cover — `pyrosm.engine.readers` does `from rapidjson import dumps, loads` and `pyrosm.utils.download` does `import certifi`. Neither `python-rapidjson` nor `certifi` was in `docs/requirements.txt` or `autodoc_mock_imports`, so `import pyrosm.pyrosm` raised `ModuleNotFoundError` on Read the Docs and autodoc skipped the directives, leaving the reference empty.

## Change
Install (and compile) pyrosm in the Read the Docs build so autodoc imports the real package instead of relying on mocks that have to be kept in sync with every new dependency:

- `.readthedocs.yml` — add `python.install: pip install .` (build deps come from `pyproject.toml`'s `build-system` requires).
- `docs/conf.py` — remove `autodoc_mock_imports` and the `sys.path` source-import hack (both would shadow the now-installed real package).
- `docs/requirements.txt` — drop the runtime deps (`pandas`, `geopandas`, `shapely`) that pyrosm now pulls in itself; keep only the Sphinx toolchain. Update the stale comment.

## Verification
Built the docs locally with the new configuration (pyrosm installed, no mocks): the reference page renders the `OSM` class, all 14 of its methods, and the four `pyrosm.data` functions, with no autodoc import failure.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
