### PR TITLE
Fix malformed RST in OSM docstrings so the API reference renders cleanly

### DIFF
--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -50,7 +50,7 @@ class OSM:
     ----------
 
     filepath : str
-        Filepath to input OSM dataset ( *.osm.pbf )
+        Filepath to input OSM dataset (``*.osm.pbf``)
 
     bounding_box : list | shapely geometry
         Filtering OSM data spatially is allowed by passing a
@@ -330,6 +330,7 @@ class OSM:
         network_type : str
             What kind of network to parse.
             Possible values are:
+
               - `'walking'`
               - `'cycling'`
               - `'driving'`
@@ -493,8 +494,9 @@ class OSM:
 
             You can opt-in specific elements by using 'custom_filter'.
             To keep only specific buildings such as 'residential' and 'retail', you can apply
-            a custom filter which is a Python dictionary with following format:
-              - `custom_filter={'building': ['residential', 'retail']}`
+            a custom filter which is a Python dictionary with the following format::
+
+                custom_filter={'building': ['residential', 'retail']}
 
         extra_attributes : list (optional)
             Additional OSM tag keys that will be converted into columns in the resulting GeoDataFrame.
@@ -581,8 +583,9 @@ class OSM:
 
             You can opt-in specific elements by using 'custom_filter'.
             To keep only specific landuse such as 'construction' and 'industrial', you can apply
-            a custom filter which is a Python dictionary with following format:
-              `custom_filter={'landuse': ['construction', 'industrial']}`
+            a custom filter which is a Python dictionary with the following format::
+
+                custom_filter={'landuse': ['construction', 'industrial']}
 
         extra_attributes : list (optional)
             Additional OSM tag keys that will be converted into columns in the resulting GeoDataFrame.
@@ -671,8 +674,9 @@ class OSM:
 
             You can opt-in specific elements by using 'custom_filter'.
             To keep only specific natural such as 'wood' and 'tree', you can apply
-            a custom filter which is a Python dictionary with following format:
-              `custom_filter={'natural': ['wood', 'tree']}`
+            a custom filter which is a Python dictionary with the following format::
+
+                custom_filter={'natural': ['wood', 'tree']}
 
         extra_attributes : list (optional)
             Additional OSM tag keys that will be converted into columns in the resulting GeoDataFrame.
@@ -898,19 +902,22 @@ class OSM:
 
         By default, Pyrosm will parse all OSM elements (points, lines and polygons)
         that are associated with following keys:
-          - amenity
-          - shop
-          - tourism
+
+        - amenity
+        - shop
+        - tourism
 
         You can opt-out / opt-in specific elements by using 'custom_filter'.
         To parse elements associated with only specific tags, such as amenities,
-        you can specify:
-          `custom_filter={"amenity": True}`
+        you can specify::
+
+            custom_filter={"amenity": True}
 
         You can also combine multiple filters at the same time.
         For instance, you can parse all 'amenity' elements AND specific 'shop' elements,
-        such as supermarkets and book stores by specifying:
-          `custom_filter={"amenity": True, "shop": ["supermarket", "books"]}`
+        such as supermarkets and book stores by specifying::
+
+            custom_filter={"amenity": True, "shop": ["supermarket", "books"]}
 
         See Also
         --------
@@ -1336,8 +1343,8 @@ class OSM:
         pandana_weights=["length"],
     ):
         """
-        `
         Export OSM network to routable graph. Supported output graph types are:
+
           - "igraph" (default),
           - "networkx",
           - "pandarm",


### PR DESCRIPTION
Cleans up malformed reStructuredText in the `OSM` docstrings that produced docutils errors during the docs build and degraded the rendered API reference (dict examples flattened into prose, a stray asterisk, etc.).

## What was wrong
- **`Unexpected indentation`** in `get_buildings`, `get_landuse`, `get_natural`, `get_network`, `get_pois`, and `to_graph` — `custom_filter={...}` examples placed as indented sub-bullets, and bullet lists (network types, POI keys) with no blank line before them.
- **`Inline emphasis start-string without end-string`** in the `OSM` class docstring — the unescaped `*` in `*.osm.pbf` (the `filepath` parameter).
- A **stray backtick** on its own line at the top of the `to_graph` docstring.

## Change (docstrings only, `pyrosm/pyrosm.py`)
- Convert the inline `custom_filter={...}` examples to `::` literal blocks (with the required blank line) so they render as code.
- Add the blank line required before the bullet lists (`network_type` values, POI keys).
- Wrap `*.osm.pbf` in double backticks.
- Remove the stray backtick in `to_graph`.

## Verification
Built the docs and confirmed the previously reported `Unexpected indentation` / emphasis errors in the `pyrosm.pyrosm` docstrings are resolved; all 14 `OSM` methods still render, and the dict examples now appear as code blocks.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
