### PR TITLE
Add opt-in advanced custom_filter: regex values and Overpass-style bracket filters

### DIFF
--- a/pyrosm/boundary.py
+++ b/pyrosm/boundary.py
@@ -1,6 +1,6 @@
 from pyrosm.data_manager import get_osm_data
 from pyrosm.frames import prepare_geodataframe
-from pyrosm.utils import validate_custom_filter
+from pyrosm.utils import validate_custom_filter, ensure_filter_key
 import warnings
 
 
@@ -26,11 +26,10 @@ def get_boundary_data(
     if custom_filter is None:
         custom_filter = {"boundary": boundary_type}
 
-    if "boundary" not in custom_filter.keys():
-        custom_filter["boundary"] = True
-
-    # Check that the custom filter is in correct format
+    # Validate / normalize the filter (normalizes True -> [True]; compiles advanced forms),
+    # then ensure the "boundary" key is present (an OR term) so boundaries are always included.
     custom_filter = validate_custom_filter(custom_filter)
+    custom_filter = ensure_filter_key(custom_filter, "boundary")
 
     # Call signature for fetching buildings
     nodes, ways, relation_ways, relations = get_osm_data(

--- a/pyrosm/buildings.py
+++ b/pyrosm/buildings.py
@@ -1,6 +1,6 @@
 from pyrosm.data_manager import get_osm_data
 from pyrosm.frames import prepare_geodataframe
-from pyrosm.utils import validate_custom_filter
+from pyrosm.utils import validate_custom_filter, ensure_filter_key
 import warnings
 
 
@@ -19,12 +19,10 @@ def get_building_data(
     if custom_filter is None:
         custom_filter = {"building": [True]}
     else:
-        # Check that the custom filter is in correct format
+        # Check that the custom filter is in correct format, then ensure the "building"
+        # key is present (an OR term) so buildings are always included.
         custom_filter = validate_custom_filter(custom_filter)
-
-        # Ensure that the "building" tag exists
-        if "building" not in custom_filter.keys():
-            custom_filter["building"] = [True]
+        custom_filter = ensure_filter_key(custom_filter, "building")
 
     # Call signature for fetching buildings
     nodes, ways, relation_ways, relations = get_osm_data(

--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from cykhash.khashsets cimport any_int64_from_iter, isin_int64, Int64Set_from_buffer
 from cpython cimport array
+from pyrosm.filter_compiler import CompiledFilter
 
 
 # Structural fields the parser attaches to every (flattened) way record; any other
@@ -99,14 +100,18 @@ cdef filter_osm_records(data_records,
     solver = Solver(filter_type)
     filtered_data = []
 
+    # An advanced (compiled) filter is evaluated as a predicate; the dict normalization and
+    # the per-key OR loop below are skipped for it.
+    cdef bint use_predicate = isinstance(data_filter, CompiledFilter)
+
     if not isinstance(osm_data_type, list):
         osm_data_type = [osm_data_type]
 
-    if data_filter is not None:
+    if data_filter is not None and not use_predicate:
         if len(data_filter) == 0:
             data_filter = None
 
-    if data_filter is not None:
+    if data_filter is not None and not use_predicate:
         # A bare True value ({osm_key: True}) means "match any value for this
         # key". Normalize it to [True] so the membership checks below and the
         # Solver can treat every filter value as an iterable, rather than
@@ -140,6 +145,16 @@ cdef filter_osm_records(data_records,
             if len(set(record_keys) - WAY_STRUCTURAL_KEYS) == 0:
                 continue
         elif not has_osm_data_type(osm_data_type, record_keys):
+            continue
+
+        # Advanced filter: the key gate above already restricted candidacy to the filter's
+        # positive keys; keep/exclude the record by the predicate (issues #116, #341).
+        if use_predicate:
+            if data_filter.matches(record):
+                if filter_type == "keep":
+                    filtered_data.append(record)
+            elif filter_type == "exclude":
+                filtered_data.append(record)
             continue
 
         # Check if should be filtered based on given data_filter.
@@ -224,6 +239,19 @@ cdef record_should_be_kept(tag, osm_keys, data_filter, filter_type, bint keep_al
         return len(tag) > 0
 
     cdef str k, osm_key
+
+    # Advanced (compiled) filter: gate on the candidate keys (the element must carry at least
+    # one positive key), then keep/exclude by the predicate (issues #116, #341).
+    if isinstance(data_filter, CompiledFilter):
+        for osm_key in osm_keys:
+            if osm_key in tag:
+                break
+        else:
+            return False
+        if filter_type == "keep":
+            return data_filter.matches(tag)
+        return not data_filter.matches(tag)
+
     filter_keys = list(data_filter.keys())
     tag_keys = list(tag.keys())
 
@@ -275,8 +303,10 @@ cdef filter_relation_indices(relations, osm_keys, data_filter, filter_type, bint
     cdef int i, n = len(relations.get("tags", []))
     indices = []
 
-    # Ensure keys
-    if len(data_filter) == 0:
+    # Ensure keys (an advanced compiled filter is passed straight through to the predicate).
+    if isinstance(data_filter, CompiledFilter):
+        relation_filter = data_filter
+    elif len(data_filter) == 0:
         relation_filter = {}
     else:
         relation_filter = {key: value for key, value in data_filter.items()}
@@ -292,7 +322,9 @@ cdef filter_node_indices(node_arrays, osm_keys, data_filter, filter_type, bint k
     cdef int i, n = len(node_arrays["tags"])
     indices = []
 
-    if len(data_filter) == 0:
+    if isinstance(data_filter, CompiledFilter):
+        node_filter = data_filter
+    elif len(data_filter) == 0:
         node_filter = {}
     else:
         node_filter = {key: value for key, value in data_filter.items()}

--- a/pyrosm/data_manager.pyx
+++ b/pyrosm/data_manager.pyx
@@ -7,7 +7,8 @@ import numpy as np
 
 cdef get_data_filter_and_osm_keys(custom_filter):
     # Advanced (opt-in) filters compile to a CompiledFilter predicate; its positive keys are
-    # the candidate-key gate. compile_custom_filter is idempotent and leaves a plain dict as-is.
+    # the candidate-key gate. compile_custom_filter leaves a plain dict (or an already-compiled
+    # filter) as-is, so calling it here again is safe.
     custom_filter = compile_custom_filter(custom_filter)
     if isinstance(custom_filter, CompiledFilter):
         return custom_filter, list(custom_filter.positive_keys)

--- a/pyrosm/data_manager.pyx
+++ b/pyrosm/data_manager.pyx
@@ -2,9 +2,16 @@ from pyrosm.data_filter cimport filter_osm_records, filter_node_indices, \
     filter_array_dict_by_indices_or_mask, filter_relation_indices
 from pyrosm._arrays cimport convert_to_arrays_and_drop_empty, convert_way_records_to_lists, concatenate_dicts_of_arrays
 from pyrosm.tagparser cimport explode_tag_array
+from pyrosm.filter_compiler import compile_custom_filter, CompiledFilter
 import numpy as np
 
 cdef get_data_filter_and_osm_keys(custom_filter):
+    # Advanced (opt-in) filters compile to a CompiledFilter predicate; its positive keys are
+    # the candidate-key gate. compile_custom_filter is idempotent and leaves a plain dict as-is.
+    custom_filter = compile_custom_filter(custom_filter)
+    if isinstance(custom_filter, CompiledFilter):
+        return custom_filter, list(custom_filter.positive_keys)
+
     osm_keys = []
     if isinstance(custom_filter, dict):
         data_filter = {}

--- a/pyrosm/engine/readers.py
+++ b/pyrosm/engine/readers.py
@@ -184,15 +184,13 @@ def _resolve_tags_as_columns(base_tags, extra_attributes, tags_to_keep):
 
 def _ensure_layer_key(custom_filter, key):
     """A ``None`` ``custom_filter`` becomes ``{key: [True]}``; otherwise the layer key is
-    ensured present -- mirroring the in-memory ``get_<layer>_data`` default merge."""
-    from pyrosm.utils import validate_custom_filter
+    ensured present (an OR term) -- mirroring the in-memory ``get_<layer>_data`` default merge.
+    Handles both a plain dict and an advanced (compiled) filter."""
+    from pyrosm.utils import validate_custom_filter, ensure_filter_key
 
     if custom_filter is None:
         return {key: [True]}
-    custom_filter = dict(validate_custom_filter(custom_filter))
-    if key not in custom_filter:
-        custom_filter[key] = [True]
-    return custom_filter
+    return ensure_filter_key(validate_custom_filter(custom_filter), key)
 
 
 def get_buildings(
@@ -309,6 +307,8 @@ def get_pois(
 
     if custom_filter is None:
         custom_filter = {"amenity": True, "shop": True, "tourism": True}
+    # Validate / compile (also accepts advanced regex & bracket forms) before reading keys.
+    custom_filter = validate_custom_filter(custom_filter)
     # Per-key tag columns, exactly as OSM.get_pois builds them (Conf.tags.<key>, or the
     # basic tags for keys without a dedicated column set).
     base_tags = []
@@ -316,7 +316,7 @@ def get_pois(
         base_tags += getattr(Conf.tags, k, list(Conf.tags._basic_tags))
     return _get_layer(
         filepath,
-        validate_custom_filter(custom_filter),
+        custom_filter,
         "keep",
         _resolve_tags_as_columns(base_tags, extra_attributes, tags_to_keep),
         workers,
@@ -346,7 +346,11 @@ def get_boundaries(
     contains that text; ``extra_attributes`` / ``tags_to_keep`` adjust the tag columns. See
     :func:`_get_layer` for the other keyword arguments."""
     from pyrosm.config import Conf
-    from pyrosm.utils import validate_custom_filter, validate_boundary_type
+    from pyrosm.utils import (
+        validate_custom_filter,
+        validate_boundary_type,
+        ensure_filter_key,
+    )
 
     boundary_type = validate_boundary_type(boundary_type)
     if name is not None and output is not None:
@@ -358,11 +362,13 @@ def get_boundaries(
     value = True if boundary_type == "all" else [boundary_type]
     if custom_filter is None:
         custom_filter = {"boundary": value}
-    if "boundary" not in custom_filter:
-        custom_filter["boundary"] = True
+    # Validate / normalize (normalizes True -> [True]; compiles advanced forms), then ensure
+    # the "boundary" key is present (an OR term) so boundaries are always included.
+    custom_filter = validate_custom_filter(custom_filter)
+    custom_filter = ensure_filter_key(custom_filter, "boundary")
     gdf = _get_layer(
         filepath,
-        validate_custom_filter(custom_filter),
+        custom_filter,
         "keep",
         _resolve_tags_as_columns(Conf.tags.boundary, extra_attributes, tags_to_keep),
         workers,
@@ -539,7 +545,7 @@ def get_network(
     extra_attributes=None,
     nodes=False,
     custom_filter=None,
-    filter_type="exclude",
+    filter_type=None,
     tags_to_keep=None,
     bounding_box=None,
     workers=None,
@@ -567,23 +573,34 @@ def get_network(
     cache."""
     from pyrosm.config import Conf
     from pyrosm.utils import validate_custom_filter, validate_tags_as_columns
+    from pyrosm.filter_compiler import CompiledFilter
 
     tags_as_columns = list(Conf.tags.highway)
     if tags_to_keep is not None:
         validate_tags_as_columns(tags_to_keep)
         tags_as_columns = list(tags_to_keep)
+    # Predefined networks select 'highway' ways; an advanced custom filter selects ways by its
+    # own positive keys (so railway/cycleway networks work).
+    network_keys = ["highway"]
     if custom_filter is not None:
         custom_filter = validate_custom_filter(custom_filter)
-        filter_type = filter_type.lower()
-        if filter_type not in ("keep", "exclude"):
-            raise ValueError(
-                "'filter_type' -parameter should be either 'keep' or 'exclude'."
-            )
+        advanced_filter = isinstance(custom_filter, CompiledFilter)
+        # Advanced filters default to 'keep' (Overpass union); plain-dict filters to 'exclude'.
+        if filter_type is None:
+            filter_type = "keep" if advanced_filter else "exclude"
+        else:
+            filter_type = filter_type.lower()
+            if filter_type not in ("keep", "exclude"):
+                raise ValueError(
+                    "'filter_type' -parameter should be either 'keep' or 'exclude'."
+                )
         network_filter = custom_filter
         # Expose the filter keys as columns too (e.g. 'bicycle', 'service').
         for key in custom_filter.keys():
             if key not in tags_as_columns:
                 tags_as_columns.append(key)
+        if advanced_filter:
+            network_keys = list(custom_filter.positive_keys)
     else:
         network_filter = _network_filter(network_type)
         # Predefined networks are always exclude filters keyed on 'highway'.
@@ -595,8 +612,7 @@ def get_network(
     data_filter = (
         None if network_filter is None else parse_custom_filter(network_filter)[0]
     )
-    # Networks always select highway ways (the filter values may reference other keys).
-    filter_spec = (["highway"], data_filter, filter_type)
+    filter_spec = (network_keys, data_filter, filter_type)
     bounding_box = _normalize_bounding_box(bounding_box)
     bounds = _bbox_bounds(bounding_box)
 
@@ -616,9 +632,11 @@ def get_network(
         )
         return (node_gdf, edges) if nodes else edges
 
+    decode_keys = [k.encode("utf-8") for k in network_keys]
+
     def decode():
         return _decode_and_run(
-            filepath, [b"highway"], False, workers, assemble, bbox_bounds=bounds
+            filepath, decode_keys, False, workers, assemble, bbox_bounds=bounds
         )
 
     # A user-supplied output writes the result there and returns it: a GeoParquet file for the

--- a/pyrosm/filter_compiler.py
+++ b/pyrosm/filter_compiler.py
@@ -310,11 +310,12 @@ def is_advanced_filter(custom_filter):
 
 
 def compile_custom_filter(custom_filter):
-    """Normalise any ``custom_filter`` form. Idempotent.
+    """Turn any ``custom_filter`` the user passed into the form the readers expect.
 
     Returns ``None`` for ``None``, a :class:`CompiledFilter` for the opt-in advanced forms
     (bracket string(s) or a regex-bearing dict), and the unchanged dict for a plain dict so
-    the existing fast path is preserved.
+    the existing fast path is preserved. Calling it again on its own result changes nothing,
+    so it is safe to call more than once on the same filter.
     """
     if custom_filter is None or isinstance(custom_filter, CompiledFilter):
         return custom_filter

--- a/pyrosm/filter_compiler.py
+++ b/pyrosm/filter_compiler.py
@@ -1,0 +1,330 @@
+"""Compile advanced (opt-in) ``custom_filter`` forms into an evaluable predicate.
+
+Pyrosm's default ``custom_filter`` is a plain dict of exact string values combined with
+OR. Two richer forms are supported on top of that, and both are strictly opt-in:
+
+1. **Regex values** inside a dict, e.g. ``{"ref": [re.compile(r"I[ -]?20")]}``. A compiled
+   pattern is matched against the tag value with ``re.search`` (substring match), which finds
+   inconsistently tagged values a literal filter misses.
+
+2. **Overpass-style bracket strings**, e.g.
+   ``['["highway"~"cycleway"]', '["highway"~"path"]["bicycle"~"designated"]']``. Each string is
+   the AND of its brackets; a list of strings is the OR of the strings. This is the
+   tag-filter subset of Overpass QL that osmnx users already type — not the full language.
+
+Both forms lower into the same internal representation: a ``CompiledFilter`` holding a
+**disjunctive normal form** predicate (OR of AND-groups of :class:`Condition`). A plain
+dict with only string / list / ``True`` values is left untouched and keeps pyrosm's existing
+fast dict path; only the two opt-in forms produce a ``CompiledFilter``.
+"""
+
+import re
+from dataclasses import dataclass, field
+from functools import lru_cache
+
+# Operators whose condition requires the key to be present with a matching value. They
+# alone define the candidate-key gate: an element that carries none of these keys cannot
+# satisfy any AND-group, so it can be discarded before evaluation.
+POSITIVE_OPERATORS = frozenset({"eq", "regex", "exists"})
+
+
+@lru_cache(maxsize=None)
+def _compiled_pattern(pattern, flags):
+    """Compile and cache a regex source string (per process, so it survives pickling)."""
+    return re.compile(pattern, flags)
+
+
+@dataclass(frozen=True)
+class Condition:
+    """A single tag test, e.g. ``highway = residential`` or ``ref ~ "I[ -]?20"``.
+
+    ``operator`` is one of ``eq``, ``ne``, ``regex``, ``nregex``, ``exists``, ``nexists``.
+    For ``eq``/``ne`` ``value`` is a literal string; for ``regex``/``nregex`` it is the regex
+    source and ``flags`` the ``re`` flags to compile it with (preserving e.g. ``IGNORECASE`` or
+    ``DOTALL`` from a caller's compiled pattern). ``value``/``flags`` are unused for
+    ``exists``/``nexists``. Only regex sources and integer flags (not compiled objects) are
+    stored, so the condition pickles cleanly across the engine's worker processes.
+    """
+
+    key: str
+    operator: str
+    value: str = ""
+    flags: int = 0
+
+    @property
+    def is_positive(self):
+        return self.operator in POSITIVE_OPERATORS
+
+    def matches(self, tags):
+        """Return whether ``tags`` (a key -> value mapping) satisfies this condition.
+
+        A negative operator (``ne``/``nregex``/``nexists``) is satisfied when the key is
+        absent, mirroring Overpass: ``["bicycle"!="no"]`` keeps ways that have no bicycle tag.
+        """
+        if self.operator == "exists":
+            return self.key in tags
+        if self.operator == "nexists":
+            return self.key not in tags
+        if self.key not in tags:
+            # Positive operators need the key present; negative ones are satisfied without it.
+            return self.operator in ("ne", "nregex")
+
+        tag_value = tags[self.key]
+        if self.operator == "eq":
+            return tag_value == self.value
+        if self.operator == "ne":
+            return tag_value != self.value
+        pattern = _compiled_pattern(self.value, self.flags)
+        found = pattern.search(str(tag_value)) is not None
+        return found if self.operator == "regex" else not found
+
+
+@dataclass(frozen=True)
+class CompiledFilter:
+    """An OR of AND-groups of :class:`Condition`, evaluated per element.
+
+    ``groups`` is a tuple of groups; each group is a tuple of conditions. An element matches
+    when *any* group matches, and a group matches when *all* its conditions hold.
+    """
+
+    groups: tuple = field(default_factory=tuple)
+
+    def matches(self, tags):
+        return any(
+            all(condition.matches(tags) for condition in group) for group in self.groups
+        )
+
+    @property
+    def positive_keys(self):
+        """Keys from positive conditions, used as pyrosm's candidate-key gate (``osm_keys``)."""
+        return sorted(
+            {
+                condition.key
+                for group in self.groups
+                for condition in group
+                if condition.is_positive
+            }
+        )
+
+    def keys(self):
+        """Every referenced key, so callers can expose filter keys as result columns."""
+        return sorted({condition.key for group in self.groups for condition in group})
+
+    def or_require(self, key):
+        """Return a filter that also keeps elements carrying ``key`` (an extra OR-group).
+
+        Mirrors how the feature modules inject a default layer key (e.g. ``building``) into a
+        dict filter: the group is appended only when ``key`` is not already referenced.
+        """
+        if key in self.keys():
+            return self
+        extra_group = (Condition(key, "exists"),)
+        return CompiledFilter(self.groups + (extra_group,))
+
+
+def _read_quoted(text):
+    """Read a leading single- or double-quoted token; return (unquoted_value, remainder)."""
+    if not text:
+        raise ValueError("expected a quoted key or value, got empty text")
+    quote = text[0]
+    if quote not in "\"'":
+        raise ValueError(f"expected a quoted key or value, got: {text!r}")
+    end = text.find(quote, 1)
+    if end == -1:
+        raise ValueError(f"unterminated quote in: {text!r}")
+    return text[1:end], text[end + 1 :]
+
+
+def _read_operator(text):
+    """Read a leading comparison operator; return (condition_operator, remainder)."""
+    for token, operator in (
+        ("!=", "ne"),
+        ("!~", "nregex"),
+        ("=", "eq"),
+        ("~", "regex"),
+    ):
+        if text.startswith(token):
+            return operator, text[len(token) :]
+    raise ValueError(f"expected one of = != ~ !~, got: {text!r}")
+
+
+def _split_brackets(spec):
+    """Split ``'["a"="b"]["c"]'`` into the bracket interiors ``['"a"="b"', '"c"']``.
+
+    Quote-aware so a ``]`` inside a quoted value does not end the bracket early.
+    """
+    interiors = []
+    i, n = 0, len(spec)
+    while i < n:
+        if spec[i].isspace():
+            i += 1
+            continue
+        if spec[i] != "[":
+            raise ValueError(f"expected '[' at position {i} in filter string: {spec!r}")
+        j = i + 1
+        quote = None
+        while j < n:
+            char = spec[j]
+            if quote is not None:
+                if char == quote:
+                    quote = None
+            elif char in "\"'":
+                quote = char
+            elif char == "]":
+                break
+            j += 1
+        else:
+            raise ValueError(f"unbalanced '[' in filter string: {spec!r}")
+        interiors.append(spec[i + 1 : j])
+        i = j + 1
+    return interiors
+
+
+def _parse_bracket(interior):
+    """Parse one bracket interior (e.g. ``'"highway"~"path"'``) into a :class:`Condition`."""
+    text = interior.strip()
+    if not text:
+        raise ValueError("empty bracket '[]' in filter string")
+
+    # [!"key"] -> the key must be absent.
+    if text.startswith("!"):
+        key, remainder = _read_quoted(text[1:].strip())
+        if not key:
+            raise ValueError(f"empty key in filter bracket: {interior!r}")
+        if remainder.strip():
+            raise ValueError(f'unexpected text after [!"key"]: {interior!r}')
+        return Condition(key, "nexists")
+
+    # [~"keyregex"~"valueregex"] -> regex on the key name. Unsupported: it would force a
+    # full scan of every tag of every element, defeating the candidate-key gate.
+    if text.startswith("~"):
+        raise ValueError(
+            'key-regex filters (e.g. [~"^addr:.*$"~"."]) are not supported'
+        )
+
+    key, remainder = _read_quoted(text)
+    if not key:
+        raise ValueError(f"empty key in filter bracket: {interior!r}")
+    remainder = remainder.strip()
+
+    # ["key"] -> the key must be present (any value).
+    if not remainder:
+        return Condition(key, "exists")
+
+    operator, remainder = _read_operator(remainder)
+    value, remainder = _read_quoted(remainder.strip())
+    remainder = remainder.strip()
+
+    flags = 0
+    if remainder:
+        if remainder.replace(" ", "") == ",i":
+            if operator not in ("regex", "nregex"):
+                raise ValueError(
+                    "the ',i' flag is only valid on the ~ and !~ operators"
+                )
+            flags = re.IGNORECASE
+        else:
+            raise ValueError(f"unexpected text after value: {interior!r}")
+
+    return Condition(key, operator, value, flags)
+
+
+def parse_bracket_filter(spec):
+    """Parse a bracket string (or list of strings) into AND-groups of conditions.
+
+    One string becomes one AND-group; a list of strings becomes one group each (OR). Every
+    group must hold at least one positive condition so the candidate-key gate stays sound.
+    """
+    specs = [spec] if isinstance(spec, str) else list(spec)
+    groups = []
+    for one in specs:
+        if not isinstance(one, str):
+            raise ValueError(
+                f"each bracket filter must be a string, got {one!r} of type {type(one)}"
+            )
+        conditions = tuple(_parse_bracket(b) for b in _split_brackets(one))
+        if not conditions:
+            raise ValueError(f"filter string has no brackets: {one!r}")
+        if not any(condition.is_positive for condition in conditions):
+            raise ValueError(
+                f"filter string {one!r} has only negative conditions; add at least one "
+                f"positive condition (=, ~, or a bare key) so it can select elements"
+            )
+        groups.append(conditions)
+    return tuple(groups)
+
+
+def _dict_to_groups(custom_filter):
+    """Lower a dict that contains at least one regex value into OR-of-singleton groups.
+
+    Each ``key: value`` pair becomes its own AND-group (preserving the dict's OR semantics).
+    Values follow the same contract as a plain dict filter: ``True`` (-> ``exists``) or a list
+    whose items are strings (-> ``eq``), compiled patterns (-> ``regex``), or ``True``.
+    """
+    groups = []
+    for key, values in custom_filter.items():
+        if values is True:
+            groups.append((Condition(key, "exists"),))
+            continue
+        # A bare compiled pattern is allowed (it is unambiguously a regex intent); a string
+        # must still be wrapped in a list, as in a plain dict filter.
+        if isinstance(values, re.Pattern):
+            groups.append((Condition(key, "regex", values.pattern, values.flags),))
+            continue
+        if not isinstance(values, list):
+            raise ValueError(
+                f"value for key {key!r} should be inside a list. Got {values!r}."
+            )
+        for value in values:
+            if value is True:
+                groups.append((Condition(key, "exists"),))
+            elif isinstance(value, re.Pattern):
+                groups.append((Condition(key, "regex", value.pattern, value.flags),))
+            elif isinstance(value, str):
+                groups.append((Condition(key, "eq", value),))
+            else:
+                raise ValueError(
+                    f"value {value!r} for key {key!r} must be a string, a compiled regex, "
+                    f"or True"
+                )
+    return tuple(groups)
+
+
+def _dict_has_regex(custom_filter):
+    # A regex value is recognised as a bare compiled pattern or one inside a value list (matching
+    # the plan); a tuple-wrapped pattern is not "advanced" and is rejected by the validator.
+    return any(
+        isinstance(values, re.Pattern)
+        or (isinstance(values, list) and any(isinstance(v, re.Pattern) for v in values))
+        for values in custom_filter.values()
+    )
+
+
+def is_advanced_filter(custom_filter):
+    """Whether ``custom_filter`` uses an opt-in advanced form (string, list, or regex dict)."""
+    if isinstance(custom_filter, (str, list, tuple, CompiledFilter)):
+        return True
+    if isinstance(custom_filter, dict):
+        return _dict_has_regex(custom_filter)
+    return False
+
+
+def compile_custom_filter(custom_filter):
+    """Normalise any ``custom_filter`` form. Idempotent.
+
+    Returns ``None`` for ``None``, a :class:`CompiledFilter` for the opt-in advanced forms
+    (bracket string(s) or a regex-bearing dict), and the unchanged dict for a plain dict so
+    the existing fast path is preserved.
+    """
+    if custom_filter is None or isinstance(custom_filter, CompiledFilter):
+        return custom_filter
+    if isinstance(custom_filter, (str, list, tuple)):
+        return CompiledFilter(parse_bracket_filter(custom_filter))
+    if isinstance(custom_filter, dict):
+        if _dict_has_regex(custom_filter):
+            return CompiledFilter(_dict_to_groups(custom_filter))
+        return custom_filter
+    raise ValueError(
+        f"'custom_filter' should be a dict, a bracket-filter string, or a list of such "
+        f"strings. Got {custom_filter!r} of type {type(custom_filter)}."
+    )

--- a/pyrosm/landuse.py
+++ b/pyrosm/landuse.py
@@ -1,6 +1,6 @@
 from pyrosm.data_manager import get_osm_data
 from pyrosm.frames import prepare_geodataframe
-from pyrosm.utils import validate_custom_filter
+from pyrosm.utils import validate_custom_filter, ensure_filter_key
 import warnings
 
 
@@ -20,12 +20,10 @@ def get_landuse_data(
     if custom_filter is None:
         custom_filter = {"landuse": [True]}
     else:
-        # Check that the custom filter is in correct format
+        # Check that the custom filter is in correct format, then ensure the "landuse"
+        # key is present (an OR term) so landuse elements are always included.
         custom_filter = validate_custom_filter(custom_filter)
-
-        # Ensure that the "landuse" tag exists
-        if "landuse" not in custom_filter.keys():
-            custom_filter["landuse"] = [True]
+        custom_filter = ensure_filter_key(custom_filter, "landuse")
 
     # Call signature for fetching buildings
     nodes, ways, relation_ways, relations = get_osm_data(

--- a/pyrosm/natural.py
+++ b/pyrosm/natural.py
@@ -1,6 +1,6 @@
 from pyrosm.data_manager import get_osm_data
 from pyrosm.frames import prepare_geodataframe
-from pyrosm.utils import validate_custom_filter
+from pyrosm.utils import validate_custom_filter, ensure_filter_key
 import warnings
 
 
@@ -20,12 +20,10 @@ def get_natural_data(
     if custom_filter is None:
         custom_filter = {"natural": [True]}
     else:
-        # Check that the custom filter is in correct format
+        # Check that the custom filter is in correct format, then ensure the "natural"
+        # key is present (an OR term) so natural elements are always included.
         custom_filter = validate_custom_filter(custom_filter)
-
-        # Ensure that the "landuse" tag exists
-        if "natural" not in custom_filter.keys():
-            custom_filter["natural"] = [True]
+        custom_filter = ensure_filter_key(custom_filter, "natural")
 
     # Call signature for fetching buildings
     nodes, ways, relation_ways, relations = get_osm_data(

--- a/pyrosm/networks.py
+++ b/pyrosm/networks.py
@@ -12,13 +12,15 @@ def get_network_data(
     slice_to_segments,
     filter_type="exclude",
     keep_metadata=True,
+    osm_keys="highway",
 ):
     # Structural columns are always kept; element metadata only when requested.
     tags_as_columns += ["id", "nodes"]
     if keep_metadata:
         tags_as_columns += ["timestamp", "changeset", "version"]
 
-    # Call signature for fetching network data
+    # Call signature for fetching network data. Predefined networks keep only ways with a
+    # 'highway' tag; an advanced custom filter selects ways by its own positive keys instead.
     nodes, ways, relation_ways, relations = get_osm_data(
         node_arrays=None,
         way_records=way_records,
@@ -26,8 +28,7 @@ def get_network_data(
         tags_as_columns=tags_as_columns,
         data_filter=network_filter,
         filter_type=filter_type,
-        # Keep only records having 'highway' tag
-        osm_keys="highway",
+        osm_keys=osm_keys,
         keep_metadata=keep_metadata,
     )
 

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -2,6 +2,7 @@ import warnings
 
 import pandas as pd
 from pyrosm.config import Conf
+from pyrosm.filter_compiler import CompiledFilter
 from pyrosm.pbfreader import parse_osm_data
 from pyrosm.frames import create_nodes_gdf
 from pyrosm.utils import (
@@ -317,7 +318,7 @@ class OSM:
         nodes=False,
         timestamp=None,
         custom_filter=None,
-        filter_type="exclude",
+        filter_type=None,
         tags_to_keep=None,
     ):
         """
@@ -358,18 +359,26 @@ class OSM:
             `custom_filter` so that custom-filtered networks can also be exported
             to a graph.
 
-        custom_filter : dict (optional)
-            A custom filter for selecting which highway ways to keep, e.g.
-            `{'highway': ['footway', 'residential'], 'bicycle': ['yes']}`. When
-            given, it replaces the predefined `network_type` filter (the two are
-            not combined). Only ways having a `highway` tag are considered; the
-            filter then keeps or excludes among those according to `filter_type`.
-            The filter keys are also added as columns to the result.
+        custom_filter : dict | str | list (optional)
+            A custom filter for selecting which ways to keep. When given, it replaces the
+            predefined `network_type` filter (the two are not combined), and the filter keys
+            are added as columns to the result. Three forms are supported:
 
-        filter_type : str (default: 'exclude')
-            Whether `custom_filter` should `'keep'` or `'exclude'` the matching
-            ways. Only consulted when `custom_filter` is given; the predefined
-            `network_type` filters are always applied as `'exclude'`.
+              - a dict like `{'highway': ['footway', 'residential'], 'bicycle': ['yes']}`
+                (exact values, combined with OR; only ways having a `highway` tag are
+                considered);
+              - a dict with compiled regex values, e.g. `{'ref': [re.compile(r'I[ -]?20')]}`;
+              - an Overpass-style bracket string, or a list of them, e.g.
+                `['["highway"~"cycleway"]', '["highway"~"path"]["bicycle"~"designated"]']`
+                (each string is the AND of its brackets, a list is their OR). These select
+                ways by the filter's own keys, so non-highway networks (e.g. `railway`,
+                `cycleway`) are supported.
+
+        filter_type : str (optional)
+            Whether `custom_filter` should `'keep'` or `'exclude'` the matching ways. Only
+            consulted when `custom_filter` is given. When omitted it defaults to `'keep'` for
+            a regex/bracket (advanced) filter and `'exclude'` for a plain-dict filter; the
+            predefined `network_type` filters are always applied as `'exclude'`.
 
         timestamp: str | datetime | int
             If provided, the data from given moment of time will be returned. The time should be provided in UTC.
@@ -397,6 +406,28 @@ class OSM:
         Take a look at the OSM documentation for further details about the data:
         `https://wiki.openstreetmap.org/wiki/Key:highway <https://wiki.openstreetmap.org/wiki/Key:highway>`__
         """
+        # Resolve the custom filter and filter_type once, so the engine and in-memory paths
+        # agree. An advanced (regex/bracket) filter compiles to a CompiledFilter and defaults
+        # to 'keep' (Overpass union semantics); a plain-dict filter and the predefined
+        # network_type presets default to 'exclude'.
+        advanced_filter = False
+        if custom_filter is not None:
+            custom_filter = validate_custom_filter(custom_filter)
+            advanced_filter = isinstance(custom_filter, CompiledFilter)
+            if filter_type is None:
+                filter_type = "keep" if advanced_filter else "exclude"
+            elif isinstance(filter_type, str) and filter_type.lower() in (
+                "keep",
+                "exclude",
+            ):
+                filter_type = filter_type.lower()
+            else:
+                raise ValueError(
+                    "'filter_type' -parameter should be either 'keep' or 'exclude'. "
+                )
+        else:
+            filter_type = "exclude"
+
         if self._use_engine(timestamp):
             return self._read_engine(
                 engine_backend.get_network,
@@ -413,33 +444,22 @@ class OSM:
         # semantics even when a custom_filter is provided)
         network_filter = self._get_network_filter(network_type)
         tags_as_columns = list(self.conf.tags.highway)
+        # Predefined networks select ways by 'highway'; an advanced custom filter selects by
+        # its own positive keys (so railway/cycleway networks work).
+        network_osm_keys = "highway"
 
         if tags_to_keep is not None:
             validate_tags_as_columns(tags_to_keep)
             tags_as_columns = list(tags_to_keep)
 
-        # A custom_filter replaces the predefined network filter and may use any
-        # 'keep'/'exclude' semantics; the predefined filters are always 'exclude'.
         if custom_filter is not None:
-            custom_filter = validate_custom_filter(custom_filter)
-
-            if not isinstance(filter_type, str) or filter_type.lower() not in [
-                "keep",
-                "exclude",
-            ]:
-                raise ValueError(
-                    "'filter_type' -parameter should be either 'keep' or 'exclude'. "
-                )
-            filter_type = filter_type.lower()
-
             network_filter = custom_filter
             # Expose the filter keys as columns too (e.g. 'bicycle', 'service').
             for key in custom_filter.keys():
                 if key not in tags_as_columns:
                     tags_as_columns.append(key)
-        else:
-            # Predefined networks are always exclude filters.
-            filter_type = "exclude"
+            if advanced_filter:
+                network_osm_keys = list(custom_filter.positive_keys)
 
         if extra_attributes is not None:
             validate_tags_as_columns(extra_attributes)
@@ -458,6 +478,7 @@ class OSM:
             slice_to_segments=nodes,
             filter_type=filter_type,
             keep_metadata=self.keep_metadata,
+            osm_keys=network_osm_keys,
         )
 
         if edges is not None:
@@ -951,14 +972,9 @@ class OSM:
         # If custom_filter has not been defined, initialize with default
         if custom_filter is None:
             custom_filter = {"amenity": True, "shop": True, "tourism": True}
-
         else:
-            # Check that the custom filter is in correct format
-            if not isinstance(custom_filter, dict):
-                raise ValueError(
-                    f"'custom_filter' should be a Python dictionary. "
-                    f"Got {custom_filter} with type {type(custom_filter)}."
-                )
+            # Validate / compile the filter (also accepts advanced regex & bracket forms).
+            custom_filter = validate_custom_filter(custom_filter)
 
         self._read_pbf(timestamp)
 

--- a/pyrosm/utils/__init__.py
+++ b/pyrosm/utils/__init__.py
@@ -14,6 +14,14 @@ import warnings
 
 
 def validate_custom_filter(custom_filter):
+    # Opt-in advanced forms (a bracket-filter string, a list of them, or a dict containing
+    # compiled regex values) compile into a CompiledFilter predicate; compilation validates
+    # the syntax. A plain dict keeps the existing exact-value fast path below.
+    from pyrosm.filter_compiler import compile_custom_filter, is_advanced_filter
+
+    if is_advanced_filter(custom_filter):
+        return compile_custom_filter(custom_filter)
+
     # Check that the custom filter is in correct format
     if not isinstance(custom_filter, dict):
         raise ValueError(
@@ -46,6 +54,24 @@ def validate_custom_filter(custom_filter):
                     f"Got {item} of type {type(item)}"
                 )
     return custom_filter
+
+
+def ensure_filter_key(custom_filter, key):
+    """Add a default feature key to a filter as an OR term, regardless of its form.
+
+    Mirrors the dict injection feature modules do (``custom_filter[key] = [True]``), but
+    also handles an advanced (compiled) filter via :meth:`CompiledFilter.or_require`. Never
+    mutates the input: a copy is returned only when the key has to be added.
+    """
+    from pyrosm.filter_compiler import CompiledFilter
+
+    if isinstance(custom_filter, CompiledFilter):
+        return custom_filter.or_require(key)
+    if key in custom_filter:
+        return custom_filter
+    updated = dict(custom_filter)
+    updated[key] = [True]
+    return updated
 
 
 def validate_osm_keys(osm_keys):

--- a/tests/test_advanced_filter.py
+++ b/tests/test_advanced_filter.py
@@ -96,11 +96,12 @@ def test_all_operators():
 
 def test_regex_dict_mixes_true_str_and_regex():
     # a dict routed to the advanced path lowers every value the same way a plain dict does:
-    # True -> exists, list items str -> eq / pattern -> regex, all OR'd.
+    # bare True or True-in-a-list -> exists, list items str -> eq / pattern -> regex, all OR'd.
     f = compile_custom_filter(
-        {"building": True, "name": ["Foo"], "ref": [re.compile("A1")]}
+        {"building": True, "shop": [True], "name": ["Foo"], "ref": [re.compile("A1")]}
     )
     assert f.matches({"building": "yes"})
+    assert f.matches({"shop": "kiosk"})
     assert f.matches({"name": "Foo"})
     assert f.matches({"ref": "A1 road"})
     assert not f.matches({"highway": "primary"})
@@ -170,6 +171,8 @@ def test_or_require_appends_only_when_absent():
         "[! ]",  # negated existence with blank key
         '[""="x"]',  # empty key
         '[!""]',  # empty key (negated existence)
+        "",  # empty filter string (no brackets)
+        {"ref": [re.compile("x")], "name": "Foo"},  # bare-string value in a regex dict
         ["building"],  # a bare key, not bracket syntax
         [123],  # non-string entry in a bracket list
         123,  # unsupported type
@@ -212,6 +215,15 @@ def test_condition_value_object():
     c = Condition("highway", "regex", "^foo", re.IGNORECASE)
     assert c.is_positive
     assert Condition("a", "ne").is_positive is False
+
+
+def test_read_quoted_unterminated():
+    # a defensive guard in the quote reader (the bracket splitter normally guarantees balanced
+    # quotes before this is reached)
+    from pyrosm.filter_compiler import _read_quoted
+
+    with pytest.raises(ValueError, match="unterminated"):
+        _read_quoted('"abc')
 
 
 def test_regex_dict_preserves_pattern_flags():
@@ -372,6 +384,17 @@ def test_engine_parity_pois(helsinki_pbf):
         custom_filter=advanced
     )
     assert ids(engine) == ids(in_memory)
+
+
+def test_engine_get_network_resolves_default_filter_type(helsinki_pbf):
+    # the OSM API resolves filter_type before calling the engine, so exercise the engine reader
+    # directly to cover its own default: filter_type=None -> keep for an advanced filter.
+    import pyrosm.engine as engine_backend
+
+    advanced = '["highway"~"footway|cycleway"]'
+    direct = engine_backend.get_network(helsinki_pbf, custom_filter=advanced, workers=1)
+    in_memory = OSM(helsinki_pbf).get_network(custom_filter=advanced, filter_type="keep")
+    assert ids(direct) == ids(in_memory)
 
 
 def test_engine_parity_landuse_injection(helsinki_pbf):

--- a/tests/test_advanced_filter.py
+++ b/tests/test_advanced_filter.py
@@ -345,7 +345,7 @@ def test_plain_dict_unchanged(helsinki_pbf):
 
 
 # --------------------------------------------------------------------------------------------
-# Out-of-core engine parity (serial; the sandbox cannot spawn worker pools)
+# Out-of-core engine parity (single worker)
 # --------------------------------------------------------------------------------------------
 
 
@@ -387,8 +387,8 @@ def test_engine_parity_pois(helsinki_pbf):
 
 
 def test_engine_get_network_resolves_default_filter_type(helsinki_pbf):
-    # the OSM API resolves filter_type before calling the engine, so exercise the engine reader
-    # directly to cover its own default: filter_type=None -> keep for an advanced filter.
+    # called directly (not via OSM, which passes a concrete filter_type), the engine reader
+    # resolves an omitted filter_type to keep for an advanced filter.
     import pyrosm.engine as engine_backend
 
     advanced = '["highway"~"footway|cycleway"]'

--- a/tests/test_advanced_filter.py
+++ b/tests/test_advanced_filter.py
@@ -1,0 +1,384 @@
+"""Advanced (opt-in) filtering: regex dict values and Overpass-style bracket strings.
+
+Covers the filter compiler (parsing + predicate semantics) directly, then the end-to-end
+behaviour through the in-memory and out-of-core readers on bundled data. The opt-in forms add
+regex value matching (issue #116) and Overpass-style bracket filters with AND-within-a-string /
+OR-across-strings, including non-highway networks (issue #341).
+"""
+
+import re
+import pickle
+
+import pytest
+
+from pyrosm import OSM, get_data
+from pyrosm.utils import validate_custom_filter
+from pyrosm.filter_compiler import (
+    compile_custom_filter,
+    is_advanced_filter,
+    CompiledFilter,
+    Condition,
+)
+
+
+@pytest.fixture
+def test_pbf():
+    return get_data("test_pbf")
+
+
+@pytest.fixture
+def helsinki_pbf():
+    return get_data("helsinki_pbf")
+
+
+def ids(gdf):
+    """Sorted id list of a result frame (None -> empty), for set-equality comparisons."""
+    if gdf is None:
+        return []
+    return sorted(gdf["id"].tolist())
+
+
+# --------------------------------------------------------------------------------------------
+# Compiler unit tests (no PBF)
+# --------------------------------------------------------------------------------------------
+
+
+def test_regex_dict_matches_per_key_variants():
+    # issue #116: the same road tagged inconsistently across keys. Conditions are per-key, so
+    # each variant is targeted by its own key.
+    f = compile_custom_filter(
+        {"ref": [re.compile(r"I[ -]?20")], "tiger:name_base": [re.compile(r"I[ -]?20")]}
+    )
+    assert f.matches({"ref": "I 20"})
+    assert f.matches({"ref": "I 20;US 259"})  # substring via re.search
+    assert f.matches({"tiger:name_base": "I-20"})
+    assert not f.matches({"ref": "US 259"})
+    # the literal equivalent misses the ;-joined value and the I-20 variant
+    literal = compile_custom_filter({"ref": [re.compile(r"^I 20$")]})
+    assert literal.matches({"ref": "I 20"})
+    assert not literal.matches({"ref": "I 20;US 259"})
+
+
+def test_bracket_string_is_and_list_is_or():
+    # AND within a string
+    f = compile_custom_filter('["highway"~"path"]["bicycle"~"designated"]')
+    assert f.matches({"highway": "path", "bicycle": "designated"})
+    assert not f.matches({"highway": "path"})
+    # OR across a list of strings
+    f = compile_custom_filter(['["highway"~"cycleway"]', '["railway"~"subway"]'])
+    assert f.matches({"highway": "cycleway"})
+    assert f.matches({"railway": "subway"})
+    assert not f.matches({"highway": "primary"})
+
+
+def test_all_operators():
+    eq = compile_custom_filter('["a"="x"]')
+    assert eq.matches({"a": "x"}) and not eq.matches({"a": "y"})
+
+    # negative ops are satisfied when the key is absent (Overpass semantics), so each is
+    # paired with a positive condition (a group needs at least one positive condition)
+    ne = compile_custom_filter('["k"]["a"!="x"]')
+    assert ne.matches({"k": "1"}) and not ne.matches({"k": "1", "a": "x"})
+    assert ne.matches({"k": "1", "a": "y"})
+
+    regex = compile_custom_filter('["a"~"^foo"]')
+    assert regex.matches({"a": "foobar"}) and not regex.matches({"a": "barfoo"})
+
+    nregex = compile_custom_filter('["k"]["a"!~"^foo"]')
+    assert nregex.matches({"k": "1"}) and not nregex.matches({"k": "1", "a": "foobar"})
+
+    exists = compile_custom_filter('["a"]')
+    assert exists.matches({"a": ""}) and not exists.matches({"b": "1"})
+
+    nexists = compile_custom_filter('["k"][!"a"]')
+    assert nexists.matches({"k": "1"}) and not nexists.matches({"k": "1", "a": "x"})
+
+
+def test_regex_dict_mixes_true_str_and_regex():
+    # a dict routed to the advanced path lowers every value the same way a plain dict does:
+    # True -> exists, list items str -> eq / pattern -> regex, all OR'd.
+    f = compile_custom_filter(
+        {"building": True, "name": ["Foo"], "ref": [re.compile("A1")]}
+    )
+    assert f.matches({"building": "yes"})
+    assert f.matches({"name": "Foo"})
+    assert f.matches({"ref": "A1 road"})
+    assert not f.matches({"highway": "primary"})
+
+
+def test_regex_dict_value_forms():
+    # a compiled pattern is accepted both as a bare value and inside a list (the plan's two
+    # forms); both lower to a CompiledFilter and match the same way.
+    bare = compile_custom_filter({"ref": re.compile("I[ -]?20")})
+    listed = compile_custom_filter({"ref": [re.compile("I[ -]?20")]})
+    assert isinstance(bare, CompiledFilter) and isinstance(listed, CompiledFilter)
+    assert bare.matches({"ref": "I-20"}) and listed.matches({"ref": "I-20"})
+    # a tuple-wrapped pattern is not "advanced" -> falls to the validator, which requires a list
+    with pytest.raises(ValueError, match="inside a list"):
+        validate_custom_filter({"ref": (re.compile("x"),)})
+
+
+def test_whitespace_between_brackets():
+    f = compile_custom_filter(' ["a"="x"]  ["b"~"y"] ')
+    assert f.matches({"a": "x", "b": "yy"})
+
+
+def test_case_insensitive_flag():
+    f = compile_custom_filter('["name"~"oxford",i]')
+    assert f.matches({"name": "OXFORD Street"})
+    assert not compile_custom_filter('["name"~"oxford"]').matches({"name": "OXFORD Street"})
+
+
+def test_quote_aware_value_with_bracket():
+    # a ] inside a quoted value must not end the bracket early
+    f = compile_custom_filter('["name"~"a]b"]')
+    assert f.matches({"name": "xa]by"})
+
+
+def test_positive_keys_exclude_negative_conditions():
+    f = compile_custom_filter('["highway"="path"]["bicycle"!="no"]')
+    # only the positive condition's key gates candidacy
+    assert f.positive_keys == ["highway"]
+    assert sorted(f.keys()) == ["bicycle", "highway"]
+
+
+def test_or_require_appends_only_when_absent():
+    f = compile_custom_filter('["amenity"="cafe"]')
+    augmented = f.or_require("building")
+    assert "building" in augmented.keys()
+    assert augmented.matches({"building": "yes"})  # OR term
+    assert augmented.matches({"amenity": "cafe"})
+    # no-op when the key is already referenced
+    assert f.or_require("amenity") is f
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        '["highway"',  # unbalanced
+        '["highway"="a"',  # unbalanced
+        '[~"^addr:.*$"~"."]',  # key-regex unsupported
+        '["a"!="b"]',  # only a negative condition
+        '["a"#"b"]',  # unknown operator
+        '["a"="b",x]',  # bad flag
+        '["a"="b",i]',  # ,i only valid on regex ops
+        '["a"=b]',  # unquoted value
+        "[]",  # empty bracket
+        "foo",  # not bracket syntax
+        '[!"a"junk]',  # trailing text after [!"key"]
+        "[!]",  # negated existence with no key
+        "[! ]",  # negated existence with blank key
+        '[""="x"]',  # empty key
+        '[!""]',  # empty key (negated existence)
+        ["building"],  # a bare key, not bracket syntax
+        [123],  # non-string entry in a bracket list
+        123,  # unsupported type
+        {"a": [123], "b": [re.compile("x")]},  # bad value in a regex-bearing dict
+    ],
+)
+def test_invalid_filters_raise(bad):
+    with pytest.raises(ValueError):
+        compile_custom_filter(bad)
+
+
+def test_is_advanced_filter_detection():
+    assert is_advanced_filter('["a"="b"]')
+    assert is_advanced_filter(['["a"="b"]'])
+    assert is_advanced_filter({"ref": [re.compile("x")]})
+    assert not is_advanced_filter({"highway": ["primary"]})
+    assert not is_advanced_filter({"building": True})
+    assert not is_advanced_filter(None)
+
+
+def test_compile_is_idempotent_and_passthrough():
+    assert compile_custom_filter(None) is None
+    plain = {"highway": ["primary"]}
+    assert compile_custom_filter(plain) is plain  # plain dict untouched
+    compiled = compile_custom_filter('["a"="b"]')
+    assert compile_custom_filter(compiled) is compiled
+
+
+def test_pickle_roundtrip():
+    # the engine ships the filter to spawn workers, so it must pickle (and only sources are
+    # stored, never compiled regex objects)
+    f = compile_custom_filter(['["highway"~"path"]["bicycle"~"designated"]', '["a"="b"]'])
+    restored = pickle.loads(pickle.dumps(f))
+    assert restored == f
+    assert isinstance(restored, CompiledFilter)
+    assert restored.matches({"highway": "path", "bicycle": "designated"})
+
+
+def test_condition_value_object():
+    c = Condition("highway", "regex", "^foo", re.IGNORECASE)
+    assert c.is_positive
+    assert Condition("a", "ne").is_positive is False
+
+
+def test_regex_dict_preserves_pattern_flags():
+    # a compiled pattern's flags (e.g. DOTALL) survive lowering, not just IGNORECASE
+    f = compile_custom_filter({"note": [re.compile("a.b", re.DOTALL)]})
+    assert f.matches({"note": "a\nb"})  # '.' matches newline only with DOTALL
+    no_dotall = compile_custom_filter({"note": [re.compile("a.b")]})
+    assert not no_dotall.matches({"note": "a\nb"})
+
+
+# --------------------------------------------------------------------------------------------
+# In-memory reader (helsinki_pbf)
+# --------------------------------------------------------------------------------------------
+
+
+def test_regex_value_union_matches_literal_union(helsinki_pbf):
+    # issue #116 end-to-end: a regex value matching several alternatives equals the literal
+    # union a plain dict expresses.
+    osm = OSM(helsinki_pbf)
+    regex = osm.get_data_by_custom_criteria(
+        custom_filter={"highway": [re.compile("footway|cycleway")]}
+    )
+    literal = osm.get_data_by_custom_criteria(
+        custom_filter={"highway": ["footway", "cycleway"]}
+    )
+    assert ids(regex) == ids(literal)
+    assert len(ids(regex)) > 0
+
+
+def test_regex_matches_semicolon_joined_value(helsinki_pbf):
+    # issue #116 end-to-end: a regex value matches a multi-value (;-joined) tag via substring,
+    # which a literal exact-match filter misses. The bundled extract has
+    # surface="paved;cobblestone".
+    osm = OSM(helsinki_pbf)
+    regex = osm.get_data_by_custom_criteria(
+        custom_filter={"surface": [re.compile("cobblestone")]}
+    )
+    literal = osm.get_data_by_custom_criteria(custom_filter={"surface": ["cobblestone"]})
+    assert regex is not None
+    assert "paved;cobblestone" in set(regex["surface"].dropna())
+    literal_surfaces = set() if literal is None else set(literal["surface"].dropna())
+    assert "paved;cobblestone" not in literal_surfaces
+
+
+def test_network_bracket_union_matches_dict(helsinki_pbf):
+    # issue #341: a list of bracket strings (OR) selecting highway values equals the dict form.
+    osm = OSM(helsinki_pbf)
+    bracket = osm.get_network(
+        custom_filter=['["highway"~"^footway$"]', '["highway"~"^cycleway$"]'],
+        filter_type="keep",
+    )
+    osm2 = OSM(helsinki_pbf)
+    plain = osm2.get_network(
+        custom_filter={"highway": ["footway", "cycleway"]}, filter_type="keep"
+    )
+    assert ids(bracket) == ids(plain)
+    assert len(ids(bracket)) > 0
+    assert set(bracket["highway"].unique()) <= {"footway", "cycleway"}
+
+
+def test_network_and_condition_is_subset(helsinki_pbf):
+    # issue #341 AND case: every returned way satisfies both brackets and is a subset of the
+    # first bracket alone (the bundled extract has path/footway ways with a bicycle tag).
+    both = OSM(helsinki_pbf).get_network(
+        custom_filter='["highway"~"path|footway"]["bicycle"~"."]', filter_type="keep"
+    )
+    first = OSM(helsinki_pbf).get_network(
+        custom_filter='["highway"~"path|footway"]', filter_type="keep"
+    )
+    assert both is not None and len(both) > 0
+    assert set(ids(both)).issubset(set(ids(first)))
+    assert both["bicycle"].notna().all()
+    assert both["highway"].str.contains("path|footway").all()
+
+
+def test_network_non_highway_key(helsinki_pbf):
+    # issue #341: advanced filters select by their own positive keys, so a non-highway network
+    # (e.g. railway) is possible -- the historical highway-only candidacy did not allow this.
+    rail = OSM(helsinki_pbf).get_network(
+        custom_filter='["railway"~"subway|tram|rail"]', filter_type="keep"
+    )
+    assert rail is not None and len(rail) > 0
+    assert "railway" in rail.columns
+    assert rail["railway"].notna().all()
+    assert rail["railway"].str.contains("subway|tram|rail").all()
+
+
+def test_network_filter_type_matrix(helsinki_pbf):
+    # advanced filters default to keep; explicit keep matches the default; keep and exclude
+    # partition the candidate universe (here: ways carrying a highway tag).
+    keep_default = OSM(helsinki_pbf).get_network(custom_filter='["highway"~"^footway$"]')
+    keep_explicit = OSM(helsinki_pbf).get_network(
+        custom_filter='["highway"~"^footway$"]', filter_type="keep"
+    )
+    exclude = OSM(helsinki_pbf).get_network(
+        custom_filter='["highway"~"^footway$"]', filter_type="exclude"
+    )
+    universe = OSM(helsinki_pbf).get_network(custom_filter='["highway"~"."]', filter_type="keep")
+
+    assert ids(keep_default) == ids(keep_explicit)
+    keep_set, exclude_set, universe_set = set(ids(keep_default)), set(ids(exclude)), set(ids(universe))
+    assert keep_set.isdisjoint(exclude_set)
+    assert keep_set | exclude_set == universe_set
+
+
+def test_buildings_layer_injection_parity(helsinki_pbf):
+    # the layer key is OR-injected for advanced filters exactly as for dicts: building OR amenity.
+    advanced = OSM(helsinki_pbf).get_buildings(custom_filter='["amenity"="restaurant"]')
+    plain = OSM(helsinki_pbf).get_buildings(custom_filter={"amenity": ["restaurant"]})
+    assert ids(advanced) == ids(plain)
+
+
+def test_plain_dict_unchanged(helsinki_pbf):
+    # backward compatibility: a plain-dict filter is untouched by the advanced path.
+    a = OSM(helsinki_pbf).get_buildings(custom_filter={"building": ["residential"]})
+    b = OSM(helsinki_pbf).get_buildings(custom_filter={"building": ["residential"]})
+    assert ids(a) == ids(b)
+    assert len(ids(a)) > 0
+
+
+# --------------------------------------------------------------------------------------------
+# Out-of-core engine parity (serial; the sandbox cannot spawn worker pools)
+# --------------------------------------------------------------------------------------------
+
+
+def test_engine_parity_buildings(helsinki_pbf):
+    advanced = '["building"~"."]'
+    in_memory = OSM(helsinki_pbf).get_buildings(custom_filter=advanced)
+    engine = OSM(helsinki_pbf, engine="out_of_core", workers=1).get_buildings(
+        custom_filter=advanced
+    )
+    assert ids(engine) == ids(in_memory)
+
+
+def test_engine_parity_network(helsinki_pbf):
+    advanced = '["highway"~"footway|cycleway"]'
+    in_memory = OSM(helsinki_pbf).get_network(custom_filter=advanced, filter_type="keep")
+    engine = OSM(helsinki_pbf, engine="out_of_core", workers=1).get_network(
+        custom_filter=advanced, filter_type="keep"
+    )
+    assert ids(engine) == ids(in_memory)
+
+
+def test_engine_parity_custom_criteria(helsinki_pbf):
+    advanced = '["highway"~"footway|cycleway"]'
+    in_memory = OSM(helsinki_pbf).get_data_by_custom_criteria(custom_filter=advanced)
+    engine = OSM(helsinki_pbf, engine="out_of_core", workers=1).get_data_by_custom_criteria(
+        custom_filter=advanced
+    )
+    assert ids(engine) == ids(in_memory)
+
+
+def test_engine_parity_pois(helsinki_pbf):
+    # POIs do not inject a layer key, so candidacy is the filter's own positive keys.
+    advanced = '["amenity"~"restaurant|cafe"]'
+    in_memory = OSM(helsinki_pbf).get_pois(custom_filter=advanced)
+    engine = OSM(helsinki_pbf, engine="out_of_core", workers=1).get_pois(
+        custom_filter=advanced
+    )
+    assert ids(engine) == ids(in_memory)
+
+
+def test_engine_parity_landuse_injection(helsinki_pbf):
+    # advanced filter on a layer that OR-injects its key (landuse): engine matches in-memory.
+    advanced = '["landuse"~"residential|forest"]'
+    in_memory = OSM(helsinki_pbf).get_landuse(custom_filter=advanced)
+    engine = OSM(helsinki_pbf, engine="out_of_core", workers=1).get_landuse(
+        custom_filter=advanced
+    )
+    assert ids(engine) == ids(in_memory)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -18,8 +18,17 @@ from pyrosm.utils import (
 )
 
 
-def test_validate_custom_filter_rejects_non_dict():
+def test_validate_custom_filter_rejects_unsupported_type():
+    # Beyond a dict, only bracket-filter strings / lists of them are accepted; other types
+    # (e.g. an int) are rejected.
     with pytest.raises(ValueError, match="dictionary"):
+        validate_custom_filter(123)
+
+
+def test_validate_custom_filter_rejects_bare_key_list():
+    # A list of plain key names (not bracket syntax) is treated as a bracket filter and
+    # fails to parse with a clear message.
+    with pytest.raises(ValueError, match="expected '\\['"):
         validate_custom_filter(["building"])
 
 


### PR DESCRIPTION
## Summary

Adds two **opt-in** ways to express a `custom_filter`, on top of the existing exact-value dict. Both are strictly opt-in: a `custom_filter` that is `None` or a plain dict (every current call) takes the existing code path unchanged.

1. **Regex values** in a dict — a value may be a compiled `re.Pattern`, matched against the tag value with `re.search` (substring match), e.g. `{"ref": [re.compile(r"I[ -]?20")]}`. This finds inconsistently tagged values (`ref="I 20"`, `ref="I 20;US 259"`, `tiger:name_base="I-20"`) that an exact filter misses (#116).

2. **Overpass-style bracket strings** — a single string or a list of them, using the Overpass tag-filter subset that OSMnx users already type, e.g.

   ```python
   cf = ['["cycleway"~"track"]',
         '["highway"~"cycleway"]',
         '["highway"~"path"]["bicycle"~"designated"]',
         '["cyclestreet"]',
         '["highway"~"living_street"]']
   edges = osm.get_network(network_type="cycling", custom_filter=cf)
   ```

   Each string is the AND of its brackets; a list of strings is their OR. Supported per bracket: `["k"="v"]`, `["k"!="v"]`, `["k"~"re"]`, `["k"!~"re"]`, `["k"]` (key present), `[!"k"]` (key absent), and a `,i` case-insensitive flag on the regex operators. This enables custom network filters, including the AND case and non-`highway` keys such as `railway`/`cycleway` (#341).

Both forms compile into one internal predicate (`pyrosm/filter_compiler.py`, a disjunctive-normal-form `CompiledFilter`) that the in-memory and out-of-core readers evaluate through the same shared entry points (`parse_custom_filter`, `element_should_be_kept`), so the two engines filter identically.

## Behavior

- For an advanced `custom_filter`, the candidate elements are selected by the filter's own keys (its positive conditions), so `get_network` can return non-`highway` networks (e.g. `railway`, `cycleway`); a plain-dict network filter keeps the previous `highway`-only candidacy.
- `get_network`'s `filter_type` defaults to `keep` for an advanced filter (Overpass union semantics) and `exclude` for the predefined `network_type` presets; an explicit `filter_type` is always honoured.
- Feature methods that inject a default key (`get_buildings`/`get_landuse`/`get_natural`/`get_boundaries`) add it to an advanced filter as an OR term, exactly as they do for a dict.
- The compiled filter stores regex sources and `re` flags (not compiled objects), so it pickles across the out-of-core engine's worker processes.

Scope: the supported syntax is the Overpass **tag-filter bracket subset**, not the full Overpass query language; key-regex brackets (`[~"k"~"v"]`) are rejected with a clear error; SQL querying is not part of this change.

Closes #116.
Refs #341.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153; OpenAI gpt-5.5 (high reasoning) via Codex CLI 0.136.0.
