### PR TITLE
Add subset_only export to write_pbf (export selected layers)

### DIFF
--- a/docs/saving_and_cropping.ipynb
+++ b/docs/saving_and_cropping.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 1,
    "id": "a355214f",
    "metadata": {},
    "outputs": [
@@ -37,7 +37,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cropped size: pyrosm_crop_2zcu98_7.osm.pbf 6.9 MiB.\n",
+      "Cropped size: pyrosm_crop_ekhj6h5z.osm.pbf 6.9 MiB.\n",
       "Original size: Helsinki.osm.pbf 60.0 MiB.\n"
      ]
     }
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 2,
    "id": "dd9d5169",
    "metadata": {},
    "outputs": [
@@ -70,7 +70,7 @@
        "(1486, 36)"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "id": "d52f0f56",
    "metadata": {},
    "outputs": [
@@ -141,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "id": "4af00353",
    "metadata": {},
    "outputs": [
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 5,
    "id": "baca2c5d",
    "metadata": {},
    "outputs": [
@@ -182,7 +182,7 @@
        "np.float64(16.667588739971247)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "subset-pbf-code",
    "metadata": {},
    "outputs": [

--- a/docs/saving_and_cropping.ipynb
+++ b/docs/saving_and_cropping.ipynb
@@ -7,13 +7,14 @@
    "source": [
     "# Saving and cropping data\n",
     "\n",
-    "`Pyrosm` can write `.osm.pbf` files, not only read them. This lets you **crop** a large extract down to a smaller area to share or re-read faster (`OSM.to_pbf`), and **write modified OSM data** back to a valid PBF after editing tags or attributes in pandas (`OSM.write_pbf`).\n",
+    "`Pyrosm` can write `.osm.pbf` files, not only read them. This lets you **crop** a large extract down to a smaller area to share or re-read faster (`OSM.to_pbf`), **write modified OSM data** back to a valid PBF after editing tags or attributes in pandas, or export **only selected layers** (e.g. just the buildings or the road network) to a new PBF (`OSM.write_pbf`).\n",
     "\n",
     "**How to?**\n",
     "\n",
     "- [Crop a PBF to a bounding box](#crop-a-pbf-to-a-bounding-box)\n",
     "- [Smaller output: compact and repack](#smaller-output-compact-and-repack)\n",
-    "- [Write modified OSM data back to a PBF](#write-modified-osm-data-back-to-a-pbf)"
+    "- [Write modified OSM data back to a PBF](#write-modified-osm-data-back-to-a-pbf)\n",
+    "- [Export only selected layers](#export-only-selected-layers)"
    ]
   },
   {
@@ -190,6 +191,45 @@
     "# Read it back, requesting the new tag as a column\n",
     "reread = OSM(out_path).get_network(\"driving\", extra_attributes=[\"travel_time\"])\n",
     "reread[\"travel_time\"].astype(float).mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "subset-pbf-md",
+   "metadata": {},
+   "source": [
+    "## Export only selected layers\n",
+    "\n",
+    "By default `write_pbf()` writes the **whole** dataset it read, so untouched layers survive. Pass `subset_only=True` to instead write a PBF containing **only** the features you give it -- for example parse the buildings and export just those, or just the road network. The references each feature needs to stay valid are pulled in automatically (a way's nodes, a relation's member ways and nodes), so the output is a valid, re-readable PBF.\n",
+    "\n",
+    "You can also combine several layers by passing a **list** (`[buildings, network]`); the union of their elements is written."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "subset-pbf-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "osm = OSM(get_data(\"helsinki\"))\n",
+    "buildings = osm.get_buildings()\n",
+    "network = osm.get_network()\n",
+    "\n",
+    "# A buildings-only subset is much smaller than the whole dataset\n",
+    "whole = os.path.join(tempfile.gettempdir(), \"whole.osm.pbf\")\n",
+    "osm.write_pbf(buildings, whole)  # default: the whole dataset is written\n",
+    "b_only = os.path.join(tempfile.gettempdir(), \"buildings_only.osm.pbf\")\n",
+    "osm.write_pbf(buildings, b_only, subset_only=True)  # only the buildings (+ refs)\n",
+    "for label, p in [(\"whole dataset\", whole), (\"buildings only\", b_only)]:\n",
+    "    print(f\"{label:15s} {os.path.getsize(p) / 1024 / 1024:.1f} MiB\")\n",
+    "\n",
+    "# Combine several layers by passing a list -> the union is written\n",
+    "combined = os.path.join(tempfile.gettempdir(), \"buildings_and_network.osm.pbf\")\n",
+    "osm.write_pbf([buildings, network], combined, subset_only=True)\n",
+    "both = OSM(combined)\n",
+    "print(\"combined:\", len(both.get_buildings()), \"buildings,\",\n",
+    "      len(both.get_network()), \"network edges\")"
    ]
   }
  ],

--- a/docs/saving_and_cropping.ipynb
+++ b/docs/saving_and_cropping.ipynb
@@ -207,10 +207,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "subset-pbf-code",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "whole dataset   54.4 MiB\n",
+      "buildings only  12.8 MiB\n",
+      "combined: 176900 buildings, 255130 network edges\n"
+     ]
+    }
+   ],
    "source": [
     "osm = OSM(get_data(\"helsinki\"))\n",
     "buildings = osm.get_buildings()\n",

--- a/pyrosm/pbf_writer.py
+++ b/pyrosm/pbf_writer.py
@@ -160,6 +160,22 @@ def _normalize_id(oid):
         return None
 
 
+def _infer_osm_type(geom):
+    """Best-effort OSM type for a row that lacks an ``osm_type`` column.
+
+    Some returned frames omit ``osm_type`` -- notably the node frame from
+    ``get_network(nodes=True)`` -- so without this their existing elements would not
+    match the cache and would be re-synthesized as duplicate new nodes. Inferred from
+    the geometry kind: ``Point`` -> node, ``LineString``/``Polygon`` -> way.
+    """
+    gt = getattr(geom, "geom_type", None)
+    if gt == "Point":
+        return "node"
+    if gt in ("LineString", "Polygon"):
+        return "way"
+    return None
+
+
 def _collect_edits(frames, way_by_id, node_coordinates, rel_ids):
     """Split frame rows into tag edits (matched by osm_type+id) and new rows."""
     node_edits, way_edits, rel_edits = {}, {}, {}
@@ -169,6 +185,8 @@ def _collect_edits(frames, way_by_id, node_coordinates, rel_ids):
         for _, row in gdf.iterrows():
             otype = _normalize_osm_type(row.get("osm_type"))
             oid = _normalize_id(row.get("id"))
+            if otype is None:
+                otype = _infer_osm_type(row[geom_col])
             tags = _row_tags(row, geom_col)
             if oid is not None and otype == "way" and oid in way_by_id:
                 way_edits[oid] = tags
@@ -179,6 +197,55 @@ def _collect_edits(frames, way_by_id, node_coordinates, rel_ids):
             else:
                 new_rows.append((oid, row[geom_col], tags))
     return node_edits, way_edits, rel_edits, new_rows
+
+
+def _subset_keep_sets(node_edits, way_edits, rel_edits, way_by_id, relations):
+    """Closure of the matched elements over the cache, for ``subset_only``.
+
+    Starts from the elements matched in the frame(s) and pulls in their references so
+    the written PBF stays valid: kept relations add their member ways/nodes (recursing
+    into sub-relations), then kept ways add their node refs. Only cache-present members
+    are added (a member absent from the cache has no record to emit); relations are
+    still written with their full original member list by ``_add_base_relations``.
+    Returns ``(keep_nodes, keep_ways, keep_rels)`` as sets of ids.
+    """
+    keep_nodes = set(node_edits)
+    keep_ways = set(way_edits)
+    keep_rels = set(rel_edits)
+
+    members_by_rid = {}
+    if "id" in relations:
+        rid_arr, mem_arr = relations["id"], relations["members"]
+        for i in range(len(rid_arr)):
+            members_by_rid[int(rid_arr[i])] = mem_arr[i]
+
+    # Relations -> members, to a fixed point so super-relations resolve.
+    pending = list(keep_rels)
+    while pending:
+        mem = members_by_rid.get(pending.pop())
+        if mem is None:
+            continue
+        mtypes, mids = mem["member_type"], mem["member_id"]
+        for j in range(len(mids)):
+            mtype = mtypes[j]
+            if isinstance(mtype, (bytes, bytearray)):
+                mtype = mtype.decode()
+            mid = int(mids[j])
+            if mtype == "way":
+                keep_ways.add(mid)
+            elif mtype == "node":
+                keep_nodes.add(mid)
+            elif mtype == "relation" and mid in members_by_rid and mid not in keep_rels:
+                keep_rels.add(mid)
+                pending.append(mid)
+
+    # Ways -> node refs (direct + pulled in via relations).
+    for wid in keep_ways:
+        w = way_by_id.get(wid)
+        if w is not None:
+            keep_nodes.update(int(n) for n in w["nodes"])
+
+    return keep_nodes, keep_ways, keep_rels
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +358,8 @@ class _RecordBuilder:
         }
 
     def bounds(self):
+        if not self.lons:  # empty subset -> degenerate header bbox
+            return (0.0, 0.0, 0.0, 0.0)
         lons = np.asarray(self.lons, dtype=np.float64)
         lats = np.asarray(self.lats, dtype=np.float64)
         return (
@@ -314,9 +383,11 @@ def _node_tag_records(nodes_cache):
     return out
 
 
-def _add_base_nodes(builder, node_coordinates, nodes_cache, node_edits):
+def _add_base_nodes(builder, node_coordinates, nodes_cache, node_edits, keep=None):
     poi_tags = _node_tag_records(nodes_cache)
     for nid, rec in node_coordinates.items():
+        if keep is not None and nid not in keep:
+            continue
         if nid in node_edits:
             tags = node_edits[nid]
         else:
@@ -335,9 +406,11 @@ def _add_base_nodes(builder, node_coordinates, nodes_cache, node_edits):
         )
 
 
-def _add_base_ways(builder, way_records, way_edits):
+def _add_base_ways(builder, way_records, way_edits, keep=None):
     for w in way_records:
         wid = w["id"]
+        if keep is not None and wid not in keep:
+            continue
         builder.ways.append(
             {
                 "id": wid,
@@ -349,11 +422,13 @@ def _add_base_ways(builder, way_records, way_edits):
         )
 
 
-def _add_base_relations(builder, relations, rel_edits):
+def _add_base_relations(builder, relations, rel_edits, keep=None):
     if "id" not in relations:
         return
     for i in range(len(relations["id"])):
         rid = int(relations["id"][i])
+        if keep is not None and rid not in keep:
+            continue
         mem = relations["members"][i]
         members = [
             (mem["member_type"][j], int(mem["member_id"][j]), mem["member_role"][j])
@@ -382,13 +457,24 @@ def _add_base_relations(builder, relations, rel_edits):
 # Public entry point
 # ---------------------------------------------------------------------------
 def write_geodataframe_to_pbf(
-    data, output_path, node_coordinates, way_records, relations, nodes
+    data,
+    output_path,
+    node_coordinates,
+    way_records,
+    relations,
+    nodes,
+    subset_only=False,
 ):
     """Write `data` (+ the cached dataset) to a valid PBF at `output_path`.
 
     `node_coordinates` / `way_records` / `relations` / `nodes` are the caches the
     `OSM` object holds after reading; `data` is a GeoDataFrame or list of them
     whose tag edits are applied by ``osm_type``+``id`` (new rows are synthesized).
+
+    When ``subset_only`` is True, only the elements present in `data` are written
+    (matched by ``osm_type``+``id``), together with the references they need to stay
+    valid -- kept ways pull in their nodes and kept relations pull in their member
+    ways/nodes (the union across all frames). New rows are still synthesized.
     """
     relations = relations or {}
     frames = _reproject_to_wgs84(_as_frames(data))
@@ -400,10 +486,16 @@ def write_geodataframe_to_pbf(
         frames, way_by_id, node_coordinates, rel_ids
     )
 
+    keep_nodes = keep_ways = keep_rels = None
+    if subset_only:
+        keep_nodes, keep_ways, keep_rels = _subset_keep_sets(
+            node_edits, way_edits, rel_edits, way_by_id, relations
+        )
+
     builder = _RecordBuilder()
-    _add_base_nodes(builder, node_coordinates, nodes, node_edits)
-    _add_base_ways(builder, way_records, way_edits)
-    _add_base_relations(builder, relations, rel_edits)
+    _add_base_nodes(builder, node_coordinates, nodes, node_edits, keep_nodes)
+    _add_base_ways(builder, way_records, way_edits, keep_ways)
+    _add_base_relations(builder, relations, rel_edits, keep_rels)
 
     builder.begin_synthesis()
     for oid, geom, tags in new_rows:

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -1268,7 +1268,7 @@ class OSM:
             repack=repack,
         )
 
-    def write_pbf(self, data, output_path):
+    def write_pbf(self, data, output_path, subset_only=False):
         """
         Write the OSM data this object holds back to a valid, re-readable
         ``*.osm.pbf``, applying attribute/tag edits from a (modified)
@@ -1280,6 +1280,12 @@ class OSM:
         added as new elements synthesized from their geometry (with negative ids).
         Topology and coordinates come from the data pyrosm read, so the output is
         faithful and re-readable (e.g. by pyrosm, osmium, GDAL and r5py/R5).
+
+        Pass ``subset_only=True`` to instead write a PBF containing **only** the
+        elements in ``data`` (matched by ``osm_type`` + ``id``) plus the references
+        they need to stay valid -- e.g. export just the buildings or just the road
+        network to a new file. Multiple layers can be combined by passing a list
+        (``[buildings, network]``); the union of their elements is written.
 
         Typical use is to modify attributes in pandas and save them back::
 
@@ -1302,6 +1308,10 @@ class OSM:
         output_path : str
             Where to write the PBF.
 
+        subset_only : bool (default False)
+            If True, write only the elements present in ``data`` (and the nodes and
+            relation members they reference) instead of the whole cached dataset.
+
         Returns
         -------
         str
@@ -1309,8 +1319,10 @@ class OSM:
 
         Notes
         -----
-        v1 applies edits and additions, not deletions: dropping rows from ``data``
-        does not remove elements (the whole cached dataset is the base set).
+        v1 applies edits and additions, not deletions: with the default
+        ``subset_only=False`` the whole cached dataset is the base set, so dropping
+        rows from ``data`` does not remove elements. Use ``subset_only=True`` to limit
+        the output to the elements in ``data``.
         """
         from pyrosm.pbf_writer import write_geodataframe_to_pbf
 
@@ -1324,6 +1336,7 @@ class OSM:
             way_records=self._way_records,
             relations=self._relations,
             nodes=self._nodes,
+            subset_only=subset_only,
         )
 
     @staticmethod

--- a/tests/test_pbf_export.py
+++ b/tests/test_pbf_export.py
@@ -1480,3 +1480,160 @@ def test_pbf_writer_node_tag_records_empty():
     assert _node_tag_records(None) == {}
     assert _node_tag_records({}) == {}
     assert _node_tag_records({"id": [1], "lat": [0.0]}) == {}
+
+
+# ---------------------------------------------------------------------------
+# OSM.write_pbf(subset_only=True) — export only selected layers (issue #348)
+# ---------------------------------------------------------------------------
+def _ids(gdf):
+    return set() if gdf is None else set(int(i) for i in gdf["id"])
+
+
+def test_write_pbf_subset_only_buildings(helsinki_pbf, tmp_path):
+    """subset_only=True writes only the passed layer: buildings survive (same ids,
+    same count -> relation member ways were pulled in), the unrelated road network
+    is absent. Inverse of test_write_pbf_whole_dataset_preserved."""
+    osm = OSM(helsinki_pbf)
+    buildings = osm.get_buildings()
+    out = str(tmp_path / "buildings_only.osm.pbf")
+    osm.write_pbf(buildings, out, subset_only=True)
+
+    back = OSM(out)
+    b2 = back.get_buildings()
+    assert b2 is not None and len(b2) == len(buildings)
+    assert _ids(b2) == _ids(buildings)
+    assert b2.geometry.notna().all()
+    # if the source had multipolygon building relations, they round-trip too
+    if "relation" in set(buildings["osm_type"]):
+        assert "relation" in set(b2["osm_type"])
+    net2 = back.get_network()
+    assert net2 is None or len(net2) == 0
+
+
+def test_write_pbf_subset_only_network_excludes_buildings(helsinki_pbf, tmp_path):
+    osm = OSM(helsinki_pbf)
+    network = osm.get_network()
+    out = str(tmp_path / "network_only.osm.pbf")
+    osm.write_pbf(network, out, subset_only=True)
+
+    back = OSM(out)
+    net2 = back.get_network()
+    assert net2 is not None and len(net2) > 0
+    assert _ids(network) <= _ids(net2)
+    b = back.get_buildings()
+    assert b is None or len(b) == 0
+
+
+def test_write_pbf_subset_only_multilayer(helsinki_pbf, tmp_path):
+    """A list of frames writes the union of their elements; both layers come back
+    and standalone POIs (in neither layer) are not carried along."""
+    osm = OSM(helsinki_pbf)
+    buildings = osm.get_buildings()
+    network = osm.get_network()
+    src_poi_nodes = osm.get_pois()
+    src_poi_nodes = _ids(src_poi_nodes[src_poi_nodes["osm_type"] == "node"])
+
+    out = str(tmp_path / "multi.osm.pbf")
+    osm.write_pbf([buildings, network], out, subset_only=True)
+
+    back = OSM(out)
+    b2, net2 = back.get_buildings(), back.get_network()
+    assert b2 is not None and len(b2) > 0 and _ids(buildings) <= _ids(b2)
+    assert net2 is not None and len(net2) > 0 and _ids(network) <= _ids(net2)
+    # standalone POI nodes were in neither layer -> far fewer remain as tagged nodes
+    out_pois = back.get_pois()
+    out_poi_nodes = (
+        _ids(out_pois[out_pois["osm_type"] == "node"])
+        if out_pois is not None
+        else set()
+    )
+    assert len(out_poi_nodes) < len(src_poi_nodes)
+
+
+def test_write_pbf_subset_only_false_is_whole_dataset(helsinki_pbf, tmp_path):
+    """subset_only=False (default) is unchanged: passing one layer still writes the
+    whole cached dataset, so the network (not passed) survives."""
+    osm = OSM(helsinki_pbf)
+    out = str(tmp_path / "whole.osm.pbf")
+    osm.write_pbf(osm.get_buildings(), out, subset_only=False)
+    assert len(OSM(out).get_network()) > 0
+
+
+def test_write_pbf_subset_only_empty(helsinki_pbf, tmp_path):
+    """An empty subset (no matched elements, no new rows) writes a readable PBF."""
+    osm = OSM(helsinki_pbf)
+    empty = osm.get_buildings().iloc[:0]
+    out = str(tmp_path / "empty.osm.pbf")
+    osm.write_pbf(empty, out, subset_only=True)
+    b = OSM(out).get_buildings()
+    assert b is None or len(b) == 0
+
+
+def test_write_pbf_subset_only_network_with_nodes(helsinki_pbf, tmp_path):
+    """get_network(nodes=True) returns (nodes, edges); subset-exporting that tuple
+    writes the road ways + their (real) nodes and does not synthesize duplicate
+    negative-id nodes from the node frame (which has no osm_type column)."""
+    osm = OSM(helsinki_pbf)
+    nodes, edges = osm.get_network(nodes=True)
+    out = str(tmp_path / "net_nodes.osm.pbf")
+    osm.write_pbf([nodes, edges], out, subset_only=True)
+
+    back = OSM(out)
+    net2 = back.get_network()
+    assert net2 is not None and len(net2) > 0
+    # no synthesized duplicates: every written node id is a real (positive) id
+    node_ids, _, _, _, _ = _read_elements(out)
+    assert node_ids and all(nid > 0 for nid in node_ids)
+
+
+def test_infer_osm_type():
+    from pyrosm.pbf_writer import _infer_osm_type
+
+    assert _infer_osm_type(Point(0, 0)) == "node"
+    assert _infer_osm_type(LineString([(0, 0), (1, 1)])) == "way"
+    assert _infer_osm_type(Polygon([(0, 0), (1, 0), (1, 1)])) == "way"
+    assert _infer_osm_type(MultiPolygon([Polygon([(0, 0), (1, 0), (1, 1)])])) is None
+    assert _infer_osm_type(None) is None
+
+
+def test_subset_keep_sets_closure():
+    """The closure resolves way/node/sub-relation members and way node-refs, and
+    tolerates kept/member ids that are absent from the cache."""
+    from pyrosm.pbf_writer import _subset_keep_sets
+
+    # No relations cache: a kept way pulls in its node refs; nothing else.
+    kn, kw, kr = _subset_keep_sets(
+        {}, {5: {}}, {}, {5: {"id": 5, "nodes": [50, 51]}}, {}
+    )
+    assert kr == set() and kw == {5} and kn == {50, 51}
+
+    # Relation 1 has way/node/sub-relation members (incl. sub-rel 999 absent from the
+    # cache); relation 2 (a sub-relation) has a way. 888 is a kept relation absent
+    # from the cache. way 10 -> [100, 101], way 11 -> [101, 102].
+    relations = {
+        "id": np.array([1, 2], dtype=np.int64),
+        "members": np.array(
+            [
+                {
+                    "member_type": [b"way", b"node", b"relation", b"relation"],
+                    "member_id": np.array([10, 100, 2, 999], dtype=np.int64),
+                    "member_role": [b"outer", b"", b"", b""],
+                },
+                {
+                    # plain str member_type (not bytes) is handled too
+                    "member_type": ["way"],
+                    "member_id": np.array([11], dtype=np.int64),
+                    "member_role": ["outer"],
+                },
+            ],
+            dtype=object,
+        ),
+    }
+    way_by_id = {
+        10: {"id": 10, "nodes": [100, 101]},
+        11: {"id": 11, "nodes": [101, 102]},
+    }
+    kn, kw, kr = _subset_keep_sets({}, {}, {1: {}, 888: {}}, way_by_id, relations)
+    assert kr == {1, 2, 888}  # sub-relation 2 resolved; 888 kept; 999 absent
+    assert kw == {10, 11}  # way members of relations 1 and 2
+    assert kn == {100, 101, 102}  # node member + way node-refs


### PR DESCRIPTION
## Summary

Adds a `subset_only` option to `OSM.write_pbf` (issue #348). By default `write_pbf` writes the whole cached dataset; with `subset_only=True` it writes a PBF containing **only** the features in the given GeoDataFrame(s), plus the references they need to stay valid.

## Behaviour

- `OSM.write_pbf(data, output_path, subset_only=False)` — the default is unchanged (the whole cached dataset is written, so untouched layers survive).
- `subset_only=True` writes only the elements present in `data` (matched by `osm_type` + `id`), with reference completion from the cache: kept ways pull in their nodes and kept relations pull in their member ways/nodes (recursing into super-relations), so the output stays a valid, re-readable PBF.
- Multiple layers can be combined by passing a list (`[buildings, network]`); the union of their elements is written.

## Implementation

- `pyrosm/pbf_writer.py`: `_subset_keep_sets` computes the reference closure; a `keep` filter gates `_add_base_nodes` / `_add_base_ways` / `_add_base_relations` (`keep=None` preserves the existing whole-dataset path verbatim). Frames that omit `osm_type` (e.g. the node frame from `get_network(nodes=True)`) have their element type inferred from geometry, so existing elements match the cache instead of being re-synthesized as new nodes. An empty subset writes a valid header-only PBF.
- `pyrosm/pyrosm.py`: the `subset_only` parameter on `write_pbf`.
- `docs/saving_and_cropping.ipynb`: an "Export only selected layers" section.

## Verification

New tests in `tests/test_pbf_export.py`: a buildings-only subset excludes the unrelated road network, a network-only subset excludes buildings, a multi-layer list writes the union of both, `get_network(nodes=True)` round-trips without synthesized duplicate nodes, an empty subset writes a readable PBF, and the default `subset_only=False` still writes the whole dataset; plus unit tests for the reference closure and the geometry-based type inference.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
