### PR TITLE
Support geometry editing (move, delete, reshape) in write_pbf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+- NEW: `OSM.write_pbf` can edit geometry, not just tags. Pass `apply_geometry=True` to move an existing node (a node row's `Point` sets its coordinates, and every way and relation referencing it follows), to reshape an existing way through its `nodes` member-id column (inserting, removing and reordering vertices), and to add a new element under a caller-chosen negative id so a way's `nodes` list can reference a vertex added in the same call. The new `delete` parameter takes `(osm_type, id)` pairs to omit elements from the output, with `on_orphan_node` (`'remove'`/`'keep'`/`'error'`) and `on_deleted_member` (`'drop'`/`'error'`) deciding what happens to the references a removal breaks. Defaults are unchanged: without `apply_geometry`/`delete`, `write_pbf` writes exactly what it wrote before
+- NEW: Add a `keep_node_info` parameter to `OSM(...)`, which keeps the `nodes` column of each way's ordered member node ids in the returned GeoDataFrames. It was previously only reachable by setting the attribute after construction, and it is what `write_pbf(..., apply_geometry=True)` reshapes a way through
+
 v0.11.0
 -------
 

--- a/pyrosm/pbf_writer.py
+++ b/pyrosm/pbf_writer.py
@@ -6,10 +6,16 @@ here; the per-row tag extraction, the whole-dataset record assembly, and the
 vertex-synthesis of new geometries (approach B) all live in this module so
 ``pyrosm.py`` stays at a high level of abstraction. The low-level PBF block
 serialization lives in the Cython ``pyrosm.pbf_export`` module.
+
+Geometry edits follow the OSM model: coordinates live on nodes, and a way is an
+ordered list of member node ids. Moving a node therefore moves every way that
+references it, and an existing way is reshaped through its ``nodes`` member list
+rather than through its (derived) LineString.
 """
 
 import json
 import time
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -176,30 +182,122 @@ def _infer_osm_type(geom):
     return None
 
 
-def _collect_edits(frames, way_by_id, node_coordinates, rel_ids):
-    """Split frame rows into tag edits (matched by osm_type+id) and new rows."""
-    node_edits, way_edits, rel_edits = {}, {}, {}
-    new_rows = []
+def _row_refs(row):
+    """Ordered member node ids from a row's ``nodes`` column, or None when absent."""
+    refs = row.get("nodes")
+    if refs is None or not isinstance(refs, (list, tuple, np.ndarray)):
+        return None
+    if len(refs) == 0:
+        return None
+    return [int(r) for r in refs]
+
+
+def _set_geometry_edit(mapping, oid, value, what):
+    """Record a geometry edit, rejecting two conflicting edits of the same element.
+
+    Tag edits are last-wins (frames legitimately carry different tag columns for the
+    same element), but two different coordinates or member lists for one element are
+    a topology conflict with no safe resolution. This also catches the segment-level
+    edge frame from ``get_network(nodes=True)``, where each way spans several rows.
+    """
+    previous = mapping.get(oid)
+    if previous is not None and previous != value:
+        raise ValueError(
+            "write_pbf: conflicting %s for id %d (%r and %r). Every row of an "
+            "element must carry the same geometry." % (what, oid, previous, value)
+        )
+    mapping[oid] = value
+
+
+class _Edits:
+    """Per-element edits and additions collected from the input frame(s)."""
+
+    def __init__(self):
+        self.node_tags, self.node_coords = {}, {}
+        self.way_tags, self.way_refs = {}, {}
+        self.rel_tags = {}
+        self.new_nodes = []  # (id, lon, lat, tags)
+        self.new_ways = []  # (id, refs, tags)
+        self.auto_rows = []  # (row id, geometry, tags, explicit id or None)
+
+
+def _claim_new_id(seen, kind, oid):
+    if (kind, oid) in seen:
+        raise ValueError(
+            "write_pbf: new %s id %d appears more than once." % (kind, oid)
+        )
+    seen.add((kind, oid))
+
+
+def _add_new_element(edits, oid, otype, geom, tags, refs, seen):
+    """Queue a row with a caller-chosen (negative) id as a new element.
+
+    A ``nodes`` member list makes the row a way over existing/added nodes; otherwise
+    a ``Point`` becomes a node and a line/ring becomes a way whose vertices are
+    synthesized like an id-less row's. Ids are unique per element type, as in OSM, so
+    a new node and a new way may both be -1.
+    """
+    gtype = getattr(geom, "geom_type", None)
+    if otype == "node" or (otype is None and gtype == "Point"):
+        _claim_new_id(seen, "node", oid)
+        if gtype != "Point":
+            raise ValueError(
+                "write_pbf: new node id %d needs a Point geometry, got %r."
+                % (oid, gtype)
+            )
+        _check_lonlat(geom.x, geom.y, oid)
+        edits.new_nodes.append((oid, geom.x, geom.y, tags))
+    elif refs is not None:
+        _claim_new_id(seen, "way", oid)
+        edits.new_ways.append((oid, refs, tags))
+    else:
+        _claim_new_id(seen, "way", oid)
+        edits.auto_rows.append((oid, geom, tags, oid))
+
+
+def _collect_edits(frames, way_by_id, node_coordinates, rel_ids, apply_geometry):
+    """Split frame rows into edits of existing elements and new elements.
+
+    Existing elements are matched by ``osm_type`` + ``id``; their tags are always
+    taken from the row. With ``apply_geometry`` a node row's ``Point`` also moves the
+    node, a way row's ``nodes`` column also reshapes the way, and a row with a
+    negative unmatched id is added under exactly that id (so a way can reference a
+    vertex added in the same call). Otherwise unmatched rows are synthesized with
+    generated ids, as they always have been.
+    """
+    edits = _Edits()
+    seen_new = set()
     for gdf in frames:
         geom_col = gdf.geometry.name
         for _, row in gdf.iterrows():
             otype = _normalize_osm_type(row.get("osm_type"))
             oid = _normalize_id(row.get("id"))
+            geom = row[geom_col]
             if otype is None:
-                otype = _infer_osm_type(row[geom_col])
+                otype = _infer_osm_type(geom)
             tags = _row_tags(row, geom_col)
+            refs = _row_refs(row) if apply_geometry else None
             if oid is not None and otype == "way" and oid in way_by_id:
-                way_edits[oid] = tags
+                edits.way_tags[oid] = tags
+                if refs is not None:
+                    _set_geometry_edit(edits.way_refs, oid, refs, "member node ids")
             elif oid is not None and otype == "node" and oid in node_coordinates:
-                node_edits[oid] = tags
+                edits.node_tags[oid] = tags
+                if apply_geometry and getattr(geom, "geom_type", None) == "Point":
+                    _check_lonlat(geom.x, geom.y, oid)
+                    _set_geometry_edit(
+                        edits.node_coords, oid, (geom.x, geom.y), "coordinates"
+                    )
             elif oid is not None and otype == "relation" and oid in rel_ids:
-                rel_edits[oid] = tags
+                edits.rel_tags[oid] = tags
+            elif apply_geometry and oid is not None and oid < 0:
+                _add_new_element(edits, oid, otype, geom, tags, refs, seen_new)
             else:
-                new_rows.append((oid, row[geom_col], tags))
-    return node_edits, way_edits, rel_edits, new_rows
+                edits.auto_rows.append((oid, geom, tags, None))
+    return edits
 
 
-def _subset_keep_sets(node_edits, way_edits, rel_edits, way_by_id, relations):
+def _subset_keep_sets(node_edits, way_edits, rel_edits, way_refs, relations):
     """Closure of the matched elements over the cache, for ``subset_only``.
 
     Starts from the elements matched in the frame(s) and pulls in their references so
@@ -239,13 +337,255 @@ def _subset_keep_sets(node_edits, way_edits, rel_edits, way_by_id, relations):
                 keep_rels.add(mid)
                 pending.append(mid)
 
-    # Ways -> node refs (direct + pulled in via relations).
+    # Ways -> node refs (direct + pulled in via relations), as reshaped.
     for wid in keep_ways:
-        w = way_by_id.get(wid)
-        if w is not None:
-            keep_nodes.update(int(n) for n in w["nodes"])
+        refs = way_refs.get(wid)
+        if refs is not None:
+            keep_nodes.update(refs)
 
     return keep_nodes, keep_ways, keep_rels
+
+
+# ---------------------------------------------------------------------------
+# Deletions, reshaping and referential integrity
+# ---------------------------------------------------------------------------
+_ORPHAN_NODE_POLICIES = ("remove", "keep", "error")
+_DELETED_MEMBER_POLICIES = ("drop", "error")
+
+
+def _validate_policy(name, value, allowed):
+    if value not in allowed:
+        raise ValueError(
+            "write_pbf: '%s' should be one of %s, got %r."
+            % (name, ", ".join(repr(a) for a in allowed), value)
+        )
+
+
+def _parse_deletions(delete, node_coordinates, way_by_id, rel_ids):
+    """Split ``delete`` into per-type id sets, rejecting ids not in the source."""
+    del_nodes, del_ways, del_rels = set(), set(), set()
+    for entry in delete or ():
+        if not isinstance(entry, (tuple, list)) or len(entry) != 2:
+            raise ValueError(
+                "write_pbf: 'delete' entries should be (osm_type, id) pairs, got %r."
+                % (entry,)
+            )
+        otype = _normalize_osm_type(entry[0])
+        oid = _normalize_id(entry[1])
+        if oid is not None and otype == "node" and oid in node_coordinates:
+            del_nodes.add(oid)
+        elif oid is not None and otype == "way" and oid in way_by_id:
+            del_ways.add(oid)
+        elif oid is not None and otype == "relation" and oid in rel_ids:
+            del_rels.add(oid)
+        else:
+            raise ValueError(
+                "write_pbf: cannot delete (%r, %r); no such element in the source data."
+                % (entry[0], entry[1])
+            )
+    return del_nodes, del_ways, del_rels
+
+
+class _KnownNodes:
+    """Membership test over the source nodes plus the nodes this call adds."""
+
+    def __init__(self, node_coordinates, added_ids):
+        self._source = node_coordinates
+        self._added = added_ids
+
+    def __contains__(self, nid):
+        return nid in self._added or nid in self._source
+
+
+def _check_new_refs(refs, original, known_nodes, owner):
+    """Reject member ids an edit introduces that no node in the output will have.
+
+    Only ids the edit adds are checked: a source way whose refs already point outside
+    a clipped extract is re-emitted as it was read.
+    """
+    unchanged = set(original)
+    missing = sorted({r for r in refs if r not in unchanged and r not in known_nodes})
+    if missing:
+        raise ValueError(
+            "write_pbf: %s references node id(s) %s that are neither in the source "
+            "data nor added by this call." % (owner, missing[:5])
+        )
+
+
+def _drop_deleted_nodes(refs, del_nodes, policy, owner):
+    """Member ids with the deleted nodes removed, per ``on_deleted_member``."""
+    if not del_nodes:
+        return refs
+    hits = sorted({r for r in refs if r in del_nodes})
+    if not hits:
+        return refs
+    if policy == "error":
+        raise ValueError(
+            "write_pbf: %s still references deleted node(s) %s. Pass "
+            "on_deleted_member='drop' to remove them from its member list."
+            % (owner, hits[:5])
+        )
+    return [r for r in refs if r not in del_nodes]
+
+
+class _WritePlan:
+    """Which cached elements the write emits, and with what geometry.
+
+    ``way_refs`` holds the effective member list of every cached way that is written
+    and ``node_coords`` the moved node coordinates; the ``removed_*`` sets are the
+    cached elements the write omits. ``rel_members`` overrides the member list of the
+    relations that lost a member.
+    """
+
+    def __init__(self, edits, del_nodes):
+        self.node_tags = edits.node_tags
+        self.node_coords = edits.node_coords
+        self.way_tags = edits.way_tags
+        self.rel_tags = edits.rel_tags
+        self.way_refs = {}
+        self.rel_members = {}
+        self.removed_nodes = set(del_nodes)
+        self.removed_ways = set()
+        self.removed_rels = set()
+        self.referenced_nodes = set()
+        self.orphan_candidates = set()
+
+
+def _plan_ways(plan, way_records, edits, del_nodes, del_ways, policy, known_nodes):
+    """Resolve the member list of every cached way, dropping the ones left degenerate.
+
+    A way with fewer than two members cannot form a geometry, so it is not written and
+    its original members join the orphan candidates along with the deleted ways'.
+    """
+    degenerate = []
+    for w in way_records:
+        wid = w["id"]
+        original = [int(n) for n in w["nodes"]]
+        if wid in del_ways:
+            plan.removed_ways.add(wid)
+            plan.orphan_candidates.update(original)
+            continue
+        owner = "way %d" % wid
+        refs = edits.way_refs.get(wid)
+        if refs is None:
+            refs = original
+        else:
+            _check_new_refs(refs, original, known_nodes, owner)
+        refs = _drop_deleted_nodes(refs, del_nodes, policy, owner)
+        if len(refs) < 2:
+            plan.removed_ways.add(wid)
+            plan.orphan_candidates.update(original)
+            degenerate.append(wid)
+            continue
+        plan.way_refs[wid] = refs
+    if degenerate:
+        warnings.warn(
+            "write_pbf: %d way(s) were left with fewer than two member nodes and "
+            "were not written: %s" % (len(degenerate), sorted(degenerate)[:5]),
+            UserWarning,
+            stacklevel=2,
+        )
+
+
+def _plan_new_ways(edits, del_nodes, policy, known_nodes):
+    """Validate and deletion-filter the member lists of the newly added ways."""
+    out = []
+    for wid, refs, tags in edits.new_ways:
+        owner = "new way %d" % wid
+        _check_new_refs(refs, (), known_nodes, owner)
+        refs = _drop_deleted_nodes(refs, del_nodes, policy, owner)
+        if len(refs) < 2:
+            raise ValueError(
+                "write_pbf: new way %d needs at least two member nodes, got %d."
+                % (wid, len(refs))
+            )
+        out.append((wid, refs, tags))
+    return out
+
+
+def _plan_relations(plan, relations, del_nodes, del_rels, policy):
+    """Drop deleted members from the kept relations and note the nodes they hold."""
+    if "id" not in relations:
+        return
+    ids = relations["id"]
+    for i in range(len(ids)):
+        rid = int(ids[i])
+        if rid in del_rels:
+            plan.removed_rels.add(rid)
+            continue
+        mem = relations["members"][i]
+        kept, gone = [], []
+        for j in range(len(mem["member_id"])):
+            mtype = mem["member_type"][j]
+            mid = int(mem["member_id"][j])
+            decoded = mtype.decode() if isinstance(mtype, (bytes, bytearray)) else mtype
+            if (
+                (decoded == "node" and mid in del_nodes)
+                or (decoded == "way" and mid in plan.removed_ways)
+                or (decoded == "relation" and mid in del_rels)
+            ):
+                gone.append((decoded, mid))
+                continue
+            if decoded == "node":
+                plan.referenced_nodes.add(mid)
+            kept.append((mtype, mid, mem["member_role"][j]))
+        if gone:
+            if policy == "error":
+                raise ValueError(
+                    "write_pbf: relation %d still references removed member(s) %s. "
+                    "Pass on_deleted_member='drop' to remove them from its member "
+                    "list." % (rid, gone[:5])
+                )
+            plan.rel_members[rid] = kept
+
+
+def _resolve_orphans(plan, node_coordinates, policy):
+    """Handle the nodes left unreferenced by the ways that were dropped."""
+    orphans = {
+        nid
+        for nid in plan.orphan_candidates
+        if nid not in plan.referenced_nodes
+        and nid not in plan.removed_nodes
+        and nid in node_coordinates
+    }
+    if not orphans:
+        return
+    if policy == "error":
+        raise ValueError(
+            "write_pbf: %d node(s) %s are left unreferenced by the dropped way(s). "
+            "Pass on_orphan_node='remove' to drop them too, or 'keep' to write them "
+            "as bare nodes." % (len(orphans), sorted(orphans)[:5])
+        )
+    if policy == "remove":
+        plan.removed_nodes.update(orphans)
+
+
+def _build_plan(
+    edits,
+    way_records,
+    relations,
+    node_coordinates,
+    deletions,
+    on_orphan_node,
+    on_deleted_member,
+):
+    """Resolve edits and deletions into a plan plus the validated new ways."""
+    del_nodes, del_ways, del_rels = deletions
+    plan = _WritePlan(edits, del_nodes)
+    known_nodes = _KnownNodes(node_coordinates, {n[0] for n in edits.new_nodes})
+
+    _plan_ways(
+        plan, way_records, edits, del_nodes, del_ways, on_deleted_member, known_nodes
+    )
+    new_ways = _plan_new_ways(edits, del_nodes, on_deleted_member, known_nodes)
+    for refs in plan.way_refs.values():
+        plan.referenced_nodes.update(refs)
+    for _, refs, _ in new_ways:
+        plan.referenced_nodes.update(refs)
+
+    _plan_relations(plan, relations, del_nodes, del_rels, on_deleted_member)
+    _resolve_orphans(plan, node_coordinates, on_orphan_node)
+    return plan, new_ways
 
 
 # ---------------------------------------------------------------------------
@@ -287,9 +627,29 @@ class _RecordBuilder:
         self.css.append(changeset)
         self.ntags.append(tags)
 
-    def begin_synthesis(self):
+    def add_new_node(self, nid, lon, lat, tags):
+        self.add_node(nid, lat, lon, 1, self._now, 0, tags)
+
+    def add_new_way(self, wid, refs, tags):
+        self.ways.append(
+            {
+                "id": wid,
+                "refs": refs,
+                "version": 1,
+                "timestamp": self._now,
+                "tags": tags,
+            }
+        )
+
+    def begin_synthesis(self, reserved_way_ids=()):
+        """Start the generated-id counters below every id already claimed.
+
+        ``reserved_way_ids`` are the caller-chosen ids of new ways whose vertices are
+        still to be synthesized, so they are not yet among ``self.ways``.
+        """
         min_node = min(self.node_ids) if self.node_ids else 0
         min_way = min((w["id"] for w in self.ways), default=0)
+        min_way = min([min_way] + list(reserved_way_ids))
         self._node_counter = min(-1, min_node - 1)
         self._way_counter = min(-1, min_way - 1)
 
@@ -309,20 +669,13 @@ class _RecordBuilder:
             self.ntags[self._coord_to_index[key]] = tags
         return nid
 
-    def _add_way(self, refs, tags):
-        wid = self._way_counter
-        self._way_counter -= 1
-        self.ways.append(
-            {
-                "id": wid,
-                "refs": refs,
-                "version": 1,
-                "timestamp": self._now,
-                "tags": tags,
-            }
-        )
+    def _add_way(self, refs, tags, wid=None):
+        if wid is None:
+            wid = self._way_counter
+            self._way_counter -= 1
+        self.add_new_way(wid, refs, tags)
 
-    def add_geometry(self, oid, geom, tags):
+    def add_geometry(self, oid, geom, tags, wid=None):
         if geom is None or geom.is_empty:
             raise ValueError(
                 "write_pbf: row id %r has no (or empty) geometry to synthesize a "
@@ -335,10 +688,10 @@ class _RecordBuilder:
             self._node_for(geom.x, geom.y, oid, tags)
         elif gtype == "LineString":
             refs = [self._node_for(c[0], c[1], oid) for c in geom.coords]
-            self._add_way(refs, tags)
+            self._add_way(refs, tags, wid)
         elif gtype == "Polygon" and len(geom.interiors) == 0:
             refs = [self._node_for(c[0], c[1], oid) for c in geom.exterior.coords]
-            self._add_way(refs, tags)
+            self._add_way(refs, tags, wid)
         else:
             raise ValueError(
                 "write_pbf cannot synthesize a new element from geometry type "
@@ -383,22 +736,25 @@ def _node_tag_records(nodes_cache):
     return out
 
 
-def _add_base_nodes(builder, node_coordinates, nodes_cache, node_edits, keep=None):
+def _add_base_nodes(builder, node_coordinates, nodes_cache, plan, keep=None):
     poi_tags = _node_tag_records(nodes_cache)
     for nid, rec in node_coordinates.items():
+        if nid in plan.removed_nodes:
+            continue
         if keep is not None and nid not in keep:
             continue
-        if nid in node_edits:
-            tags = node_edits[nid]
+        if nid in plan.node_tags:
+            tags = plan.node_tags[nid]
         else:
             tags = poi_tags.get(nid)
             if tags is None:
                 tags = rec.get("tags")
             tags = tags if isinstance(tags, dict) else None
+        lon, lat = plan.node_coords.get(nid, (rec["lon"], rec["lat"]))
         builder.add_node(
             nid,
-            rec["lat"],
-            rec["lon"],
+            lat,
+            lon,
             int(rec.get("version") or 1),
             int(rec.get("timestamp") or 0),
             int(rec.get("changeset") or 0),
@@ -406,34 +762,40 @@ def _add_base_nodes(builder, node_coordinates, nodes_cache, node_edits, keep=Non
         )
 
 
-def _add_base_ways(builder, way_records, way_edits, keep=None):
+def _add_base_ways(builder, way_records, plan, keep=None):
     for w in way_records:
         wid = w["id"]
+        if wid not in plan.way_refs:
+            continue
         if keep is not None and wid not in keep:
             continue
         builder.ways.append(
             {
                 "id": wid,
-                "refs": list(w["nodes"]),
+                "refs": plan.way_refs[wid],
                 "version": w.get("version") or 1,
                 "timestamp": w.get("timestamp"),
-                "tags": way_edits.get(wid, _record_tags(w)),
+                "tags": plan.way_tags.get(wid, _record_tags(w)),
             }
         )
 
 
-def _add_base_relations(builder, relations, rel_edits, keep=None):
+def _add_base_relations(builder, relations, plan, keep=None):
     if "id" not in relations:
         return
     for i in range(len(relations["id"])):
         rid = int(relations["id"][i])
+        if rid in plan.removed_rels:
+            continue
         if keep is not None and rid not in keep:
             continue
         mem = relations["members"][i]
-        members = [
-            (mem["member_type"][j], int(mem["member_id"][j]), mem["member_role"][j])
-            for j in range(len(mem["member_id"]))
-        ]
+        members = plan.rel_members.get(rid)
+        if members is None:
+            members = [
+                (mem["member_type"][j], int(mem["member_id"][j]), mem["member_role"][j])
+                for j in range(len(mem["member_id"]))
+            ]
         rtags = relations["tags"][i]
         builder.rels.append(
             {
@@ -448,7 +810,9 @@ def _add_base_relations(builder, relations, rel_edits, keep=None):
                 "changeset": (
                     int(relations["changeset"][i]) if "changeset" in relations else None
                 ),
-                "tags": rel_edits.get(rid, rtags if isinstance(rtags, dict) else {}),
+                "tags": plan.rel_tags.get(
+                    rid, rtags if isinstance(rtags, dict) else {}
+                ),
             }
         )
 
@@ -464,6 +828,10 @@ def write_geodataframe_to_pbf(
     relations,
     nodes,
     subset_only=False,
+    apply_geometry=False,
+    delete=None,
+    on_orphan_node="remove",
+    on_deleted_member="drop",
 ):
     """Write `data` (+ the cached dataset) to a valid PBF at `output_path`.
 
@@ -475,31 +843,57 @@ def write_geodataframe_to_pbf(
     (matched by ``osm_type``+``id``), together with the references they need to stay
     valid -- kept ways pull in their nodes and kept relations pull in their member
     ways/nodes (the union across all frames). New rows are still synthesized.
+
+    ``apply_geometry`` additionally applies the rows' geometry to existing elements
+    and ``delete`` removes elements; ``on_orphan_node`` and ``on_deleted_member``
+    decide what happens to the references those removals break. See
+    ``pyrosm.OSM.write_pbf`` for the full semantics.
     """
+    _validate_policy("on_orphan_node", on_orphan_node, _ORPHAN_NODE_POLICIES)
+    _validate_policy("on_deleted_member", on_deleted_member, _DELETED_MEMBER_POLICIES)
+
     relations = relations or {}
     frames = _reproject_to_wgs84(_as_frames(data))
 
     way_by_id = {w["id"]: w for w in way_records}
     rel_ids = set(int(i) for i in relations["id"]) if "id" in relations else set()
 
-    node_edits, way_edits, rel_edits, new_rows = _collect_edits(
-        frames, way_by_id, node_coordinates, rel_ids
+    edits = _collect_edits(frames, way_by_id, node_coordinates, rel_ids, apply_geometry)
+    deletions = _parse_deletions(delete, node_coordinates, way_by_id, rel_ids)
+    plan, new_ways = _build_plan(
+        edits,
+        way_records,
+        relations,
+        node_coordinates,
+        deletions,
+        on_orphan_node,
+        on_deleted_member,
     )
 
     keep_nodes = keep_ways = keep_rels = None
     if subset_only:
         keep_nodes, keep_ways, keep_rels = _subset_keep_sets(
-            node_edits, way_edits, rel_edits, way_by_id, relations
+            set(edits.node_tags) - plan.removed_nodes,
+            set(edits.way_tags) - plan.removed_ways,
+            set(edits.rel_tags) - plan.removed_rels,
+            plan.way_refs,
+            relations,
         )
 
     builder = _RecordBuilder()
-    _add_base_nodes(builder, node_coordinates, nodes, node_edits, keep_nodes)
-    _add_base_ways(builder, way_records, way_edits, keep_ways)
-    _add_base_relations(builder, relations, rel_edits, keep_rels)
+    _add_base_nodes(builder, node_coordinates, nodes, plan, keep_nodes)
+    for nid, lon, lat, tags in edits.new_nodes:
+        builder.add_new_node(nid, lon, lat, tags)
+    _add_base_ways(builder, way_records, plan, keep_ways)
+    for wid, refs, tags in new_ways:
+        builder.add_new_way(wid, refs, tags)
+    _add_base_relations(builder, relations, plan, keep_rels)
 
-    builder.begin_synthesis()
-    for oid, geom, tags in new_rows:
-        builder.add_geometry(oid, geom, tags)
+    builder.begin_synthesis(
+        reserved_way_ids=[r[3] for r in edits.auto_rows if r[3] is not None]
+    )
+    for oid, geom, tags, wid in edits.auto_rows:
+        builder.add_geometry(oid, geom, tags, wid)
 
     return write_pbf_from_records(
         builder.node_payload(),

--- a/pyrosm/pyrosm.py
+++ b/pyrosm/pyrosm.py
@@ -104,6 +104,13 @@ class OSM:
         evaluates eagerly over the whole multi-version frame, so history is read
         in memory.
 
+    keep_node_info : bool (default: False)
+        Whether to keep the `nodes` column -- the ordered member node ids of each
+        way -- in the returned GeoDataFrames. It is dropped by default because a
+        list-valued column cannot be written to most file formats. Set to `True`
+        to reshape ways with `write_pbf(..., apply_geometry=True)`, which takes a
+        way's topology from this column.
+
     workers : int | str (default: None)
         Number of worker processes the `'out_of_core'` engine uses to decode the
         file. By default (`None`) the engine reads on a single core, and the first
@@ -131,6 +138,7 @@ class OSM:
         bounding_box=None,
         keep_metadata=True,
         complete_relations=False,
+        keep_node_info=False,
         engine="in_memory",
         workers=None,
     ):
@@ -144,6 +152,9 @@ class OSM:
         if not isinstance(complete_relations, bool):
             raise ValueError("'complete_relations' should be a boolean.")
         self.complete_relations = complete_relations
+
+        if not isinstance(keep_node_info, bool):
+            raise ValueError("'keep_node_info' should be a boolean.")
 
         self.engine = validate_engine(engine)
         self.workers = validate_workers(workers)
@@ -182,7 +193,7 @@ class OSM:
             )
 
         self.conf = Conf
-        self.keep_node_info = False
+        self.keep_node_info = keep_node_info
 
         # Update file size
         self.file_size = get_file_size(self.filepath)
@@ -1283,7 +1294,17 @@ class OSM:
             repack=repack,
         )
 
-    def write_pbf(self, data, output_path, subset_only=False):
+    def write_pbf(
+        self,
+        data,
+        output_path,
+        subset_only=False,
+        *,
+        apply_geometry=False,
+        delete=None,
+        on_orphan_node="remove",
+        on_deleted_member="drop",
+    ):
         """
         Write the OSM data this object holds back to a valid, re-readable
         ``*.osm.pbf``, applying attribute/tag edits from a (modified)
@@ -1310,6 +1331,31 @@ class OSM:
             edges["travel_time"] = edges["length"] / (edges["maxspeed"] / 3.6)
             osm.write_pbf(edges, "modified.osm.pbf")
 
+        Pass ``apply_geometry=True`` and/or ``delete=`` to edit the geometry itself.
+        Geometry follows the OSM model: coordinates live on nodes, and a way is an
+        ordered list of member node ids. So moving a node moves every way that
+        references it, and an existing way is reshaped through its ``nodes`` column
+        (construct the ``OSM`` object with ``keep_node_info=True`` to get it) rather
+        than through its LineString, which is derived::
+
+            osm = OSM("data.osm.pbf", keep_node_info=True)
+            nodes, edges = osm.get_network("driving", nodes=True)
+            # Move an existing node; the ways through it follow.
+            nodes.loc[nodes["id"] == 12345, "geometry"] = Point(24.94, 60.17)
+            # Insert a new vertex into a way, referencing a node added in the same call.
+            new_node = gpd.GeoDataFrame(
+                {"id": [-1], "osm_type": ["node"]},
+                geometry=[Point(24.95, 60.18)], crs="EPSG:4326",
+            )
+            row = edges["id"] == 4732994
+            edges.loc[row, "nodes"] = edges.loc[row, "nodes"].apply(
+                lambda ids: ids[:2] + [-1] + ids[2:]
+            )
+            osm.write_pbf(
+                [nodes, edges, new_node], "edited.osm.pbf",
+                apply_geometry=True, delete=[("way", 4732995)],
+            )
+
         Parameters
         ----------
 
@@ -1327,6 +1373,44 @@ class OSM:
             If True, write only the elements present in ``data`` (and the nodes and
             relation members they reference) instead of the whole cached dataset.
 
+        apply_geometry : bool (default False)
+            If True, also apply the rows' geometry to the elements that already exist
+            in the source, and honour caller-chosen ids for new ones:
+
+            - a node row's ``Point`` moves that node to those coordinates;
+            - a way row's ``nodes`` column replaces that way's member node ids, which
+              covers inserting, removing and reordering vertices (the way's own
+              LineString is ignored -- it is derived from the nodes, and under
+              ``get_network(nodes=True)`` it is a single segment of the way);
+            - a row with a **negative** id that is not in the source is added under
+              exactly that id, instead of a generated one, so a way's ``nodes`` list
+              can reference a vertex added in the same call.
+
+            Removing a vertex from a way's ``nodes`` does not delete the node itself;
+            use ``delete`` for that. When False (default), rows only edit tags and add
+            new elements, exactly as before.
+
+        delete : iterable of (osm_type, id), optional
+            Elements to omit from the output, e.g.
+            ``[("way", 4732994), ("node", 277446336)]``. An id that is not in the
+            source raises ``ValueError``; an element that is both deleted and present
+            as a row in ``data`` is deleted. Deleting a relation drops only the
+            relation -- its members are independent elements and survive.
+
+        on_orphan_node : {'remove', 'keep', 'error'} (default 'remove')
+            What to do with a node that was a member of a dropped way and is left
+            referenced by no kept way or relation: ``'remove'`` drops it too (tagged
+            nodes included), ``'keep'`` writes it as a bare node, ``'error'`` raises.
+            Nodes that no dropped way referenced -- standalone POIs, for instance --
+            are never touched.
+
+        on_deleted_member : {'drop', 'error'} (default 'drop')
+            What to do when a kept way or relation still references a deleted element:
+            ``'drop'`` removes it from that member list, ``'error'`` raises. A way left
+            with fewer than two members cannot form a geometry, so it is not written
+            either (with a ``UserWarning``) and its own members go through
+            ``on_orphan_node``; a relation left with no members is still written.
+
         Returns
         -------
         str
@@ -1334,10 +1418,11 @@ class OSM:
 
         Notes
         -----
-        v1 applies edits and additions, not deletions: with the default
-        ``subset_only=False`` the whole cached dataset is the base set, so dropping
-        rows from ``data`` does not remove elements. Use ``subset_only=True`` to limit
-        the output to the elements in ``data``.
+        Elements not present in ``data`` keep their ids, tags, coordinates and member
+        order, so the output re-reads identically in pyrosm, osmium/pyosmium, GDAL and
+        r5py/R5. Edits never introduce a reference to a node that is not in the output;
+        a source way whose members already point outside a clipped extract is re-emitted
+        as it was read.
         """
         from pyrosm.pbf_writer import write_geodataframe_to_pbf
 
@@ -1352,6 +1437,10 @@ class OSM:
             relations=self._relations,
             nodes=self._nodes,
             subset_only=subset_only,
+            apply_geometry=apply_geometry,
+            delete=delete,
+            on_orphan_node=on_orphan_node,
+            on_deleted_member=on_deleted_member,
         )
 
     @staticmethod

--- a/tests/test_pbf_export.py
+++ b/tests/test_pbf_export.py
@@ -1059,7 +1059,11 @@ def test_write_pbf_osmium_cross_check(helsinki_pbf, tmp_path):
 def test_write_pbf_r5py_routable(helsinki_pbf, tmp_path):
     r5py = pytest.importorskip("r5py")
 
-    modes = [("driving", r5py.TransportMode.CAR), ("walking", r5py.TransportMode.WALK)]
+    modes = [
+        ("driving", r5py.TransportMode.CAR),
+        ("walking", r5py.TransportMode.WALK),
+        ("cycling", r5py.TransportMode.BICYCLE),
+    ]
     for mode_name, transport_mode in modes:
         osm = OSM(helsinki_pbf)
         edges = osm.get_network(mode_name).copy()
@@ -1466,11 +1470,12 @@ def test_write_pbf_edit_node_and_relation(helsinki_pbf, tmp_path):
 
 
 def test_pbf_writer_no_relations():
-    from pyrosm.pbf_writer import _RecordBuilder, _add_base_relations
+    from pyrosm.pbf_writer import _RecordBuilder, _add_base_relations, _plan_relations
 
     builder = _RecordBuilder()
     _add_base_relations(builder, {}, {})  # relations cache without "id" -> no-op
     assert builder.rels == []
+    _plan_relations(None, {}, set(), set(), "drop")  # likewise, nothing to plan
 
 
 def test_pbf_writer_node_tag_records_empty():
@@ -1602,9 +1607,7 @@ def test_subset_keep_sets_closure():
     from pyrosm.pbf_writer import _subset_keep_sets
 
     # No relations cache: a kept way pulls in its node refs; nothing else.
-    kn, kw, kr = _subset_keep_sets(
-        {}, {5: {}}, {}, {5: {"id": 5, "nodes": [50, 51]}}, {}
-    )
+    kn, kw, kr = _subset_keep_sets({}, {5: {}}, {}, {5: [50, 51]}, {})
     assert kr == set() and kw == {5} and kn == {50, 51}
 
     # Relation 1 has way/node/sub-relation members (incl. sub-rel 999 absent from the
@@ -1629,11 +1632,593 @@ def test_subset_keep_sets_closure():
             dtype=object,
         ),
     }
-    way_by_id = {
-        10: {"id": 10, "nodes": [100, 101]},
-        11: {"id": 11, "nodes": [101, 102]},
-    }
-    kn, kw, kr = _subset_keep_sets({}, {}, {1: {}, 888: {}}, way_by_id, relations)
+    way_refs = {10: [100, 101], 11: [101, 102]}
+    kn, kw, kr = _subset_keep_sets({}, {}, {1: {}, 888: {}}, way_refs, relations)
     assert kr == {1, 2, 888}  # sub-relation 2 resolved; 888 kept; 999 absent
     assert kw == {10, 11}  # way members of relations 1 and 2
     assert kn == {100, 101, 102}  # node member + way node-refs
+
+
+# ---------------------------------------------------------------------------
+# OSM.write_pbf geometry editing: move / delete / reshape
+# ---------------------------------------------------------------------------
+# A small, reference-complete fixture: ways 10 [1,2,3], 11 [3,4,5] and 12 [5,6,7]
+# chained through the shared nodes 3 and 5, a standalone POI node 20, and relation
+# 30 holding way 10 and node 20.
+_TINY_NODES = {
+    1: (24.940, 60.170),
+    2: (24.941, 60.171),
+    3: (24.942, 60.172),
+    4: (24.943, 60.173),
+    5: (24.944, 60.174),
+    6: (24.945, 60.175),
+    7: (24.946, 60.176),
+    20: (24.9405, 60.1705),
+}
+_TINY_WAYS = {10: [1, 2, 3], 11: [3, 4, 5], 12: [5, 6, 7]}
+_TINY_TIMESTAMP = 1600000000
+
+
+@pytest.fixture
+def tiny_pbf(tmp_path):
+    from pyrosm.pbf_export import write_pbf_from_records
+
+    ids = sorted(_TINY_NODES)
+    nodes = {
+        "id": np.array(ids, dtype=np.int64),
+        "lon": np.array([_TINY_NODES[i][0] for i in ids]),
+        "lat": np.array([_TINY_NODES[i][1] for i in ids]),
+        "version": np.ones(len(ids), dtype=np.int64),
+        "timestamp": np.full(len(ids), _TINY_TIMESTAMP, dtype=np.int64),
+        "changeset": np.zeros(len(ids), dtype=np.int64),
+        "tags": [{"amenity": "cafe"} if i == 20 else None for i in ids],
+    }
+    ways = [
+        {
+            "id": wid,
+            "refs": refs,
+            "version": 1,
+            "timestamp": _TINY_TIMESTAMP,
+            "tags": {"highway": "residential", "name": "way-%d" % wid},
+        }
+        for wid, refs in _TINY_WAYS.items()
+    ]
+    relations = [
+        {
+            "id": 30,
+            "members": [("way", 10, "outer"), ("node", 20, "label")],
+            "version": 1,
+            "timestamp": _TINY_TIMESTAMP,
+            "changeset": 0,
+            "tags": {"type": "route", "route": "bus"},
+        }
+    ]
+    return write_pbf_from_records(
+        nodes,
+        ways,
+        relations,
+        str(tmp_path / "tiny.osm.pbf"),
+        (24.940, 60.170, 24.946, 60.176),
+    )
+
+
+def _relation_members(path):
+    """Map relation id -> [(member type, id, role)] read straight from a PBF."""
+    from pyrosm.pbf_export import _iter_primitive_blocks
+
+    kinds = {0: "node", 1: "way", 2: "relation"}
+    out = {}
+    for pblock in _iter_primitive_blocks(path):
+        st = [s.decode("utf-8", "replace") for s in pblock.stringtable.s]
+        for grp in pblock.primitivegroup:
+            for rel in grp.relations:
+                memids = np.cumsum(np.array(list(rel.memids), dtype=np.int64))
+                out[rel.id] = [
+                    (kinds[t], int(mid), st[role])
+                    for t, mid, role in zip(rel.types, memids, rel.roles_sid)
+                ]
+    return out
+
+
+def _vertices(geom):
+    """Every (x, y) vertex of a LineString or MultiLineString."""
+    if geom.geom_type == "MultiLineString":
+        return [c for part in geom.geoms for c in part.coords]
+    return list(geom.coords)
+
+
+def _has_vertex(geom, xy):
+    return any(
+        abs(x - xy[0]) < 1e-6 and abs(y - xy[1]) < 1e-6 for x, y in _vertices(geom)
+    )
+
+
+def _set_way_nodes(edges, wid, refs):
+    """Set way `wid`'s member ids on every row of an edge frame."""
+    return edges.assign(
+        nodes=edges.apply(
+            lambda r: list(refs) if r["id"] == wid else r["nodes"], axis=1
+        )
+    )
+
+
+def test_write_pbf_move_shared_node(tiny_pbf, tmp_path):
+    """Moving a node moves every way through it, and adds no new element."""
+    osm = OSM(tiny_pbf)
+    nodes, edges = osm.get_network(nodes=True)
+    moved = (24.9425, 60.1725)
+    nodes.loc[nodes["id"] == 3, "geometry"] = Point(*moved)
+
+    out = str(tmp_path / "moved.osm.pbf")
+    osm.write_pbf([nodes, edges], out, apply_geometry=True)
+
+    node_ids, way_ids, rel_ids, coords, way_refs = _read_elements(out)
+    assert node_ids == set(_TINY_NODES) and way_ids == set(_TINY_WAYS)
+    assert way_refs == _TINY_WAYS  # topology untouched: same ids, same order
+    assert coords[3] == pytest.approx(moved, abs=1e-7)
+    assert coords[2] == pytest.approx(_TINY_NODES[2], abs=1e-7)
+
+    re_edges = OSM(out).get_network()
+    for wid in (10, 11):
+        geom = re_edges.loc[re_edges["id"] == wid, "geometry"].iloc[0]
+        assert _has_vertex(geom, moved)
+
+
+def test_write_pbf_move_needs_apply_geometry(tiny_pbf, tmp_path):
+    """Without apply_geometry a moved geometry is ignored, byte for byte."""
+    osm = OSM(tiny_pbf)
+    nodes, edges = osm.get_network(nodes=True)
+    baseline = str(tmp_path / "baseline.osm.pbf")
+    osm.write_pbf([nodes, edges], baseline)
+
+    nodes.loc[nodes["id"] == 3, "geometry"] = Point(24.99, 60.99)
+    out = str(tmp_path / "ignored.osm.pbf")
+    osm.write_pbf([nodes, edges], out)
+
+    assert Path(out).read_bytes() == Path(baseline).read_bytes()
+
+
+def test_write_pbf_delete_way_drops_its_exclusive_nodes(tiny_pbf, tmp_path):
+    """Deleting a way removes only the nodes no kept way still references."""
+    osm = OSM(tiny_pbf)
+    out = str(tmp_path / "del_way.osm.pbf")
+    osm.write_pbf(osm.get_network(), out, delete=[("way", 12)])
+
+    node_ids, way_ids, _, _, way_refs = _read_elements(out)
+    assert way_ids == {10, 11}
+    assert node_ids == set(_TINY_NODES) - {6, 7}  # node 5 is shared with way 11
+    assert way_refs[11] == [3, 4, 5]
+
+
+@pytest.mark.parametrize("policy,removed", [("remove", {6, 7}), ("keep", set())])
+def test_write_pbf_orphan_node_policies(tiny_pbf, tmp_path, policy, removed):
+    osm = OSM(tiny_pbf)
+    out = str(tmp_path / ("orphan_%s.osm.pbf" % policy))
+    osm.write_pbf(osm.get_network(), out, delete=[("way", 12)], on_orphan_node=policy)
+    node_ids, _, _, _, _ = _read_elements(out)
+    assert node_ids == set(_TINY_NODES) - removed
+
+
+def test_write_pbf_orphan_node_error(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf)
+    with pytest.raises(ValueError, match="unreferenced"):
+        osm.write_pbf(
+            osm.get_network(),
+            str(tmp_path / "boom.osm.pbf"),
+            delete=[("way", 12)],
+            on_orphan_node="error",
+        )
+
+
+def test_write_pbf_delete_node_mid_way(tiny_pbf, tmp_path):
+    """A deleted node leaves the ways through it valid, minus that member."""
+    osm = OSM(tiny_pbf)
+    out = str(tmp_path / "del_node.osm.pbf")
+    osm.write_pbf(osm.get_network(), out, delete=[("node", 2)])
+
+    node_ids, way_ids, _, _, way_refs = _read_elements(out)
+    assert 2 not in node_ids and way_ids == set(_TINY_WAYS)
+    assert way_refs[10] == [1, 3]
+    assert way_refs[11] == [3, 4, 5] and way_refs[12] == [5, 6, 7]
+
+    geom = OSM(out).get_network().set_index("id").loc[10, "geometry"]
+    assert not _has_vertex(geom, _TINY_NODES[2])
+
+
+def test_write_pbf_delete_node_member_error(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf)
+    with pytest.raises(ValueError, match="deleted node"):
+        osm.write_pbf(
+            osm.get_network(),
+            str(tmp_path / "boom.osm.pbf"),
+            delete=[("node", 2)],
+            on_deleted_member="error",
+        )
+
+
+def test_write_pbf_delete_leaves_way_degenerate(tiny_pbf, tmp_path):
+    """A way left with a single member is dropped, with a warning."""
+    osm = OSM(tiny_pbf)
+    out = str(tmp_path / "degenerate.osm.pbf")
+    with pytest.warns(UserWarning, match="fewer than two member nodes"):
+        osm.write_pbf(osm.get_network(), out, delete=[("node", 1), ("node", 2)])
+
+    node_ids, way_ids, _, _, _ = _read_elements(out)
+    assert way_ids == {11, 12}
+    assert 3 in node_ids  # way 11 still references it, so it is not an orphan
+
+
+def test_write_pbf_delete_standalone_node(tiny_pbf, tmp_path):
+    """Deleting an unreferenced node drops it and detaches it from its relation."""
+    osm = OSM(tiny_pbf)
+    out = str(tmp_path / "del_poi.osm.pbf")
+    osm.write_pbf(osm.get_network(), out, delete=[("node", 20)])
+
+    node_ids, way_ids, rel_ids, _, _ = _read_elements(out)
+    assert 20 not in node_ids and way_ids == set(_TINY_WAYS) and rel_ids == {30}
+    assert _relation_members(out)[30] == [("way", 10, "outer")]
+
+
+def test_write_pbf_delete_way_detaches_it_from_relations(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf)
+    out = str(tmp_path / "del_member.osm.pbf")
+    osm.write_pbf(osm.get_network(), out, delete=[("way", 10)])
+    assert _relation_members(out)[30] == [("node", 20, "label")]
+
+    with pytest.raises(ValueError, match="removed member"):
+        osm.write_pbf(
+            osm.get_network(),
+            str(tmp_path / "boom.osm.pbf"),
+            delete=[("way", 10)],
+            on_deleted_member="error",
+        )
+
+
+def test_write_pbf_delete_relation_keeps_its_members(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf)
+    out = str(tmp_path / "del_rel.osm.pbf")
+    osm.write_pbf(osm.get_network(), out, delete=[("relation", 30)])
+
+    node_ids, way_ids, rel_ids, _, _ = _read_elements(out)
+    assert rel_ids == set()
+    assert way_ids == set(_TINY_WAYS) and node_ids == set(_TINY_NODES)
+
+
+def test_write_pbf_insert_vertex(tiny_pbf, tmp_path):
+    """A new node with a caller-chosen id can be spliced into a way's member list."""
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    edges = _set_way_nodes(osm.get_network(), 10, [1, -1, 2, 3])
+    inserted = (24.9405, 60.1705)
+    new_node = gpd.GeoDataFrame(
+        {"id": [-1], "osm_type": ["node"]},
+        geometry=[Point(*inserted)],
+        crs="EPSG:4326",
+    )
+
+    out = str(tmp_path / "insert.osm.pbf")
+    osm.write_pbf([edges, new_node], out, apply_geometry=True)
+
+    node_ids, way_ids, _, coords, way_refs = _read_elements(out)
+    assert way_refs[10] == [1, -1, 2, 3]
+    assert node_ids == set(_TINY_NODES) | {-1}
+    assert coords[-1] == pytest.approx(inserted, abs=1e-7)
+
+    geom = OSM(out).get_network().set_index("id").loc[10, "geometry"]
+    assert _has_vertex(geom, inserted)
+
+
+def test_write_pbf_remove_and_reorder_vertices(tiny_pbf, tmp_path):
+    """Reshaping reorders/drops members; a dropped vertex's node survives."""
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    edges = _set_way_nodes(osm.get_network(), 10, [1, 3])
+    edges = _set_way_nodes(edges, 11, [5, 4, 3])
+
+    out = str(tmp_path / "reshape.osm.pbf")
+    osm.write_pbf(edges, out, apply_geometry=True)
+
+    node_ids, _, _, _, way_refs = _read_elements(out)
+    assert way_refs[10] == [1, 3] and way_refs[11] == [5, 4, 3]
+    assert node_ids == set(_TINY_NODES)  # node 2 is only unlinked, not deleted
+
+
+def test_write_pbf_new_way_over_existing_nodes(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    new_way = gpd.GeoDataFrame(
+        {"id": [-5], "osm_type": ["way"], "highway": ["path"], "nodes": [[1, 7]]},
+        geometry=[LineString([_TINY_NODES[1], _TINY_NODES[7]])],
+        crs="EPSG:4326",
+    )
+
+    out = str(tmp_path / "new_way.osm.pbf")
+    osm.write_pbf([osm.get_network(), new_way], out, apply_geometry=True)
+
+    node_ids, way_ids, _, _, way_refs = _read_elements(out)
+    assert way_ids == set(_TINY_WAYS) | {-5}
+    assert way_refs[-5] == [1, 7]
+    assert node_ids == set(_TINY_NODES)  # no vertices synthesized
+    assert _way_tags(out)[-5] == {"highway": "path"}
+
+
+def test_write_pbf_mixed_edit_add_delete_untouched(tiny_pbf, tmp_path):
+    """One frame carrying an edited, a moved, an added, a deleted and an untouched row."""
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    nodes, _ = osm.get_network(nodes=True)
+    edges = osm.get_network()
+    edges.loc[edges["id"] == 11, "maxspeed"] = "30"  # retag
+    edges = _set_way_nodes(edges, 10, [1, -1, 2, 3])  # reshape
+    moved = (24.9435, 60.1735)
+    nodes.loc[nodes["id"] == 4, "geometry"] = Point(*moved)  # move
+    new_node = gpd.GeoDataFrame(
+        {"id": [-1], "osm_type": ["node"], "barrier": ["gate"]},
+        geometry=[Point(24.9405, 60.1705)],
+        crs="EPSG:4326",
+    )
+
+    out = str(tmp_path / "mixed.osm.pbf")
+    osm.write_pbf(
+        [nodes, edges, new_node], out, apply_geometry=True, delete=[("way", 12)]
+    )
+
+    node_ids, way_ids, rel_ids, coords, way_refs = _read_elements(out)
+    assert way_ids == {10, 11}
+    assert way_refs[10] == [1, -1, 2, 3]
+    assert way_refs[11] == [3, 4, 5]  # untouched topology
+    assert coords[4] == pytest.approx(moved, abs=1e-7)
+    assert node_ids == (set(_TINY_NODES) | {-1}) - {6, 7}
+    assert rel_ids == {30}
+
+    tags = _way_tags(out)
+    assert tags[11]["maxspeed"] == "30"
+    assert tags[10]["name"] == "way-10"  # untouched way keeps its tags
+
+
+def test_write_pbf_edited_file_is_reference_complete(tiny_pbf, tmp_path):
+    """pyosmium reads the edited file and finds no reference to a missing element."""
+    osmium = pytest.importorskip("osmium")
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    nodes, _ = osm.get_network(nodes=True)
+    nodes.loc[nodes["id"] == 3, "geometry"] = Point(24.9425, 60.1725)
+    edges = _set_way_nodes(osm.get_network(), 11, [3, 5])
+
+    out = str(tmp_path / "complete.osm.pbf")
+    osm.write_pbf(
+        [nodes, edges], out, apply_geometry=True, delete=[("way", 12), ("node", 2)]
+    )
+
+    class Collector(osmium.SimpleHandler):
+        def __init__(self):
+            super().__init__()
+            self.nodes, self.ways = set(), set()
+            self.node_refs, self.way_refs = set(), set()
+
+        def node(self, n):
+            self.nodes.add(n.id)
+
+        def way(self, w):
+            self.ways.add(w.id)
+            self.node_refs.update(n.ref for n in w.nodes)
+
+        def relation(self, r):
+            for m in r.members:
+                (self.node_refs if m.type == "n" else self.way_refs).add(m.ref)
+
+    seen = Collector()
+    seen.apply_file(out)
+    assert seen.node_refs <= seen.nodes
+    assert seen.way_refs <= seen.ways
+
+
+def test_write_pbf_edits_are_deterministic(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    nodes, _ = osm.get_network(nodes=True)
+    nodes.loc[nodes["id"] == 3, "geometry"] = Point(24.9425, 60.1725)
+    edges = _set_way_nodes(osm.get_network(), 10, [3, 2, 1])
+
+    written = []
+    for i in range(2):
+        out = str(tmp_path / ("det_%d.osm.pbf" % i))
+        osm.write_pbf([nodes, edges], out, apply_geometry=True, delete=[("way", 12)])
+        written.append(Path(out).read_bytes())
+    assert written[0] == written[1]
+
+
+def test_write_pbf_subset_only_follows_reshape(tiny_pbf, tmp_path):
+    """A subset export pulls in the vertices the reshaped member list references."""
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    edges = osm.get_network()
+    edges = _set_way_nodes(edges[edges["id"] == 10], 10, [1, -1, 3])
+    new_node = gpd.GeoDataFrame(
+        {"id": [-1], "osm_type": ["node"]},
+        geometry=[Point(24.9405, 60.1705)],
+        crs="EPSG:4326",
+    )
+
+    out = str(tmp_path / "subset.osm.pbf")
+    osm.write_pbf([edges, new_node], out, subset_only=True, apply_geometry=True)
+
+    node_ids, way_ids, _, _, way_refs = _read_elements(out)
+    assert way_ids == {10} and way_refs[10] == [1, -1, 3]
+    assert node_ids == {1, -1, 3}
+
+
+def test_write_pbf_reshape_to_unknown_node_raises(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    edges = _set_way_nodes(osm.get_network(), 10, [1, 999999, 3])
+    with pytest.raises(ValueError, match="neither in the source data"):
+        osm.write_pbf(edges, str(tmp_path / "boom.osm.pbf"), apply_geometry=True)
+
+
+def test_write_pbf_conflicting_geometry_edits_raise(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    nodes, _ = osm.get_network(nodes=True)
+    other = nodes[nodes["id"] == 3].copy()
+    other.loc[:, "geometry"] = Point(24.99, 60.99)
+    with pytest.raises(ValueError, match="conflicting coordinates"):
+        osm.write_pbf(
+            [nodes, other], str(tmp_path / "boom.osm.pbf"), apply_geometry=True
+        )
+
+    edges = osm.get_network()
+    conflicting = _set_way_nodes(edges[edges["id"] == 10].copy(), 10, [3, 2, 1])
+    with pytest.raises(ValueError, match="conflicting member node ids"):
+        osm.write_pbf(
+            [edges, conflicting], str(tmp_path / "boom2.osm.pbf"), apply_geometry=True
+        )
+
+
+def test_write_pbf_duplicate_new_id_raises(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf)
+    new_nodes = gpd.GeoDataFrame(
+        {"id": [-1, -1], "osm_type": ["node", "node"]},
+        geometry=[Point(24.9401, 60.1701), Point(24.9402, 60.1702)],
+        crs="EPSG:4326",
+    )
+    with pytest.raises(ValueError, match="appears more than once"):
+        osm.write_pbf(new_nodes, str(tmp_path / "boom.osm.pbf"), apply_geometry=True)
+
+
+@pytest.mark.parametrize(
+    "entry,message",
+    [
+        (("way", 999999), "no such element"),
+        (("banana", 10), "no such element"),
+        (("way",), "should be \\(osm_type, id\\) pairs"),
+    ],
+)
+def test_write_pbf_invalid_deletion_raises(tiny_pbf, tmp_path, entry, message):
+    osm = OSM(tiny_pbf)
+    with pytest.raises(ValueError, match=message):
+        osm.write_pbf(osm.get_network(), str(tmp_path / "boom.osm.pbf"), delete=[entry])
+
+
+@pytest.mark.parametrize(
+    "kwargs", [{"on_orphan_node": "nope"}, {"on_deleted_member": "nope"}]
+)
+def test_write_pbf_invalid_policy_raises(tiny_pbf, tmp_path, kwargs):
+    osm = OSM(tiny_pbf)
+    with pytest.raises(ValueError, match="should be one of"):
+        osm.write_pbf(osm.get_network(), str(tmp_path / "boom.osm.pbf"), **kwargs)
+
+
+def test_write_pbf_geometry_edits_on_real_data(helsinki_pbf, tmp_path):
+    """Move, reshape and delete on the bundled extract, without new dangling refs."""
+    osm = OSM(helsinki_pbf, keep_node_info=True)
+    nodes, _ = osm.get_network("driving", nodes=True)
+    edges = osm.get_network("driving")
+
+    target = int(edges.loc[edges["nodes"].apply(len) >= 4, "id"].iloc[0])
+    original = list(edges.set_index("id").loc[target, "nodes"])
+    deleted_way = int(edges.loc[edges["id"] != target, "id"].iloc[0])
+
+    node_id = original[0]
+    before = nodes.loc[nodes["id"] == node_id, "geometry"].iloc[0]
+    moved = (before.x + 0.0001, before.y + 0.0001)
+    nodes.loc[nodes["id"] == node_id, "geometry"] = Point(*moved)
+    edges = _set_way_nodes(edges, target, original[:1] + original[2:])
+
+    out = str(tmp_path / "real_edit.osm.pbf")
+    osm.write_pbf(
+        [nodes, edges], out, apply_geometry=True, delete=[("way", deleted_way)]
+    )
+
+    node_ids, way_ids, _, coords, way_refs = _read_elements(out)
+    assert coords[node_id] == pytest.approx(moved, abs=1e-7)
+    assert way_refs[target] == original[:1] + original[2:]
+    assert deleted_way not in way_ids
+
+    # The edits introduce no reference the source did not already have.
+    source_dangling = {
+        int(n)
+        for w in osm._way_records
+        for n in w["nodes"]
+        if int(n) not in osm._node_coordinates
+    }
+    written_dangling = {n for refs in way_refs.values() for n in refs} - node_ids
+    assert written_dangling <= source_dangling
+
+    re_osm = OSM(out)
+    re_edges = re_osm.get_network("driving")
+    assert deleted_way not in set(re_edges["id"])
+    assert _has_vertex(re_edges.set_index("id").loc[target, "geometry"], moved)
+
+
+def test_write_pbf_new_line_keeps_chosen_id(tiny_pbf, tmp_path):
+    """A chosen id survives vertex synthesis, and generated ids stay clear of it."""
+    osm = OSM(tiny_pbf)
+    line = LineString([(24.950, 60.180), (24.951, 60.181)])
+    added = gpd.GeoDataFrame(
+        {"id": [-7, None], "osm_type": ["way", "way"], "highway": ["path", "track"]},
+        geometry=[line, LineString([(24.952, 60.182), (24.953, 60.183)])],
+        crs="EPSG:4326",
+    )
+
+    out = str(tmp_path / "chosen_id.osm.pbf")
+    osm.write_pbf([osm.get_network(), added], out, apply_geometry=True)
+
+    node_ids, way_ids, _, _, way_refs = _read_elements(out)
+    assert -7 in way_ids
+    assert _way_tags(out)[-7] == {"highway": "path"}
+    # The generated way got an id below the chosen one, not a colliding -1.
+    generated = way_ids - set(_TINY_WAYS) - {-7}
+    assert len(generated) == 1 and max(generated) < -7
+    # Both lines' vertices were synthesized as new nodes.
+    assert set(way_refs[-7]) <= node_ids - set(_TINY_NODES)
+
+
+def test_write_pbf_empty_member_list_is_no_reshape(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf, keep_node_info=True)
+    edges = _set_way_nodes(osm.get_network(), 10, [])
+
+    out = str(tmp_path / "empty_nodes.osm.pbf")
+    osm.write_pbf(edges, out, apply_geometry=True)
+    assert _read_elements(out)[4] == _TINY_WAYS
+
+
+def test_write_pbf_new_node_needs_a_point(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf)
+    bad = gpd.GeoDataFrame(
+        {"id": [-1], "osm_type": ["node"]},
+        geometry=[LineString([(24.95, 60.18), (24.96, 60.19)])],
+        crs="EPSG:4326",
+    )
+    with pytest.raises(ValueError, match="needs a Point geometry"):
+        osm.write_pbf(bad, str(tmp_path / "boom.osm.pbf"), apply_geometry=True)
+
+
+def test_write_pbf_new_way_needs_two_members(tiny_pbf, tmp_path):
+    osm = OSM(tiny_pbf)
+    bad = gpd.GeoDataFrame(
+        {"id": [-5], "osm_type": ["way"], "nodes": [[1]]},
+        geometry=[LineString([_TINY_NODES[1], _TINY_NODES[2]])],
+        crs="EPSG:4326",
+    )
+    with pytest.raises(ValueError, match="at least two member nodes"):
+        osm.write_pbf(bad, str(tmp_path / "boom.osm.pbf"), apply_geometry=True)
+
+
+def test_keep_node_info_parameter(tiny_pbf):
+    """The constructor keyword keeps the way member-id column reshaping needs."""
+    assert "nodes" not in OSM(tiny_pbf).get_network().columns
+    edges = OSM(tiny_pbf, keep_node_info=True).get_network()
+    assert list(edges.set_index("id").loc[10, "nodes"]) == _TINY_WAYS[10]
+
+    with pytest.raises(ValueError, match="keep_node_info"):
+        OSM(tiny_pbf, keep_node_info="yes")
+
+
+def test_write_pbf_new_ids_are_per_element_type(tiny_pbf, tmp_path):
+    """A new node and a new way may share an id, as they are separate namespaces."""
+    osm = OSM(tiny_pbf)
+    added = gpd.GeoDataFrame(
+        {"id": [-1, -1], "osm_type": ["node", "way"], "nodes": [None, [1, 7]]},
+        geometry=[Point(24.95, 60.18), LineString([_TINY_NODES[1], _TINY_NODES[7]])],
+        crs="EPSG:4326",
+    )
+
+    out = str(tmp_path / "namespaces.osm.pbf")
+    osm.write_pbf([osm.get_network(), added], out, apply_geometry=True)
+
+    node_ids, way_ids, _, coords, way_refs = _read_elements(out)
+    assert -1 in node_ids and -1 in way_ids
+    assert way_refs[-1] == [1, 7]
+    assert coords[-1] == pytest.approx((24.95, 60.18), abs=1e-7)


### PR DESCRIPTION
`OSM.write_pbf` previously applied only tag edits to elements that already exist in the source: coordinates and topology always came from the original read, so an existing node could not be moved, an existing way could not be reshaped, and there was no way to remove an element (only `subset_only` export). This adds those capabilities.

## API

```python
OSM.write_pbf(
    data, output_path, subset_only=False, *,
    apply_geometry=False,      # apply geometry to existing elements
    delete=None,               # iterable of (osm_type, id)
    on_orphan_node="remove",   # "remove" | "keep" | "error"
    on_deleted_member="drop",  # "drop" | "error"
)
```

The new arguments are keyword-only. With `apply_geometry=False` and `delete=None` — the defaults — the writer produces exactly what it produced before, byte for byte.

`OSM(...)` also gains a `keep_node_info` parameter, which keeps the `nodes` column of each way's ordered member node ids in the returned GeoDataFrames. It was previously reachable only by setting the attribute after construction, and it is the column a way is reshaped through.

## Semantics

Geometry follows the OSM model: coordinates live on nodes, and a way is an ordered list of member node ids. `apply_geometry=True` enables three things:

- **Move an existing node** — a node row's `Point` sets that node's lon/lat. Every way and relation referencing it keeps the same member ids, so their geometry follows.
- **Reshape an existing way** — a way row's `nodes` column replaces its member node ids, covering vertex insertion, removal and reordering. The way's own LineString is ignored: it is derived from the nodes, and under `get_network(nodes=True)` it is a single segment of the way rather than the whole way.
- **Add an element under a chosen id** — a row with a negative id that is not in the source is written with exactly that id instead of a generated one, so a way's `nodes` list can reference a vertex added in the same call. Rows with no id keep the existing generated-id behaviour. New ids are per element type, as in OSM, so a new node and a new way may both be `-1`.

Removing a vertex from a way's `nodes` unlinks the node but does not delete it; `delete` does that.

## Referential integrity

- `on_orphan_node` covers nodes that were members of a dropped way and end up referenced by no kept way or relation: `"remove"` drops them, `"keep"` writes them as bare nodes, `"error"` raises. Nodes that no dropped way referenced — standalone POIs, for instance — are never touched.
- `on_deleted_member` covers a kept way or relation that still references a deleted element: `"drop"` removes it from that member list, `"error"` raises.
- A way left with fewer than two members cannot form a geometry, so it is not written (with a `UserWarning`) and its own members then go through `on_orphan_node`. A relation left with no members is still written. Deleting a relation drops only the relation; its members are independent elements and survive.
- Two rows giving one node different coordinates, or one way different member lists, raise `ValueError` rather than resolving silently. Tag edits remain last-wins, since frames legitimately carry different tag columns for the same element.
- Deleting an id that is not in the source raises `ValueError`. An element that is both deleted and present as a row in `data` is deleted.
- Edits never introduce a reference to a node that is not in the output. A source way whose members already point outside a clipped extract is re-emitted as it was read, so the guarantee is that edits add no new dangling references rather than that the output is unconditionally reference-complete — the bundled extracts already contain such references by construction.

`subset_only=True` composes with both: deletions are removed from the keep sets, and the closure walks the reshaped member lists so inserted vertices are pulled in.

## Implementation

The work is in `pyrosm/pbf_writer.py`, which resolves the frames and the deletions into a write plan — effective member list per way, moved coordinates, and the omitted element sets — before any record is built. The Cython writer is unchanged: it already takes plain records and id-sorts nodes.

## Verification

New tests cover each capability with a write → re-read → assert round-trip on geometry, tags and topology. Most run against a small, reference-complete fixture PBF built in the test module, so the edge cases are asserted exactly: moving a node shared by several ways, deleting a node mid-way, deleting a way whose nodes are shared with a kept way, inserting a vertex between two existing nodes, and a single frame mixing edited, added, deleted and untouched rows. Each orphan and deleted-member policy is covered, as is a byte-equality check that the default path reproduces the previous output. A pyosmium cross-check asserts the edited file is well-formed and that every way reference and relation member resolves, and a round-trip on the bundled Helsinki extract asserts the edits add no dangling references beyond those already in the source. Output is deterministic for a given input.

The existing `write_pbf` and `to_pbf` tests are unchanged, apart from the call sites of a white-box unit test of the private subset-closure helper, whose signature changed from a way-record mapping to a member-id mapping; its assertions are unchanged. The full test matrix runs in CI.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
