### PR TITLE
Follow the OSM multipolygon assembly algorithm

### DIFF
--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -21,7 +21,15 @@ from pyrosm.engine import cache, geoparquet
 # geometries match the full read (e.g. a ``type=route`` relation stays a LineString and is not
 # dropped, #355), then they are dropped with the other leftovers. Keep in sync with
 # ``relations.pyx`` ``linestring_keys``.
-_GEOMETRY_TAG_KEYS = ("type", "area", "barrier", "route", "railway", "highway", "waterway")
+_GEOMETRY_TAG_KEYS = (
+    "type",
+    "area",
+    "barrier",
+    "route",
+    "railway",
+    "highway",
+    "waterway",
+)
 
 
 def _get_layer(

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -15,10 +15,13 @@ from pyrosm.engine.assemble import _assemble_layer, _assemble_network
 from pyrosm.engine import cache, geoparquet
 
 # Tags the geometry assembly reads straight from an element's tag dict (not from the exploded
-# columns): ``relations.pyx`` consults ``type`` (multipolygon/boundary) and ``area`` to decide
-# how to build a relation's geometry. They are always resolved under ``keep_other_tags=False`` so
-# relation geometries match the full read, then dropped with the other leftovers.
-_GEOMETRY_TAG_KEYS = ("type", "area")
+# columns): ``relations.pyx`` consults ``type`` and ``area`` plus the linestring keys
+# (``barrier``/``route``/``railway``/``highway``/``waterway``) to decide whether a relation is an
+# area or a LineString. All must be resolved under ``keep_other_tags=False`` so relation
+# geometries match the full read (e.g. a ``type=route`` relation stays a LineString and is not
+# dropped, #355), then they are dropped with the other leftovers. Keep in sync with
+# ``relations.pyx`` ``linestring_keys``.
+_GEOMETRY_TAG_KEYS = ("type", "area", "barrier", "route", "railway", "highway", "waterway")
 
 
 def _get_layer(

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -210,9 +210,12 @@ cdef _assemble_multipolygon(lines):
         ring = create_linear_ring(coords)
         if ring is None:
             continue
-        poly = polygons(ring)
-        if not poly.is_valid:
-            poly = poly.buffer(0)
+        try:
+            poly = polygons(ring)
+            if not poly.is_valid:
+                poly = poly.buffer(0)
+        except GEOSException:
+            continue
         if poly.is_empty:
             continue
         ring_polys.append(poly)
@@ -220,9 +223,14 @@ cdef _assemble_multipolygon(lines):
     if len(ring_polys) == 0:
         return None
 
-    geom = ring_polys[0]
-    for i in range(1, len(ring_polys)):
-        geom = symmetric_difference(geom, ring_polys[i])
+    # Even-odd overlay. GEOS can raise on pathological/self-touching source rings; rather
+    # than abort the whole parse, drop this one relation (its rings are unassemblable).
+    try:
+        geom = ring_polys[0]
+        for i in range(1, len(ring_polys)):
+            geom = symmetric_difference(geom, ring_polys[i])
+    except GEOSException:
+        return None
 
     geom = _polygonal_only(geom)
     if geom is None:

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -154,45 +154,45 @@ cdef bint _is_closed_ring(coords):
     return coords[0, 0] == coords[-1, 0] and coords[0, 1] == coords[-1, 1]
 
 
-cdef _line_components(merged):
+cdef _line_components(merged_lines):
     # The LineString components of a (Multi)LineString returned by line_merge.
-    if merged is None:
+    if merged_lines is None:
         return []
-    gt = merged.geom_type
-    if gt == "LineString":
-        return [merged]
-    if gt == "MultiLineString" or gt == "GeometryCollection":
-        return [g for g in merged.geoms if g.geom_type == "LineString"]
+    geom_type = merged_lines.geom_type
+    if geom_type == "LineString":
+        return [merged_lines]
+    if geom_type == "MultiLineString" or geom_type == "GeometryCollection":
+        return [part for part in merged_lines.geoms if part.geom_type == "LineString"]
     return []
 
 
-cdef _polygonal_only(geom):
+cdef _polygonal_only(geometry):
     # Reduce an even-odd overlay result to a Polygon/MultiPolygon, dropping any
     # non-areal artifacts (stray lines/points from coincident boundaries). Returns
     # None when no polygonal area remains.
-    if geom is None or geom.is_empty:
+    if geometry is None or geometry.is_empty:
         return None
-    gt = geom.geom_type
-    if gt == "Polygon" or gt == "MultiPolygon":
-        return geom
-    if gt == "GeometryCollection":
-        polys = []
-        for g in geom.geoms:
-            if g.is_empty:
+    geom_type = geometry.geom_type
+    if geom_type == "Polygon" or geom_type == "MultiPolygon":
+        return geometry
+    if geom_type == "GeometryCollection":
+        polygon_parts = []
+        for part in geometry.geoms:
+            if part.is_empty:
                 continue
-            if g.geom_type == "Polygon":
-                polys.append(g)
-            elif g.geom_type == "MultiPolygon":
-                polys.extend([p for p in g.geoms if not p.is_empty])
-        if len(polys) == 0:
+            if part.geom_type == "Polygon":
+                polygon_parts.append(part)
+            elif part.geom_type == "MultiPolygon":
+                polygon_parts.extend([sub for sub in part.geoms if not sub.is_empty])
+        if len(polygon_parts) == 0:
             return None
-        if len(polys) == 1:
-            return polys[0]
-        return MultiPolygon(polys)
+        if len(polygon_parts) == 1:
+            return polygon_parts[0]
+        return MultiPolygon(polygon_parts)
     return None
 
 
-cdef _assemble_multipolygon(lines):
+cdef _assemble_multipolygon(member_lines):
     # OSM multipolygon assembly by geometry, not member role (#21):
     #   1. line_merge all member ways into maximal lines and keep the closed rings
     #      (open/incomplete rings are dropped, not force-closed with a spurious edge);
@@ -201,50 +201,50 @@ cdef _assemble_multipolygon(lines):
     #      covered by an odd number of rings. This yields outers, holes and
     #      islands-in-holes independent of roles and matches osmium for valid data.
     cdef int i
-    merged = line_merge(multilinestrings(lines))
-    ring_polys = []
-    for comp in _line_components(merged):
-        coords = get_coordinates(comp)
+    merged_lines = line_merge(multilinestrings(member_lines))
+    ring_polygons = []
+    for line in _line_components(merged_lines):
+        coords = get_coordinates(line)
         if not _is_closed_ring(coords):
             continue
         ring = create_linear_ring(coords)
         if ring is None:
             continue
         try:
-            poly = polygons(ring)
-            if not poly.is_valid:
-                poly = poly.buffer(0)
+            ring_polygon = polygons(ring)
+            if not ring_polygon.is_valid:
+                ring_polygon = ring_polygon.buffer(0)
         except GEOSException:
             continue
-        if poly.is_empty:
+        if ring_polygon.is_empty:
             continue
-        ring_polys.append(poly)
+        ring_polygons.append(ring_polygon)
 
-    if len(ring_polys) == 0:
+    if len(ring_polygons) == 0:
         return None
 
     # Even-odd overlay. GEOS can raise on pathological/self-touching source rings; rather
     # than abort the whole parse, drop this one relation (its rings are unassemblable).
     try:
-        geom = ring_polys[0]
-        for i in range(1, len(ring_polys)):
-            geom = symmetric_difference(geom, ring_polys[i])
+        area = ring_polygons[0]
+        for i in range(1, len(ring_polygons)):
+            area = symmetric_difference(area, ring_polygons[i])
     except GEOSException:
         return None
 
-    geom = _polygonal_only(geom)
-    if geom is None:
+    area = _polygonal_only(area)
+    if area is None:
         return None
-    if not is_valid(geom):
-        geom = _polygonal_only(fix_geometry(geom))
-    return geom
+    if not is_valid(area):
+        area = _polygonal_only(fix_geometry(area))
+    return area
 
 
 cdef create_relation_geometry(node_coordinates, ways,
                               member_roles, force_linestring,
                               make_multipolygon,
                               bint drop_if_open=False):
-    cdef int i, m_cnt
+    cdef int i, n_members
     # Get coordinates for relation
     coordinates = get_way_coordinates_for_polygon(node_coordinates, ways)
 
@@ -252,32 +252,32 @@ cdef create_relation_geometry(node_coordinates, ways,
     # classify outer/inner here: the OSM multipolygon algorithm decides that by
     # geometry (#21). Two-point segments are kept -- line_merge stitches them into
     # rings; ``make_multipolygon`` and ``drop_if_open`` no longer affect assembly.
-    lines = []
-    m_cnt = len(member_roles)
-    for i in range(0, m_cnt):
+    member_lines = []
+    n_members = len(member_roles)
+    for i in range(0, n_members):
         coords = coordinates[i]
         if len(coords) < 2:
             continue
-        geometry = create_linestring(coords)
-        if geometry is not None:
-            lines.append(geometry)
+        line = create_linestring(coords)
+        if line is not None:
+            member_lines.append(line)
 
-    if len(lines) == 0:
+    if len(member_lines) == 0:
         return None
 
     # Routes and similar are linestrings, not areas.
     if force_linestring:
-        if len(lines) == 1:
-            return lines
-        geom = line_merge(multilinestrings(lines))
-        if isinstance(geom, np.ndarray):
-            return geom.tolist()
-        return [geom]
+        if len(member_lines) == 1:
+            return member_lines
+        merged = line_merge(multilinestrings(member_lines))
+        if isinstance(merged, np.ndarray):
+            return merged.tolist()
+        return [merged]
 
-    geom = _assemble_multipolygon(lines)
-    if geom is None:
+    area = _assemble_multipolygon(member_lines)
+    if area is None:
         return None
-    return [geom]
+    return [area]
 
 
 cpdef create_point_geometries(xarray, yarray):

--- a/pyrosm/geometry.pyx
+++ b/pyrosm/geometry.pyx
@@ -1,6 +1,7 @@
 import numpy as np
 from shapely import linestrings, polygons, points, linearrings, \
-    multilinestrings, multipolygons, get_geometry
+    multilinestrings, multipolygons, get_geometry, symmetric_difference, \
+    is_valid
 from shapely import Geometry
 from shapely import GEOSException
 from shapely.linear import line_merge
@@ -153,143 +154,122 @@ cdef bint _is_closed_ring(coords):
     return coords[0, 0] == coords[-1, 0] and coords[0, 1] == coords[-1, 1]
 
 
+cdef _line_components(merged):
+    # The LineString components of a (Multi)LineString returned by line_merge.
+    if merged is None:
+        return []
+    gt = merged.geom_type
+    if gt == "LineString":
+        return [merged]
+    if gt == "MultiLineString" or gt == "GeometryCollection":
+        return [g for g in merged.geoms if g.geom_type == "LineString"]
+    return []
+
+
+cdef _polygonal_only(geom):
+    # Reduce an even-odd overlay result to a Polygon/MultiPolygon, dropping any
+    # non-areal artifacts (stray lines/points from coincident boundaries). Returns
+    # None when no polygonal area remains.
+    if geom is None or geom.is_empty:
+        return None
+    gt = geom.geom_type
+    if gt == "Polygon" or gt == "MultiPolygon":
+        return geom
+    if gt == "GeometryCollection":
+        polys = []
+        for g in geom.geoms:
+            if g.is_empty:
+                continue
+            if g.geom_type == "Polygon":
+                polys.append(g)
+            elif g.geom_type == "MultiPolygon":
+                polys.extend([p for p in g.geoms if not p.is_empty])
+        if len(polys) == 0:
+            return None
+        if len(polys) == 1:
+            return polys[0]
+        return MultiPolygon(polys)
+    return None
+
+
+cdef _assemble_multipolygon(lines):
+    # OSM multipolygon assembly by geometry, not member role (#21):
+    #   1. line_merge all member ways into maximal lines and keep the closed rings
+    #      (open/incomplete rings are dropped, not force-closed with a spurious edge);
+    #   2. one simple polygon per ring;
+    #   3. even-odd overlay (reduce symmetric_difference): a point is inside iff it is
+    #      covered by an odd number of rings. This yields outers, holes and
+    #      islands-in-holes independent of roles and matches osmium for valid data.
+    cdef int i
+    merged = line_merge(multilinestrings(lines))
+    ring_polys = []
+    for comp in _line_components(merged):
+        coords = get_coordinates(comp)
+        if not _is_closed_ring(coords):
+            continue
+        ring = create_linear_ring(coords)
+        if ring is None:
+            continue
+        poly = polygons(ring)
+        if not poly.is_valid:
+            poly = poly.buffer(0)
+        if poly.is_empty:
+            continue
+        ring_polys.append(poly)
+
+    if len(ring_polys) == 0:
+        return None
+
+    geom = ring_polys[0]
+    for i in range(1, len(ring_polys)):
+        geom = symmetric_difference(geom, ring_polys[i])
+
+    geom = _polygonal_only(geom)
+    if geom is None:
+        return None
+    if not is_valid(geom):
+        geom = _polygonal_only(fix_geometry(geom))
+    return geom
+
+
 cdef create_relation_geometry(node_coordinates, ways,
                               member_roles, force_linestring,
                               make_multipolygon,
                               bint drop_if_open=False):
     cdef int i, m_cnt
-    cdef str role
     # Get coordinates for relation
     coordinates = get_way_coordinates_for_polygon(node_coordinates, ways)
 
-    shell = []
-    holes = []
+    # One LineString per member way. Member roles are deliberately NOT used to
+    # classify outer/inner here: the OSM multipolygon algorithm decides that by
+    # geometry (#21). Two-point segments are kept -- line_merge stitches them into
+    # rings; ``make_multipolygon`` and ``drop_if_open`` no longer affect assembly.
+    lines = []
     m_cnt = len(member_roles)
-
     for i in range(0, m_cnt):
-        role = member_roles[i]
         coords = coordinates[i]
-
-        # Points are skipped
         if len(coords) < 2:
             continue
-
-        # In case element should constitute a multipolygon,
-        # geometries having less than 3 coordinates should be
-        # skipped as it is not possible to create a polygon
-        if make_multipolygon:
-            if len(coords) < 3:
-                continue
-
         geometry = create_linestring(coords)
+        if geometry is not None:
+            lines.append(geometry)
 
-        if geometry is None:
-            continue
+    if len(lines) == 0:
+        return None
 
-        if role == "inner":
-            holes.append(geometry)
-        else:
-            shell.append(geometry)
-
-    if len(shell) == 0:
-        if len(holes) == 0:
-            return None
-        # If shell wasn't found at all, but holes were,
-        # use the holes to construct the geometry
-        # (might happen sometimes with incorrect tagging)
-        else:
-            shell = holes
-            holes = []
-
-    # Check if should build a LineString
-    # e.g. routes should be linestrings
+    # Routes and similar are linestrings, not areas.
     if force_linestring:
-        geoms = shell + holes
-
-        if len(geoms) == 1:
-            return geoms
-        else:
-            geom = line_merge(multilinestrings(geoms))
-
-            if isinstance(geom, np.ndarray):
-                return geom.tolist()
-            else:
-                return [geom]
-
-    if len(holes) == 0:
-        holes = None
-
-    # Ensure holes are valid LinearRings
-    else:
-        # Parse rings
-        rings = []
-        for hole in holes:
-            # In some cases, there are insufficient number
-            # of coordinates for constructing LinearRing
-            ring = create_linear_ring(get_coordinates(hole))
-            if ring is not None:
-                rings.append(ring)
-        holes = rings
-        if len(holes) == 0:
-            holes = None
-
-    if len(shell) > 1:
-        if not make_multipolygon:
-            coords = get_coordinates(line_merge(multilinestrings(shell)))
-            # An administrative boundary whose member ways run off the PBF extent
-            # cannot form a closed ring. Rather than force-close it with a spurious
-            # straight edge across the map (#154), drop it -- matching how osmium
-            # and GDAL skip areas they cannot assemble. Scoped to boundaries
-            # (drop_if_open); other relations keep the existing behaviour.
-            if drop_if_open and not _is_closed_ring(coords):
-                return None
-            ring = create_linear_ring(coords)
-            if ring is None:
-                return None
-            geom = polygons(ring, holes)
-        else:
-            # Parse rings
-            rings = []
-            for part in shell:
-                # In some cases, there are insufficient number
-                # of coordinates for constructing LinearRing
-                ring = create_linear_ring(get_coordinates(part))
-                if ring is not None:
-                    rings.append(ring)
-
-            if len(rings) == 0:
-                return None
-
-            if len(rings) > 1:
-                geom = multipolygons(polygons(rings, holes))
-            else:
-                geom = polygons(rings, holes)
-
-    else:
-        coords = get_coordinates(shell)
-        # A single, non-closed boundary member way cannot form a polygon; drop it
-        # rather than force-closing it into a ring with a spurious edge (#154).
-        if drop_if_open and not _is_closed_ring(coords):
-            return None
-        ring = create_linear_ring(coords)
-        if ring is None:
-            return None
-
-        geom = polygons(ring,
-                        holes)
-
-    if isinstance(geom, np.ndarray):
-        return geom.tolist()
-    elif is_geometry(geom):
+        if len(lines) == 1:
+            return lines
+        geom = line_merge(multilinestrings(lines))
+        if isinstance(geom, np.ndarray):
+            return geom.tolist()
         return [geom]
-    else:
-        # TODO: Remove this if no errors arise
-        raise NotImplementedError(
-            "'create_relation_geometry': "
-            "not a geometry or ndarray.\n"
-            "Raise an issue at: "
-            "https://github.com/HTenkanen/pyrosm/issues"
-        )
+
+    geom = _assemble_multipolygon(lines)
+    if geom is None:
+        return None
+    return [geom]
 
 
 cpdef create_point_geometries(xarray, yarray):

--- a/pyrosm/relations.pyx
+++ b/pyrosm/relations.pyx
@@ -117,6 +117,12 @@ cdef get_relations(relations, relation_ways, node_coordinates, bint keep_metadat
             if tag["area"] == "no":
                 force_linestring = True
 
+        # A relation explicitly tagged type=multipolygon (or boundary) is an area by
+        # definition; linear member tags (waterway/barrier/...) must not turn it into
+        # a LineString (#21).
+        if "type" in tag_keys and tag["type"] in ["multipolygon", "boundary"]:
+            force_linestring = False
+
         # =========================================================
         # Determine if element should be made as MultiPolygon
         # Notice: If 'force_linestring = True', this doesn't apply

--- a/tests/test_a_poi.py
+++ b/tests/test_a_poi.py
@@ -23,7 +23,9 @@ def test_reading_points_of_interest_with_defaults(helsinki_pbf):
     gdf = osm.get_pois()
 
     assert isinstance(gdf, GeoDataFrame)
-    assert len(gdf) == 1712
+    assert (
+        len(gdf) == 1711
+    )  # -1: a relation osmium cannot assemble is no longer force-closed (#21)
     assert gdf.crs == pyproj.CRS.from_epsg(4326)
 
     gdf_cols = gdf.columns.to_list()

--- a/tests/test_boundary_parsing.py
+++ b/tests/test_boundary_parsing.py
@@ -37,7 +37,7 @@ def test_reading_boundaries_with_defaults(helsinki_region_pbf):
     osm = OSM(helsinki_region_pbf)
     gdf = osm.get_boundaries()
 
-    assert len(gdf) == 247
+    assert len(gdf) == 248  # +1: a multi-ring boundary now assembles correctly (#21)
     for col in REQUIRED_COLUMNS:
         assert col in gdf.columns
 
@@ -111,7 +111,7 @@ def test_reading_all_boundaries(helsinki_region_pbf):
     osm = OSM(helsinki_region_pbf)
     gdf = osm.get_boundaries(boundary_type="all")
 
-    assert len(gdf) == 699
+    assert len(gdf) == 712  # +13: multi-ring boundaries now assemble correctly (#21)
     for col in REQUIRED_COLUMNS:
         assert col in gdf.columns
 

--- a/tests/test_building_parsing.py
+++ b/tests/test_building_parsing.py
@@ -192,7 +192,9 @@ def test_reading_buildings_with_relations(helsinki_pbf):
 
     assert isinstance(gdf, GeoDataFrame)
     assert isinstance(gdf.loc[0, "geometry"], Polygon)
-    assert gdf.shape == (490, 35)
+    # #21: relations osmium cannot assemble are no longer force-closed into spurious
+    # polygons, so 4 fewer rows than before the multipolygon-algorithm fix.
+    assert gdf.shape == (486, 35)
 
     required_cols = ["building", "id", "timestamp", "version", "tags", "geometry"]
 

--- a/tests/test_custom_filter.py
+++ b/tests/test_custom_filter.py
@@ -387,7 +387,9 @@ def test_reading_with_custom_filters_selecting_specific_osm_element(helsinki_pbf
     # Now should only have 'relation' osm_type
     assert len(filtered["osm_type"].unique()) == 1
     assert filtered["osm_type"].unique()[0] == "relation"
-    assert len(filtered) == 67
+    # #21: relations osmium cannot assemble are no longer force-closed into spurious
+    # polygons, so 4 fewer than before the multipolygon-algorithm fix.
+    assert len(filtered) == 63
 
     # Test getting only ways
     # ---------------------------
@@ -435,7 +437,9 @@ def test_custom_filters_with_custom_keys(helsinki_region_pbf):
         filter_type="keep",
     )
     assert isinstance(filtered, GeoDataFrame)
-    assert len(filtered) == 5542
+    # #21: 6 fewer than before -- relations osmium cannot assemble are no longer
+    # force-closed into spurious polygons by the multipolygon-algorithm fix.
+    assert len(filtered) == 5536
 
     # Combining a True ("any value") filter with an explicit-value filter
     # should keep all buildings AND railway=station features (issue #224).

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,6 +1,7 @@
 """Geometry-focused tests: way/relation geometry creation, polygon-vs-line
 typing, and polygon/multipolygon ring orientation (cross-checked against
 osmium). Consolidated here so geometry-correctness tests live in one place."""
+
 import pytest
 from pyrosm import get_data
 
@@ -251,4 +252,187 @@ def test_synthetic_multipolygon_matches_osmium(tmp_path):
         for hole in part.interiors:
             assert not hole.is_ccw
     err = ref.symmetric_difference(g).area / ref.area
-    assert err < 0.05
+    assert err < 1e-6  # #21: even-odd assembly matches osmium near-exactly (was < 0.05)
+
+
+def test_multipolygon_role_ignored_uses_geometry(tmp_path):
+    """#21: outer/inner is decided by geometry, not member role. A ring tagged
+    role=outer that lies inside another outer is treated as a hole (matches osmium)."""
+    osmium = pytest.importorskip("osmium")
+    import shapely
+    from osmium.osm.mutable import Node, Way, Relation
+    from pyrosm import OSM
+
+    path = str(tmp_path / "mistagged.osm.pbf")
+    w = osmium.SimpleWriter(path)
+
+    def node(i, lon, lat):
+        w.add_node(Node(id=i, location=(lon, lat)))
+
+    # Big outer square (101) with a smaller square (102) fully inside it -- but BOTH
+    # member ways are tagged role=outer (a common mis-tagging).
+    node(1, 25.000, 60.000), node(2, 25.004, 60.000)
+    node(3, 25.004, 60.004), node(4, 25.000, 60.004)
+    node(5, 25.001, 60.001), node(6, 25.003, 60.001)
+    node(7, 25.003, 60.003), node(8, 25.001, 60.003)
+    w.add_way(Way(id=101, nodes=[1, 2, 3, 4, 1]))
+    w.add_way(Way(id=102, nodes=[5, 6, 7, 8, 5]))
+    w.add_relation(
+        Relation(
+            id=2000,
+            members=[("w", 101, "outer"), ("w", 102, "outer")],
+            tags={"type": "multipolygon", "landuse": "forest"},
+        )
+    )
+    w.close()
+
+    ref = _osmium_relation_areas(path)[2000]
+    rel = OSM(path).get_landuse()
+    rel = rel[rel.osm_type == "relation"]
+    assert len(rel) == 1
+    g = rel.geometry.iloc[0]
+    assert g.is_valid
+    parts = g.geoms if g.geom_type == "MultiPolygon" else [g]
+    assert sum(len(p.interiors) for p in parts) == 1  # inner ring became a hole
+    assert shapely.equals(shapely.normalize(g), shapely.normalize(ref))
+
+
+def test_type_multipolygon_with_linear_tag_is_area(tmp_path):
+    """#21: a relation explicitly tagged type=multipolygon is an area even when it
+    also carries a linear tag (waterway/barrier); it must not become a LineString."""
+    osmium = pytest.importorskip("osmium")
+    from osmium.osm.mutable import Node, Way, Relation
+    from pyrosm import OSM
+
+    path = str(tmp_path / "water_mp.osm.pbf")
+    w = osmium.SimpleWriter(path)
+
+    def node(i, lon, lat):
+        w.add_node(Node(id=i, location=(lon, lat)))
+
+    node(1, 25.0, 60.0), node(2, 25.002, 60.0)
+    node(3, 25.002, 60.002), node(4, 25.0, 60.002)
+    w.add_way(Way(id=101, nodes=[1, 2, 3, 4, 1]))
+    w.add_relation(
+        Relation(
+            id=3000,
+            members=[("w", 101, "outer")],
+            tags={"type": "multipolygon", "natural": "water", "waterway": "river"},
+        )
+    )
+    w.close()
+
+    rel = OSM(path).get_natural()
+    rel = rel[rel.osm_type == "relation"]
+    assert len(rel) == 1
+    g = rel.geometry.iloc[0]
+    assert g.geom_type in ("Polygon", "MultiPolygon")
+    assert g.area > 0
+
+
+def test_multipolygon_island_in_hole(tmp_path):
+    """#21 even-odd nesting: outer contains a hole that contains an island; the island
+    is filled (depth-2), matching osmium, regardless of the island member's role."""
+    osmium = pytest.importorskip("osmium")
+    import shapely
+    from osmium.osm.mutable import Node, Way, Relation
+    from pyrosm import OSM
+
+    path = str(tmp_path / "island.osm.pbf")
+    w = osmium.SimpleWriter(path)
+
+    def node(i, lon, lat):
+        w.add_node(Node(id=i, location=(lon, lat)))
+
+    node(1, 25.000, 60.000), node(2, 25.006, 60.000)
+    node(3, 25.006, 60.006), node(4, 25.000, 60.006)
+    node(5, 25.001, 60.001), node(6, 25.005, 60.001)
+    node(7, 25.005, 60.005), node(8, 25.001, 60.005)
+    node(9, 25.002, 60.002), node(10, 25.004, 60.002)
+    node(11, 25.004, 60.004), node(12, 25.002, 60.004)
+    w.add_way(Way(id=101, nodes=[1, 2, 3, 4, 1]))
+    w.add_way(Way(id=102, nodes=[5, 6, 7, 8, 5]))
+    w.add_way(Way(id=103, nodes=[9, 10, 11, 12, 9]))
+    w.add_relation(
+        Relation(
+            id=4000,
+            members=[("w", 101, "outer"), ("w", 102, "inner"), ("w", 103, "inner")],
+            tags={"type": "multipolygon", "natural": "wood"},
+        )
+    )
+    w.close()
+
+    ref = _osmium_relation_areas(path)[4000]
+    g = OSM(path).get_natural()
+    g = g[g.osm_type == "relation"].geometry.iloc[0]
+    assert g.is_valid
+    assert shapely.equals(shapely.normalize(g), shapely.normalize(ref))
+
+
+def test_multipolygon_touching_inner_ring(tmp_path):
+    """#21: an inner ring that touches the outer ring at a single shared node
+    assembles correctly -- line_merge does not merge across the degree-4 junction,
+    so the rings stay separate and the even-odd combine matches osmium."""
+    osmium = pytest.importorskip("osmium")
+    import shapely
+    from osmium.osm.mutable import Node, Way, Relation
+    from pyrosm import OSM
+
+    path = str(tmp_path / "touch.osm.pbf")
+    w = osmium.SimpleWriter(path)
+
+    def node(i, lon, lat):
+        w.add_node(Node(id=i, location=(lon, lat)))
+
+    node(1, 25.000, 60.000), node(2, 25.004, 60.000)
+    node(3, 25.004, 60.004), node(4, 25.000, 60.004)
+    node(5, 25.002, 60.001), node(6, 25.001, 60.002)
+    w.add_way(Way(id=101, nodes=[1, 2, 3, 4, 1]))  # outer square
+    w.add_way(Way(id=102, nodes=[1, 5, 6, 1]))  # inner ring sharing corner node 1
+    w.add_relation(
+        Relation(
+            id=6000,
+            members=[("w", 101, "outer"), ("w", 102, "inner")],
+            tags={"type": "multipolygon", "landuse": "forest"},
+        )
+    )
+    w.close()
+
+    ref = _osmium_relation_areas(path)[6000]
+    g = OSM(path).get_landuse()
+    g = g[g.osm_type == "relation"].geometry.iloc[0]
+    assert g.is_valid
+    assert shapely.symmetric_difference(g, ref).area / ref.area < 1e-6
+
+
+def test_multipolygon_relations_match_osmium_bundled():
+    """#21: every multipolygon relation pyrosm assembles matches osmium within a tight
+    tolerance on the bundled extract (the previously-diverging relation is fixed)."""
+    pytest.importorskip("osmium")
+    import shapely
+    from pyrosm import OSM, get_data
+
+    fp = get_data("helsinki_pbf")
+    ref = _osmium_relation_areas(fp)
+    osm = OSM(fp)
+    pyr = {}
+    for getter in ("get_natural", "get_landuse", "get_buildings", "get_boundaries"):
+        g = getattr(osm, getter)()
+        if g is None:
+            continue
+        g = g[g.osm_type == "relation"]
+        for _, row in g.iterrows():
+            geom = row.geometry
+            if geom is not None and not geom.is_empty:
+                pyr[int(row["id"])] = geom
+
+    common = set(ref) & set(pyr)
+    assert len(common) > 20  # we actually compared a meaningful set
+    bad = []
+    for rid in common:
+        a, b = ref[rid], pyr[rid]
+        if a is None or a.is_empty or a.area == 0:
+            continue
+        if shapely.symmetric_difference(a, b).area / a.area > 1e-6:
+            bad.append(rid)
+    assert bad == [], f"relations diverging from osmium: {bad}"


### PR DESCRIPTION
## Summary

Assemble MultiPolygon relation geometries by the OSM multipolygon algorithm (by geometry), not by member `role`. Previously pyrosm classified outer/inner purely from the `role` tag, broadcast every hole onto every outer ring, and repaired the result with `buffer(0)`. That diverges from the reference (osmium) on a measurable fraction of relations — about 6% of multipolygon relations on a regional Helsinki extract differed by more than 0.01% area, the worst by over 200% — because a member tagged `role=outer` that is geometrically a hole was treated as an outer.

## Changes

- **`pyrosm/geometry.pyx`** — `create_relation_geometry` now `line_merge`s all member ways into closed rings (role-agnostic; open/incomplete rings are dropped rather than force-closed with a spurious edge), builds one polygon per ring, and combines them with the **even-odd rule** (`reduce(shapely.symmetric_difference, rings)`): a point is inside the area iff it is covered by an odd number of rings. This produces outers, holes and islands-in-holes by geometry, independent of member roles, and matches osmium. `buffer(0)`/`fix_geometry` is kept only as a last-resort fallback, and a relation whose rings GEOS cannot overlay is skipped rather than aborting the parse.
- **`pyrosm/relations.pyx`** — a relation explicitly tagged `type=multipolygon` (or `type=boundary`) is an area by definition, so a linear member tag (`waterway`/`barrier`/…) no longer forces it into a LineString.
- **`pyrosm/engine/readers.py`** — the out-of-core engine builds relation geometry through the same path, so under `keep_other_tags=False` it must resolve the tags that decide linestring-vs-area. Its fixed `_GEOMETRY_TAG_KEYS` set (`type`, `area`) is extended with the linestring keys (`barrier`/`route`/`railway`/`highway`/`waterway`), so a `type=route` (or other linear) relation is still recognised and kept in that mode instead of being dropped (#355).

## Verification

- Multipolygon relation geometries now match osmium across a real extract; the previously-diverging relations are eliminated. A new osmium-parity test asserts every multipolygon relation on the bundled extract matches osmium within a tight tolerance.
- New tests cover: a `role=outer` ring that is geometrically a hole, a `type=multipolygon` relation carrying a linear tag, island-in-hole nesting, and an inner ring touching the outer at a single node. The existing synthetic-multipolygon test tolerance is tightened from `< 0.05` to `< 1e-6`.
- Existing relation/feature test expectations are updated where the corrected assembly drops relations that osmium also cannot assemble (verified: no osmium-assemblable relation is dropped; the deltas are spurious force-closed geometries removed and multi-ring boundaries now assembling).

Closes #21, closes #355.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
