### PR TITLE
Prepare v0.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 Changelog
 =========
 
-Unreleased
-----------
+v0.12.0
+-------
 
-- NEW: `OSM.write_pbf` can edit geometry, not just tags. Pass `apply_geometry=True` to move an existing node (a node row's `Point` sets its coordinates, and every way and relation referencing it follows), to reshape an existing way through its `nodes` member-id column (inserting, removing and reordering vertices), and to add a new element under a caller-chosen negative id so a way's `nodes` list can reference a vertex added in the same call. The new `delete` parameter takes `(osm_type, id)` pairs to omit elements from the output, with `on_orphan_node` (`'remove'`/`'keep'`/`'error'`) and `on_deleted_member` (`'drop'`/`'error'`) deciding what happens to the references a removal breaks. Defaults are unchanged: without `apply_geometry`/`delete`, `write_pbf` writes exactly what it wrote before
-- NEW: Add a `keep_node_info` parameter to `OSM(...)`, which keeps the `nodes` column of each way's ordered member node ids in the returned GeoDataFrames. It was previously only reachable by setting the attribute after construction, and it is what `write_pbf(..., apply_geometry=True)` reshapes a way through
+This release makes `OSM.write_pbf` able to edit geometry — moving nodes, reshaping ways and deleting elements — so a network read with pyrosm can be edited and written back to a `*.osm.pbf` in full. The reading engines are unchanged.
+
+- NEW: `OSM.write_pbf` can edit geometry, not just tags. Pass `apply_geometry=True` to move an existing node (a node row's `Point` sets its coordinates, and every way and relation referencing it follows), to reshape an existing way through its `nodes` member-id column (inserting, removing and reordering vertices), and to add a new element under a caller-chosen negative id so a way's `nodes` list can reference a vertex added in the same call. The new `delete` parameter takes `(osm_type, id)` pairs to omit elements from the output, with `on_orphan_node` (`'remove'`/`'keep'`/`'error'`) and `on_deleted_member` (`'drop'`/`'error'`) deciding what happens to the references a removal breaks. Defaults are unchanged: without `apply_geometry`/`delete`, `write_pbf` writes exactly what it wrote before ([#367](https://github.com/pyrosm/pyrosm/pull/367))
+- NEW: Add a `keep_node_info` parameter to `OSM(...)`, which keeps the `nodes` column of each way's ordered member node ids in the returned GeoDataFrames. It was previously only reachable by setting the attribute after construction, and it is what `write_pbf(..., apply_geometry=True)` reshapes a way through ([#367](https://github.com/pyrosm/pyrosm/pull/367))
+- NEW: Add California to the US state sources, so `get_data("california")` downloads the whole-state Geofabrik extract. The `northern_california` and `southern_california` sub-regions are unchanged ([#366](https://github.com/pyrosm/pyrosm/pull/366))
+
+Thanks for all the contributors who helped to improve the library either via PRs, or by raising or participating in an issue:
+
+- mitchellhenke ([#366](https://github.com/pyrosm/pyrosm/pull/366))
 
 v0.11.0
 -------

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ identifiers:
     value: 10.5281/zenodo.3755057
     description: "Concept DOI that always resolves to the latest version"
 doi: 10.5281/zenodo.3755057
-version: 0.11.0
-date-released: "2026-07-01"
+version: 0.12.0
+date-released: "2026-07-22"
 license: MIT
 repository-code: "https://github.com/pyrosm/pyrosm"
 url: "https://pyrosm.readthedocs.io/"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ memory. Pyrosm decodes the PBF data with [Google's Protocol Buffers](https://pro
 - filter data based on bounding box
 - control which OSM tags are parsed into columns
 - crop a PBF to a smaller area and write modified OSM data back to PBF (NEW in v0.9.0), or export only selected layers (NEW in v0.11.0)
+- edit the geometry of an OSM network — move nodes, reshape ways, delete elements — and write it back to PBF (NEW in v0.12.0)
 - export networks as a directed graph to `igraph`, `networkx` and `pandarm`, optionally with topological simplification (NEW in v0.11.0)
  
 ## Install
@@ -116,9 +117,9 @@ You can run tests with `pytest` by executing:
 
 ## Citing pyrosm
 
-If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version). An example citation for the pyrosm version 0.11.0 is as follows:
+If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version). An example citation for the pyrosm version 0.12.0 is as follows:
 
-> Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames*. (v0.11.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+> Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames*. (v0.12.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 A BibTeX entry and version-specific DOIs are available in the [documentation](https://pyrosm.readthedocs.io/en/stable/citation.html) and on the [Zenodo record](https://doi.org/10.5281/zenodo.3755057).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+v0.12.0 (Jul 22, 2026)
+----------------------
+
+This release makes ``OSM.write_pbf`` able to edit geometry -- moving nodes, reshaping ways and deleting elements -- so a network read with pyrosm can be edited and written back to a ``*.osm.pbf`` in full. The reading engines are unchanged.
+
+- NEW: ``OSM.write_pbf`` can edit geometry, not just tags. Pass ``apply_geometry=True`` to move an existing node (a node row's ``Point`` sets its coordinates, and every way and relation referencing it follows), to reshape an existing way through its ``nodes`` member-id column (inserting, removing and reordering vertices), and to add a new element under a caller-chosen negative id so a way's ``nodes`` list can reference a vertex added in the same call. The new ``delete`` parameter takes ``(osm_type, id)`` pairs to omit elements from the output, with ``on_orphan_node`` (``'remove'``/``'keep'``/``'error'``) and ``on_deleted_member`` (``'drop'``/``'error'``) deciding what happens to the references a removal breaks. Defaults are unchanged: without ``apply_geometry``/``delete``, ``write_pbf`` writes exactly what it wrote before (`#367 <https://github.com/pyrosm/pyrosm/pull/367>`__)
+- NEW: Add a ``keep_node_info`` parameter to ``OSM(...)``, which keeps the ``nodes`` column of each way's ordered member node ids in the returned GeoDataFrames. It was previously only reachable by setting the attribute after construction, and it is what ``write_pbf(..., apply_geometry=True)`` reshapes a way through (`#367 <https://github.com/pyrosm/pyrosm/pull/367>`__)
+- NEW: Add California to the US state sources, so ``get_data("california")`` downloads the whole-state Geofabrik extract. The ``northern_california`` and ``southern_california`` sub-regions are unchanged (`#366 <https://github.com/pyrosm/pyrosm/pull/366>`__)
+
+Thanks for all the contributors who helped to improve the library either via PRs, or by raising or participating in an issue:
+
+- mitchellhenke (`#366 <https://github.com/pyrosm/pyrosm/pull/366>`__)
+
 v0.11.0 (Jul 1, 2026)
 ---------------------
 

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -17,7 +17,7 @@ Recommended citation
 --------------------
 
    Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
-   with GeoDataFrames*. (v0.11.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+   with GeoDataFrames*. (v0.12.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 BibTeX
 ------
@@ -28,7 +28,7 @@ BibTeX
      author    = {Tenkanen, Henrikki},
      title     = {{pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames}},
      year      = {2026},
-     version   = {0.11.0},
+     version   = {0.12.0},
      publisher = {Zenodo},
      doi       = {10.5281/zenodo.3755057},
      url       = {https://doi.org/10.5281/zenodo.3755057}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ copyright = f"2020-{current_year}, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.11.0"
+version = release = "0.12.0"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ Current features
 - filter data based on bounding box
 - control which OSM tags are parsed into columns
 - crop a PBF to a smaller area and write modified OSM data back to PBF (NEW in v0.9.0), or export only selected layers (NEW in v0.11.0)
+- edit the geometry of an OSM network -- move nodes, reshape ways, delete elements -- and write it back to PBF (NEW in v0.12.0)
 - export networks as a directed graph to ``igraph``, ``networkx`` and ``pandarm``, optionally with topological simplification (NEW in v0.11.0)
 
 When should I use Pyrosm?
@@ -80,7 +81,7 @@ If you use pyrosm in your work, please cite it. Pyrosm is archived on
 `Zenodo <https://doi.org/10.5281/zenodo.3755057>`__ with a citable DOI:
 
     Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
-    with GeoDataFrames*. (v0.11.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+    with GeoDataFrames*. (v0.12.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 See :doc:`How to cite pyrosm <citation>` for the full reference and a BibTeX entry.
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ if _linetrace:
 
 setup(
     name="pyrosm",
-    version="0.11.0",
+    version="0.12.0",
     license="MIT",
     description="A Python tool to parse OSM data from Protobuf format into GeoDataFrame.",
     long_description=read_long_description(),


### PR DESCRIPTION
Bumps the packaged version to `0.12.0` and promotes the `Unreleased` changelog notes under a `v0.12.0` heading, following [RELEASING.md](https://github.com/pyrosm/pyrosm/blob/master/RELEASING.md).

## Release contents

Everything merged to `master` since `v0.11.0`:

- `OSM.write_pbf` geometry editing — `apply_geometry=True` to move nodes, reshape ways through their `nodes` member-id column and add elements under caller-chosen ids, plus a `delete` parameter with the `on_orphan_node` and `on_deleted_member` policies (#367)
- A `keep_node_info` parameter on `OSM(...)`, which keeps the way member-id column in the returned GeoDataFrames (#367)
- California added to the US state sources (#366)

The changelog entry for #366 is added here, as that PR merged without one. The release notes credit @mitchellhenke in the contributors section.

## Files

| File | Change |
| --- | --- |
| `setup.py`, `docs/conf.py` | version `0.11.0` → `0.12.0` |
| `CITATION.cff` | `version` and `date-released` |
| `README.md`, `docs/citation.rst`, `docs/index.rst` | citation strings |
| `CHANGELOG.md`, `docs/changelog.rst` | `Unreleased` → `v0.12.0` |

`README.md` and `docs/index.rst` also gain a feature-list bullet for network geometry editing, matching the existing `(NEW in vX.Y.Z)` markers. The historical `(NEW in v0.11.0)` markers are left as they are, and no library code is touched.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
