### PR TITLE
Align benchmarks notebook narrative with result figures

### DIFF
--- a/docs/benchmarks/benchmarks_scaling.ipynb
+++ b/docs/benchmarks/benchmarks_scaling.ipynb
@@ -10,7 +10,7 @@
     ":::{admonition} TL;DR\n",
     ":class: tip\n",
     "\n",
-    "*Pyrosm is the fastest OSM data parser designed for Python that can extract data efficiently from PBF to GeoDataFrames, as well as crop large `.osm.pbf` files into smaller chunks by bounding box and save them to disk in PBF format (new in v0.9.0).*\n",
+    "*Benchmarks show that as of June 2026 `pyrosm` is the fastest and most memory efficient OSM data parser designed for Python that can extract data efficiently from large PBF files to GeoDataFrames (up to multiple Gigabytes with 24 GiB of RAM). Pyrosm is also able to efficiently crop and modify large `.osm.pbf` files and save them to disk in PBF format - although it is not the fastest tool around (where C++ based osmium-tool dominates).*\n",
     ":::\n",
     "\n",
     "`Pyrosm` aims to be an easy-to-use and fast Python tool for parsing OpenStreetMap data from Protocolbuffer Binary Format (PBF) files into [geopandas](http://geopandas.org/) which is the Python's go-to library for working with spatial data. Pyrosm has been written mainly in Cython (Python with C-like performance) using vectorized and parallelized operations whenever possible which makes it very efficient for parsing OpenStreetMap data. Pyrosm deserializes the protocol buffer messages using Google’s Protobuf library with its fast C `upb` backend. Google’s Protocol Buffers is a commonly used and efficient method to serialize and compress structured data which is also used by OpenStreetMap contributors to distribute the OSM data in PBF format (Protocolbuffer Binary Format).\n",
@@ -33,7 +33,7 @@
     "We benchmark three tasks:\n",
     "\n",
     "1. **Parse buildings** into a GeoDataFrame across a ladder of areas (a single neighbourhood up to a whole country), measuring both **time and peak memory** and comparing pyrosm's in-memory and out-of-core engines.\n",
-    "2. **Parse the road network** (`highway=*` ways) from the Helsinki region into a GeoDataFrame.\n",
+    "2. **Parse the road network** (`highway=*` ways) similarly into a GeoDataFrame across a ladder of areas (as with buildings), measuring both **time and peak memory** and comparing pyrosm's in-memory and out-of-core engines.\n",
     "3. **Crop a large PBF** (all of Finland) down to the Helsinki region and **write the result back to disk** as a new `.osm.pbf`.\n",
     "\n",
     "### How the comparison is kept fair\n",
@@ -97,15 +97,15 @@
    "source": [
     "### Results\n",
     "\n",
-    "Here, we introduce the key benchmarking results so that you don't need to read the whole document (although you can! Read further to see exact results and exact calculations). The results represent median wall-clock times from a single machine and dataset (a ladder of areas for parsing, all of Finland for the crop), so they are best read as orders of magnitude rather than exact rankings. \n",
+    "Here, we introduce the key benchmarking results so that you don't need to read the whole document. Read further to see the exact results and calculations. The results represent median wall-clock times from a single machine, testing a few datasets in different sizes. Thus, the rankings are indicative rather than exact and should be read with caution. Systematic benchmarking under identical conditions is hard: memory usage, thermal throttling, and background OS processes can all influence timings. However, we made every effort to not interfere with the benchmarking processes in any way while they were running (i.e. nothing else was done on the computer during the runs).\n",
     "\n",
     "**The counts confirm the tools mostly did the same work (read further to see the exact results).** Building-polygon and road-line counts agree across the local-file tools to within roughly a percent (≈176,000 buildings and ≈297,000 road lines), which is the evidence that each tool parsed the same features. OSMnx is the exception: it returns a directed routing graph from live Overpass data, so its road count (≈1.06 million edges) is not comparable/fair to the raw way counts of the other tools, which is good to keep in mind. However, we found that this was the fastest way to retrieve the network data with osmnx which is the reason why we relied on this approach. \n",
     "\n",
     "#### Parsing buildings — time and memory as the area grows\n",
     "\n",
-    "The two charts below plot parse **time** and **peak memory** against area size, from the Kamppi neighbourhood up to all of Spain, each parse run in an isolated subprocess. Overall, pyrosm's new out-of-core backend reader is very performant when reading buildings from OSM.PBF: it is the fastest parser in 4 out of 6 cases in these tests. osmextract is very close second in most cases, although with larger files the difference between pyrosm and osmextract starts to grow. osmextract (R/GDAL) is timed and memory-profiled on the same files in the companion R notebook. QuackOSM (DuckDB) and pyosmium (streaming) also stay within memory but tend to be slower. \n",
+    "The two charts below plot parse **time** and **peak memory** against area size, from the Kamppi neighbourhood up to all of Spain, each parse run in an isolated subprocess. Overall, pyrosm's new out-of-core backend reader is very performant when reading buildings from OSM.PBF. Together with osmextract (R tool), they represent the fastest parsers in these tests (very close in terms of performance). osmextract (R/GDAL) is timed and memory-profiled on the same files in the companion R notebook. QuackOSM (DuckDB) and pyosmium (streaming) also stay within memory but tend to be slower. \n",
     "\n",
-    "When comparing pyrosm's two backends, the **in-memory** engine is quick on the smallest inputs, but its peak memory climbs with size until it runs out on the country files (recorded as an out-of-memory). The **out-of-core** engine (`workers=\"auto\"`) keeps peak memory bounded — on the larger areas roughly half the in-memory peak — and parses Finland and Spain end to end. \n",
+    "When comparing pyrosm's two backends, the **in-memory** engine is quick on the smallest inputs, but its peak memory climbs with size fast. The **out-of-core** engine (`workers=\"auto\"`) keeps peak memory bounded — on the larger areas roughly half the in-memory peak — and parses Finland and Spain end to end. \n",
     "\n",
     "![Buildings speed](figures/buildings_time.png)\n",
     "\n",
@@ -129,7 +129,7 @@
     "\n",
     "#### Cropping a country down to a region\n",
     "\n",
-    "In terms of the third task, focusing in the PBF cropping, osmium-tool is the clear leader, at ≈15 s on a single core and ≈3 s across ten threads, which makes sense as the bounding-box extract is exactly what its C++ engine is built for. pyrosm crops in ≈99 s on one worker and ≈25 s with ten, or ≈64 s in its compact mode that matches osmium-tool's smaller output (in terms of output file size). Thus, parallelization provides a significant boost to pyrosm cropping capabilities in a similar manner as osmium-tool. Osmosis sits in the middle (≈168 s), and pyosmium is the slowest and does not benefit from more threads (≈226 s to ≈228 s), because its extract loop runs in single-threaded Python.\n",
+    "In terms of the third task, focusing on the PBF cropping, osmium-tool is the clear leader, at ≈15 s on a single core and ≈3 s across ten threads, which makes sense as the bounding-box extract is exactly what its C++ engine is built for. pyrosm crops in ≈99 s on one worker and ≈25 s with ten, or ≈64 s in its compact mode that matches osmium-tool's smaller output file size. Thus, parallelization provides a significant boost to pyrosm cropping capabilities in a similar manner as osmium-tool. Osmosis sits in the middle (≈168 s), and pyosmium is the slowest and does not benefit from more threads (≈226 s to ≈228 s), because its extract loop runs in single-threaded Python.\n",
     "\n",
     "![Cropping benchmarks](figures/crop_times.png)\n",
     "\n",
@@ -156,7 +156,7 @@
     "\n",
     "### Installation\n",
     "\n",
-    "All six tools (plus the notebook's plotting/dataframe deps) can be installed into one\n",
+    "All seven tools (plus the notebook's plotting/dataframe deps) can be installed into one\n",
     "environment. pyrosm, osmnx, QuackOSM and pyosmium are Python packages; Osmosis is a Java tool;\n",
     "osmextract is an R package.\n",
     "\n",
@@ -690,13 +690,9 @@
    "source": [
     "### Data\n",
     "\n",
-    "- **Buildings** are parsed across a ladder of areas of increasing size, so the timings show\n",
-    "  how each tool scales with input:\n",
-    "  **Kamppi** (a neighbourhood clipped out of the Helsinki extract), the **Helsinki Region**\n",
-    "  (~63 MB, BBBike), **Paris**, **Finland** and **Spain** (Geofabrik). pyrosm is measured with\n",
-    "  both engines; the in-memory reader and OSMnx run only on the smaller areas they can handle.\n",
-    "- **Roads** are parsed on the **Helsinki Region** extract (~63 MB) — small enough that the\n",
-    "  Overpass API (and therefore OSMnx) can serve the same area for a fair comparison.\n",
+    "- **Buildings** and **Roads** are parsed across a ladder of areas of increasing size, so the timings show\n",
+    "  how each tool scales with input: **Kamppi** (a neighbourhood clipped out of the Helsinki extract), the **Helsinki Region**, **New York City**, **Paris**, **Finland** and **Spain**. pyrosm is measured with both engines; the in-memory reader and OSMnx run only on the smaller areas they can handle.\n",
+    "\n",
     "- **Cropping** uses **all of Finland** (a few hundred MB from Geofabrik) as the large input\n",
     "  that gets cropped down to the Helsinki region.\n",
     "\n",
@@ -706,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 6,
    "id": "03fe797d",
    "metadata": {
     "editable": true,
@@ -791,28 +787,14 @@
    "source": [
     "### Task 1 — Parse buildings into a GeoDataFrame: time and memory across area sizes\n",
     "\n",
-    "Every tool reads the same `building`-filtered features into a GeoDataFrame, repeated across the\n",
-    "area ladder (Kamppi → Spain). Following the practice of the\n",
-    "[osm-python-readers-benchmark](https://github.com/RaczeQ/osm-python-readers-benchmark), each\n",
-    "parse runs in its **own subprocess** while this notebook samples the whole process tree's **peak\n",
-    "memory** (psutil) alongside wall-clock time, with a per-size timeout; a crash or out-of-memory\n",
-    "kill is recorded, not fatal. Memory is the metric that matters here: pyrosm's **out-of-core**\n",
-    "engine exists to parse files that no longer fit in RAM, so the in-memory engine\n",
-    "(`engine=\"in_memory\"`) is attempted on *every* area — including Finland and Spain — to show\n",
-    "where it runs out of memory, while the out-of-core engine (`engine=\"out_of_core\", workers=\"auto\"`,\n",
-    "cache cleared before each read), QuackOSM (DuckDB) and pyosmium (streaming) keep going. pyosmium\n",
-    "is the slow but low-memory streaming reader; osmium-tool (a GeoJSON-export CLI, not a streaming\n",
-    "reader) is shown on the Helsinki extract only. **OSMnx** is included for the two smallest areas\n",
-    "(Kamppi and Helsinki), but it downloads from the Overpass API rather than reading the local file,\n",
-    "so its time and **peak memory reflect cloud work and are not directly comparable** to the\n",
-    "local-file readers.\n",
+    "Every tool reads the same `building`-filtered features into a GeoDataFrame, repeated across the area ladder (Kamppi → Spain). Following the practice of the [osm-python-readers-benchmark](https://github.com/RaczeQ/osm-python-readers-benchmark), each parse runs in its **own subprocess** while this notebook samples the whole process tree's **peak memory** (psutil) alongside wall-clock time (with a per-size timeout). Also, a crash or out-of-memory kill is recorded. With pyrosm's **out-of-core** engine (`engine=\"out_of_core\", workers=\"auto\"`), it is possible to parse files that no longer fit in RAM as it streams the data into a temporary cache. The cache is cleared before each read, so it runs the full ladder alongside QuackOSM (DuckDB). The in-memory engine (`engine=\"in_memory\"`) is run up to Finland and skipped on Spain, where it is expected to exceed the 24 GB of RAM. pyosmium (the slow but low-memory streaming reader) and osmium-tool (a GeoJSON-export CLI, not a streaming reader) read the local files too: pyosmium is run on the four smaller areas (Kamppi → Paris) and osmium-tool up to Finland. **OSMnx** is included for the four smaller areas (Kamppi → Paris), but it downloads from the Overpass API rather than reading the local file, so its time and **peak memory reflect cloud work and are not directly comparable** to the local-file readers.\n",
     "\n",
     "Each area runs in its **own cell** below, so you can run and inspect them one at a time; re-running an area's cell replaces just that area's results."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 7,
    "id": "700af69a",
    "metadata": {
     "editable": true,
@@ -998,7 +980,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 12,
    "id": "bldarea3fin",
    "metadata": {},
    "outputs": [
@@ -1022,7 +1004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 13,
    "id": "bldarea4spa",
    "metadata": {},
    "outputs": [
@@ -1051,18 +1033,13 @@
     "\n",
     "The same comparison as buildings, for the road network: every tool extracts `highway=*` ways as\n",
     "lines (`LineString`/`MultiLineString`) and we record **time and peak memory** across the area\n",
-    "ladder, each parse in its own isolated subprocess. pyrosm uses\n",
-    "`get_data_by_custom_criteria({\"highway\": True})` with both engines. The skips match the buildings\n",
-    "task — in-memory pyrosm and pyosmium are dropped on Spain (guaranteed OOM / timeout), osmium-tool\n",
-    "is the Helsinki extract only, and OSMnx is the two small areas only. OSMnx returns a simplified\n",
-    "routing graph rather than the raw ways, so its line count is higher and not directly comparable —\n",
-    "it is shown as a cloud reference. Each area runs in its **own cell** below; re-running an area's\n",
-    "cell replaces just that area's road rows."
+    "ladder, each parse in its own isolated subprocess. pyrosm uses `get_data_by_custom_criteria({\"highway\": True})` with both engines. The skips match the buildings task — in-memory pyrosm, osmium-tool and pyosmium are dropped on Spain (likely OOM / timeout), while OSMnx is tested up to Paris extract only. OSMnx returns a simplified routing graph rather than the raw ways, so its line count is higher and not directly comparable —\n",
+    "it is shown as a cloud reference. Each area runs in its **own cell** below; re-running an area's cell replaces just that area's road rows."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 14,
    "id": "8ef78051",
    "metadata": {
     "editable": true,
@@ -1130,7 +1107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 15,
    "id": "netarea0kam",
    "metadata": {},
    "outputs": [
@@ -1156,7 +1133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 16,
    "id": "netarea1hel",
    "metadata": {},
    "outputs": [
@@ -1182,7 +1159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 17,
    "id": "e4196916-4073-4f56-bc32-6c29c995edfb",
    "metadata": {},
    "outputs": [
@@ -1208,7 +1185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "id": "netarea2par",
    "metadata": {},
    "outputs": [
@@ -1234,7 +1211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 19,
    "id": "netarea3fin",
    "metadata": {},
    "outputs": [
@@ -1259,7 +1236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 20,
    "id": "netarea4spa",
    "metadata": {},
    "outputs": [
@@ -1291,7 +1268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 21,
    "id": "geomrun000",
    "metadata": {
     "editable": true,
@@ -1390,7 +1367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 22,
    "id": "af4002e6-4df3-4427-8f62-7068ce411499",
    "metadata": {
     "editable": true,
@@ -1426,7 +1403,7 @@
     "]\n",
     "\n",
     "AREAS = [\n",
-    "    Area(\"South America\",   SOUTH_AMERICA_PBF,  3, 3600),\n",
+    "    Area(\"South America\",   SOUTH_AMERICA_PBF,  5, 3600),\n",
     "]\n",
     "\n",
     "print(f\"Head-to-head: geometry + '{GEOM_KEY}' only (pyrosm out-of-core vs quackosm):\\n\")\n",
@@ -1480,7 +1457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 23,
    "id": "8ee2d7fc",
    "metadata": {
     "editable": true,
@@ -1618,7 +1595,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 24,
    "id": "bbee5852",
    "metadata": {
     "editable": true,
@@ -1826,7 +1803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 25,
    "id": "b96f29b5",
    "metadata": {},
    "outputs": [],
@@ -1847,7 +1824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 26,
    "id": "b911d4bb",
    "metadata": {},
    "outputs": [
@@ -1875,7 +1852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 27,
    "id": "5376ee20",
    "metadata": {},
    "outputs": [
@@ -2228,7 +2205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 28,
    "id": "866c4c6e",
    "metadata": {
     "editable": true,
@@ -2268,7 +2245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 29,
    "id": "682fd543",
    "metadata": {
     "editable": true,
@@ -2457,7 +2434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 30,
    "id": "h2h-code",
    "metadata": {
     "editable": true,
@@ -2547,7 +2524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 31,
    "id": "dec0579f",
    "metadata": {
     "editable": true,


### PR DESCRIPTION
Went through the `benchmarks_scaling.ipynb` narrative once more to make sure the text matches the result figures.