### PR TITLE
Ship slimmer wheels and add the Linux ARM build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,9 @@ jobs:
       matrix:
         # macos-14 (arm64) builds both arm64 and cross-compiled x86_64 wheels
         # (see [tool.cibuildwheel.macos]); Intel macos-13 runners are retired.
-        os: [ubuntu-latest, windows-latest, macos-14]
+        # ubuntu-24.04-arm builds the aarch64 Linux wheels natively, so no
+        # emulation is needed.
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v5
       - uses: pypa/cibuildwheel@v4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,13 @@ build-frontend = "build"
 # Import the freshly built wheel and parse the bundled extract end to end.
 test-command = "python {project}/ci/smoke_test.py"
 
+[tool.cibuildwheel.linux]
+# The manylinux images compile with -g, and auditwheel does not strip, so the
+# DWARF debug sections ended up as ~88% of every compiled module (an 8 MB
+# pbf_export.so carrying 0.75 MB of code). -g0 leaves them out; the toolchains of
+# the other platforms keep the debug info outside the shared library already.
+environment = { CFLAGS = "-g0" }
+
 [tool.cibuildwheel.macos]
 # Intel (macos-13) runners are retired, so build both macOS architectures on the
 # arm64 runner: arm64 natively, x86_64 cross-compiled. cibuildwheel runs the

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,11 @@ setup(
     url="https://pyrosm.readthedocs.io/",
     packages=find_packages(),
     include_package_data=True,
+    # The Cython-generated C sources sit next to the .pyx files and are picked up
+    # by include_package_data, which shipped 14 MB of them inside every binary
+    # wheel. They are only needed to build, so keep them out of the installation
+    # (the sdist keeps them, so a source build needs no Cython).
+    exclude_package_data={"pyrosm": ["*.c"]},
     zip_safe=False,
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
The published wheels carry two things nobody installing pyrosm can use, and the Linux build covers only x86_64.

**Debug info.** The manylinux images compile with `-g` and `auditwheel repair` does not strip, so DWARF sections made up 88% of every compiled module: `pbf_export.so` was 8.11 MB, of which 7.21 MB was `.debug_*` and 0.75 MB was code. Across all modules, 24.45 MB of the 27.85 MB of shared libraries was debug info. `[tool.cibuildwheel.linux] environment = { CFLAGS = "-g0" }` leaves it out. The macOS and Windows toolchains keep debug info outside the shared library already, so the setting is scoped to Linux.

**Generated C sources.** `include_package_data=True` picks up the Cython-generated `.c` files sitting next to the `.pyx` sources, so 14.29 MB of C shipped inside every binary wheel on every platform. `exclude_package_data={"pyrosm": ["*.c"]}` keeps them out of the installation. The sdist still contains them, so a source build needs no Cython.

**Linux ARM.** The wheel matrix gains `ubuntu-24.04-arm`, which builds the aarch64 wheels natively -- no emulation. Linux ARM users currently have to build pyrosm from source.

## Effect

Built from a clean clone (macOS arm64, cp312):

| | before | after |
| --- | --- | --- |
| wheel | 5.09 MB | 3.08 MB |
| unpacked | 19.7 MB | 5.43 MB |

The Linux wheel gains the debug-info saving on top: 11.98 MB → roughly 3 MB, and ~44.7 MB → ~6 MB installed.

AI assistants: Claude Opus 5 (claude-opus-5[1m], xhigh reasoning) via Claude Code 2.1.220.
