### PR TITLE
Prepare v0.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.13.1
+-------
+
+A packaging release: the wheels are considerably smaller and Linux ARM wheels are published. The library itself is unchanged.
+
+- CHANGED: The wheels no longer carry the debug information and the generated C sources. The manylinux images compile with `-g` and `auditwheel` does not strip, so the DWARF sections made up 88% of every compiled module, and `include_package_data` shipped the Cython-generated `.c` files next to the `.pyx` sources inside every binary wheel. The Linux wheel drops from 12.0 MB to about 3 MB (~44.7 MB to ~6 MB installed), and the macOS and Windows wheels from about 5.1 MB to 3.1 MB. The source distribution still contains the C sources, so a source build needs no Cython ([#374](https://github.com/pyrosm/pyrosm/pull/374))
+- NEW: Publish Linux ARM (`aarch64`) wheels, built natively on an ARM runner. Installing on Linux ARM no longer builds pyrosm from source ([#374](https://github.com/pyrosm/pyrosm/pull/374))
+
 v0.13.0
 -------
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,8 @@ identifiers:
     value: 10.5281/zenodo.3755057
     description: "Concept DOI that always resolves to the latest version"
 doi: 10.5281/zenodo.3755057
-version: 0.13.0
-date-released: "2026-07-29"
+version: 0.13.1
+date-released: "2026-08-01"
 license: MIT
 repository-code: "https://github.com/pyrosm/pyrosm"
 url: "https://pyrosm.readthedocs.io/"

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ You can run tests with `pytest` by executing:
 
 ## Citing pyrosm
 
-If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version). An example citation for the pyrosm version 0.13.0 is as follows:
+If you use pyrosm in your research or other work, please cite it. Pyrosm is archived on [Zenodo](https://doi.org/10.5281/zenodo.3755057), which provides a citable DOI (`10.5281/zenodo.3755057`, always resolving to the latest version). An example citation for the pyrosm version 0.13.1 is as follows:
 
-> Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames*. (v0.13.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+> Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames*. (v0.13.1) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 A BibTeX entry and version-specific DOIs are available in the [documentation](https://pyrosm.readthedocs.io/en/stable/citation.html) and on the [Zenodo record](https://doi.org/10.5281/zenodo.3755057).
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.13.1 (Aug 1, 2026)
+---------------------
+
+A packaging release: the wheels are considerably smaller and Linux ARM wheels are published. The library itself is unchanged.
+
+- CHANGED: The wheels no longer carry the debug information and the generated C sources. The manylinux images compile with ``-g`` and ``auditwheel`` does not strip, so the DWARF sections made up 88% of every compiled module, and ``include_package_data`` shipped the Cython-generated ``.c`` files next to the ``.pyx`` sources inside every binary wheel. The Linux wheel drops from 12.0 MB to about 3 MB (~44.7 MB to ~6 MB installed), and the macOS and Windows wheels from about 5.1 MB to 3.1 MB. The source distribution still contains the C sources, so a source build needs no Cython (`#374 <https://github.com/pyrosm/pyrosm/pull/374>`__)
+- NEW: Publish Linux ARM (``aarch64``) wheels, built natively on an ARM runner. Installing on Linux ARM no longer builds pyrosm from source (`#374 <https://github.com/pyrosm/pyrosm/pull/374>`__)
+
 v0.13.0 (Jul 29, 2026)
 ----------------------
 

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -17,7 +17,7 @@ Recommended citation
 --------------------
 
    Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
-   with GeoDataFrames*. (v0.13.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+   with GeoDataFrames*. (v0.13.1) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 BibTeX
 ------
@@ -28,7 +28,7 @@ BibTeX
      author    = {Tenkanen, Henrikki},
      title     = {{pyrosm: A Python library for reading and writing OpenStreetMap PBF data with GeoDataFrames}},
      year      = {2026},
-     version   = {0.13.0},
+     version   = {0.13.1},
      publisher = {Zenodo},
      doi       = {10.5281/zenodo.3755057},
      url       = {https://doi.org/10.5281/zenodo.3755057}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ copyright = f"2020-{current_year}, Henrikki Tenkanen + pyrosm contributors"
 author = "Henrikki Tenkanen + pyrosm contributors"
 
 # The full version, including alpha/beta/rc tags
-version = release = "0.13.0"
+version = release = "0.13.1"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -81,7 +81,7 @@ If you use pyrosm in your work, please cite it. Pyrosm is archived on
 `Zenodo <https://doi.org/10.5281/zenodo.3755057>`__ with a citable DOI:
 
     Tenkanen, H. (2026). *pyrosm: A Python library for reading and writing OpenStreetMap PBF data
-    with GeoDataFrames*. (v0.13.0) Zenodo. https://doi.org/10.5281/zenodo.3755057
+    with GeoDataFrames*. (v0.13.1) Zenodo. https://doi.org/10.5281/zenodo.3755057
 
 See :doc:`How to cite pyrosm <citation>` for the full reference and a BibTeX entry.
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ if _linetrace:
 
 setup(
     name="pyrosm",
-    version="0.13.0",
+    version="0.13.1",
     license="MIT",
     description="A Python tool to parse OSM data from Protobuf format into GeoDataFrame.",
     long_description=read_long_description(),


### PR DESCRIPTION
Bumps the packaged version to `0.13.1` and adds the `v0.13.1` changelog heading, following [RELEASING.md](https://github.com/pyrosm/pyrosm/blob/master/RELEASING.md).

## Release contents

Everything merged to `master` since `v0.13.0`, all of it packaging:

- The wheels no longer carry the debug information (Linux) or the Cython-generated C sources (every platform). The Linux wheel drops from 12.0 MB to about 3 MB, the macOS and Windows wheels from about 5.1 MB to 3.1 MB, and the installation from ~44.7 MB to ~6 MB (#374)
- Linux ARM (`aarch64`) wheels are published, built natively on an ARM runner (#374)

The library itself is unchanged, so this is a patch release.

## Files

| File | Change |
| --- | --- |
| `setup.py`, `docs/conf.py` | version `0.13.0` → `0.13.1` |
| `CITATION.cff` | `version` and `date-released` |
| `README.md`, `docs/citation.rst`, `docs/index.rst` | citation strings |
| `CHANGELOG.md`, `docs/changelog.rst` | new `v0.13.1` section |

`ci/check_version.py` accepts a `v0.13.1` tag against the bumped `setup.py`. This tag builds the wheel matrix for the first time with the ARM runner in it, so the aarch64 wheels are exercised by the `test-command` smoke test before publishing.

AI assistants: Claude Opus 5 (claude-opus-5[1m], xhigh reasoning) via Claude Code 2.1.220.
