### PR TITLE
Finalize v0.11.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ identifiers:
     value: 10.5281/zenodo.3755057
     description: "Concept DOI that always resolves to the latest version"
 doi: 10.5281/zenodo.3755057
-version: 0.10.0
-date-released: "2026-06-26"
+version: 0.11.0
+date-released: "2026-07-01"
 license: MIT
 repository-code: "https://github.com/pyrosm/pyrosm"
 url: "https://pyrosm.readthedocs.io/"

--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ You can run tests with `pytest` by executing:
 
 ## Citing pyrosm
 
-If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version). An example citation for the pyrosm version 0.10.0 is as follows:
+If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version). An example citation for the pyrosm version 0.11.0 is as follows:
 
-> Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames*. (v0.10.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+> Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames*. (v0.11.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 A BibTeX entry and version-specific DOIs are available in the [documentation](https://pyrosm.readthedocs.io/en/stable/citation.html) and on the [Zenodo record](https://doi.org/10.5281/zenodo.3755057).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-v0.11.0 (Jun 29, 2026)
-----------------------
+v0.11.0 (Jul 1, 2026)
+---------------------
 
 This release adds topological graph simplification for network exports, opt-in regular-expression and Overpass-style custom filters, and selective-layer PBF export, and rewrites multipolygon relation assembly to follow the OSM even-odd algorithm so relation geometries match osmium. It also reorganizes the documentation with a GeoPandas-style API reference. The default in-memory and out-of-core readers are otherwise unchanged.
 

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -17,7 +17,7 @@ Recommended citation
 --------------------
 
    Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
-   with GeoDataFrames*. (v0.10.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+   with GeoDataFrames*. (v0.11.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 BibTeX
 ------
@@ -28,7 +28,7 @@ BibTeX
      author    = {Tenkanen, Henrikki},
      title     = {{pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames}},
      year      = {2026},
-     version   = {0.10.0},
+     version   = {0.11.0},
      publisher = {Zenodo},
      doi       = {10.5281/zenodo.3755057},
      url       = {https://doi.org/10.5281/zenodo.3755057}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ copyright = f"2020-{current_year}, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.11.0rc01"
+version = release = "0.11.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -80,7 +80,7 @@ If you use pyrosm in your work, please cite it. Pyrosm is archived on
 `Zenodo <https://doi.org/10.5281/zenodo.3755057>`__ with a citable DOI:
 
     Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
-    with GeoDataFrames*. (v0.10.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+    with GeoDataFrames*. (v0.11.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 See :doc:`How to cite pyrosm <citation>` for the full reference and a BibTeX entry.
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ if _linetrace:
 
 setup(
     name="pyrosm",
-    version="0.11.0rc01",
+    version="0.11.0",
     license="MIT",
     description="A Python tool to parse OSM data from Protobuf format into GeoDataFrame.",
     long_description=read_long_description(),


### PR DESCRIPTION
Prepares the final v0.11.0 release.

- Bump version 0.11.0rc01 -> 0.11.0 in `setup.py` and `docs/conf.py` (the release workflow requires the tag to equal the setup.py version).
- Set the v0.11.0 date to Jul 1, 2026 in `docs/changelog.rst` (heading underline adjusted to match).
- Update citation metadata from 0.10.0 to 0.11.0: `CITATION.cff` (version and date-released 2026-07-01), the citation examples in `README.md`, `docs/citation.rst` (including the BibTeX version), and `docs/index.rst`.

The changelog notes were already moved under the v0.11.0 heading. Historical "added in v0.10.0" references are left unchanged.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.