### PR TITLE
Add California to US regions

### DIFF
--- a/pyrosm/data/geofabrik.py
+++ b/pyrosm/data/geofabrik.py
@@ -34,6 +34,7 @@ class USA:
         "alaska",
         "arizona",
         "arkansas",
+        "california",
         "colorado",
         "connecticut",
         "delaware",


### PR DESCRIPTION
California is a supported region on geofabrik, though it does also include the sub-regions of Northern California and Southern California ([download link for reference](https://download.geofabrik.de/north-america/us/california-latest.osm.pbf)).