### PR TITLE
Vendor cykhash so a wheel install needs no compiler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython", "cykhash>=2"]
+requires = ["setuptools", "wheel", "Cython"]
 
 [tool.black]
 force-exclude = '.*_pb2\.py$'

--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -1,6 +1,10 @@
 import numpy as np
 import pandas as pd
-from cykhash.khashsets cimport any_int64_from_iter, isin_int64, Int64Set_from_buffer
+from pyrosm.vendor.cykhash.khashsets cimport (
+    any_int64_from_iter,
+    isin_int64,
+    Int64Set_from_buffer,
+)
 from cpython cimport array
 from pyrosm.filter_compiler import CompiledFilter
 

--- a/pyrosm/node_lookup.pxd
+++ b/pyrosm/node_lookup.pxd
@@ -1,4 +1,4 @@
-from cykhash.khashmaps cimport Int64toInt64Map
+from pyrosm.vendor.cykhash.khashmaps cimport Int64toInt64Map
 
 
 cdef class NodeLocations:

--- a/pyrosm/node_lookup.pyx
+++ b/pyrosm/node_lookup.pyx
@@ -1,5 +1,8 @@
 import numpy as np
-from cykhash import Int64toInt64Map_from_buffers, Int64toInt64Map_to
+from pyrosm.vendor.cykhash.khashmaps import (
+    Int64toInt64Map_from_buffers,
+    Int64toInt64Map_to,
+)
 
 
 cdef class NodeLocations:

--- a/pyrosm/pbf_export.pyx
+++ b/pyrosm/pbf_export.pyx
@@ -31,8 +31,8 @@ from pyrosm.proto.osmformat_pb2 import (
 )
 from pyrosm.delta_compression cimport delta_encode
 
-from cykhash import Int64Set
-from cykhash.khashsets cimport isin_int64, Int64Set_from_buffer
+from pyrosm.vendor.cykhash.khashsets import Int64Set
+from pyrosm.vendor.cykhash.khashsets cimport isin_int64, Int64Set_from_buffer
 
 DIV = 1000000000
 

--- a/pyrosm/vendor/README.md
+++ b/pyrosm/vendor/README.md
@@ -1,0 +1,46 @@
+# Vendored third-party code
+
+## cykhash
+
+- **Upstream:** https://github.com/realead/cykhash
+- **Version:** 2.0.1 (PyPI sdist, released 2023-02-05)
+- **License:** MIT, see [cykhash/LICENSE](cykhash/LICENSE)
+
+pyrosm reads OSM ids through cykhash's khash-backed int64 set and int64->int64 map:
+`Int64Set`, `Int64Set_from_buffer`, `isin_int64` and `any_int64_from_iter` from
+`khashsets`, and `Int64toInt64Map`, `Int64toInt64Map_from_buffers` and
+`Int64toInt64Map_to` from `khashmaps`.
+
+It is vendored because cykhash publishes no wheels -- every release on PyPI is an sdist --
+so depending on it meant every `pip install pyrosm` compiled it from source, and needed a
+C compiler even on the platforms where pyrosm ships a binary wheel.
+
+### What was copied
+
+The `khashsets` and `khashmaps` modules and the files they include, from `src/cykhash/` of
+the sdist:
+
+```
+khashsets.pyx  khashsets.pxd  khashmaps.pyx  khashmaps.pxd  floatdef.pxd
+common.pxi  memory.pxi  khash.pxi  murmurhash.pxi  hash_functions.pxi
+sets/set_header.pxi  sets/set_impl.pxi  sets/set_init.pxi
+maps/map_header.pxi  maps/map_impl.pxi  maps/map_init.pxi
+```
+
+Every one of those is byte-for-byte upstream. The `.pxi` files ship pre-generated in the
+sdist, so upstream's Tempita templating step is not needed here.
+
+**The one exception is `cykhash/__init__.py`**, which is not upstream's: pyrosm imports the
+two extension modules directly, so the initializer here is a docstring that makes the
+directory a package. Upstream's re-exports both modules and additionally imports `unique`
+and `utils`, which pyrosm does not use and which are not vendored.
+
+`unique.pyx`, `utils.pyx`, the `.pxi.in` templates and upstream's own packaging files are
+left out.
+
+### Updating
+
+Download the sdist of the new version, copy the files listed above over the ones here,
+rewrite `__init__.py` the same way, and update the version above. Nothing else in pyrosm
+refers to the vendored files except the imports in `data_filter.pyx`, `node_lookup.pyx`,
+`node_lookup.pxd` and `pbf_export.pyx`.

--- a/pyrosm/vendor/__init__.py
+++ b/pyrosm/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Third-party code vendored into pyrosm. See README.md in this directory."""

--- a/pyrosm/vendor/cykhash/LICENSE
+++ b/pyrosm/vendor/cykhash/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 realead
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyrosm/vendor/cykhash/__init__.py
+++ b/pyrosm/vendor/cykhash/__init__.py
@@ -1,0 +1,7 @@
+"""Vendored cykhash: the khash-backed int64 set and map pyrosm reads OSM ids with.
+
+pyrosm imports the two extension modules directly (``pyrosm.vendor.cykhash.khashsets``
+and ``.khashmaps``), so this initializer only makes the directory a package. Upstream's
+own initializer re-exports both modules and additionally imports ``unique`` and
+``utils``, which are not vendored. See ../README.md.
+"""

--- a/pyrosm/vendor/cykhash/common.pxi
+++ b/pyrosm/vendor/cykhash/common.pxi
@@ -1,0 +1,13 @@
+
+
+cdef extern from *:
+    """ 
+        #ifndef CYKHASH_COMMON_PXI
+        #define CYKHASH_COMMON_PXI
+        
+        #define CYKHASH_INLINE static inline 
+      
+        #endif
+    """
+    pass
+

--- a/pyrosm/vendor/cykhash/floatdef.pxd
+++ b/pyrosm/vendor/cykhash/floatdef.pxd
@@ -1,0 +1,2 @@
+ctypedef double float64_t
+ctypedef float  float32_t

--- a/pyrosm/vendor/cykhash/hash_functions.pxi
+++ b/pyrosm/vendor/cykhash/hash_functions.pxi
@@ -1,0 +1,349 @@
+
+include "murmurhash.pxi"
+
+
+# hash functions from khash.h:
+cdef extern from *:
+    """
+        #ifndef CYKHASH_INTEGRAL_HASH_FUNS_PXI
+        #define CYKHASH_INTEGRAL_HASH_FUNS_PXI
+            CYKHASH_INLINE uint32_t kh_int32_hash_func(uint32_t key){return key;}
+            CYKHASH_INLINE int      kh_int32_hash_equal(uint32_t a, uint32_t b) {return a==b;}
+
+            CYKHASH_INLINE uint32_t kh_int64_hash_func(uint64_t key){
+                    return (uint32_t)((key)>>33^(key)^(key)<<11);
+            }
+            CYKHASH_INLINE int      kh_int64_hash_equal(uint64_t a, uint64_t b) {return a==b;}
+        #endif
+    """
+    pass
+
+
+
+# handling floats
+cdef extern from *:
+    """
+        #ifndef CYKHASH_FLOATING_HASH_FUNS_PXI
+        #define CYKHASH_FLOATING_HASH_FUNS_PXI
+            // correct handling for float64/32 <-> int64/32
+            #include <string.h>
+
+            typedef double float64_t;
+            typedef float float32_t;
+
+            //don't pun and alias:
+
+            CYKHASH_INLINE uint64_t f64_to_ui64(float64_t val){
+                  uint64_t res; 
+                  memcpy(&res, &val, sizeof(float64_t)); 
+                  return res;
+            } 
+
+            CYKHASH_INLINE float64_t ui64_to_f64(uint64_t val){
+                  float64_t res; 
+                  memcpy(&res, &val, sizeof(float64_t)); 
+                  return res;
+            }
+
+            CYKHASH_INLINE uint32_t f32_to_ui32(float32_t val){
+                  uint32_t res; 
+                  memcpy(&res, &val, sizeof(float32_t)); 
+                  return res;
+            } 
+
+            CYKHASH_INLINE float32_t ui32_to_f32(uint32_t val){
+                  float32_t res; 
+                  memcpy(&res, &val, sizeof(float32_t)); 
+                  return res;
+            }
+
+            // HASH AND EQUAL FUNCTIONS:
+            // 64bit
+            //khash has nothing predefined for float/double
+            //      in the first stet we add needed functionality
+            typedef float64_t khfloat64_t;
+
+            #define ZERO_HASH 0
+            #define NAN_HASH  0
+
+            CYKHASH_INLINE uint32_t kh_float64_hash_func(float64_t val){
+                  if(val==0.0){
+                    return ZERO_HASH;
+                  }
+                  if(val!=val){
+                   return NAN_HASH;
+                  }
+                  int64_t as_int = f64_to_ui64(val);
+                  return murmur2_64to32(as_int);
+            }
+
+            //                                                       take care of nans:
+            #define kh_float64_hash_equal(a, b) ((a) == (b) || ((b) != (b) && (a) != (a)))
+
+            // 32bit
+            typedef float float32_t;
+            typedef float32_t khfloat32_t;
+
+
+            CYKHASH_INLINE uint32_t kh_float32_hash_func(float32_t val){ 
+                  if(val==0.0){
+                    return ZERO_HASH;
+                  }
+                  if(val!=val){
+                   return NAN_HASH;
+                  }    
+                  int32_t as_int = f32_to_ui32(val);
+                  return murmur2_32to32(as_int);
+            }
+
+
+            //                                                       take care of nans:
+            #define kh_float32_hash_equal(a, b) ((a) == (b) || ((b) != (b) && (a) != (a)))
+        #endif
+    """  
+    pass
+
+
+cdef extern from *:
+    """
+        #ifndef CYKHASH_PYOBJECT_HASH_FUNS_PXI
+        #define CYKHASH_PYOBJECT_HASH_FUNS_PXI
+            //khash has nothing predefined for Pyobject
+            #include <Python.h>
+
+            typedef PyObject* pyobject_t;
+            typedef pyobject_t khpyobject_t;
+
+
+            CYKHASH_INLINE int floatobject_cmp(PyFloatObject* a, PyFloatObject* b){
+                return (
+                         Py_IS_NAN(PyFloat_AS_DOUBLE(a)) &&
+                         Py_IS_NAN(PyFloat_AS_DOUBLE(b))
+                       )
+                       ||
+                       ( PyFloat_AS_DOUBLE(a) == PyFloat_AS_DOUBLE(b) );
+            }
+
+
+            CYKHASH_INLINE int complexobject_cmp(PyComplexObject* a, PyComplexObject* b){
+                return (
+                            Py_IS_NAN(a->cval.real) &&
+                            Py_IS_NAN(b->cval.real) &&
+                            Py_IS_NAN(a->cval.imag) &&
+                            Py_IS_NAN(b->cval.imag)
+                       )
+                       ||
+                       (
+                            Py_IS_NAN(a->cval.real) &&
+                            Py_IS_NAN(b->cval.real) &&
+                            a->cval.imag == b->cval.imag
+                       )
+                       ||
+                       (
+                            a->cval.real == b->cval.real &&
+                            Py_IS_NAN(a->cval.imag) &&
+                            Py_IS_NAN(b->cval.imag)
+                       )
+                       ||
+                       (
+                            a->cval.real == b->cval.real &&
+                            a->cval.imag == b->cval.imag
+                       );
+            }
+
+            CYKHASH_INLINE int pyobject_cmp(PyObject* a, PyObject* b);
+
+
+            CYKHASH_INLINE int tupleobject_cmp(PyTupleObject* a, PyTupleObject* b){
+                Py_ssize_t i;
+
+                if (Py_SIZE(a) != Py_SIZE(b)) {
+                    return 0;
+                }
+
+                for (i = 0; i < Py_SIZE(a); ++i) {
+                    if (!pyobject_cmp(PyTuple_GET_ITEM(a, i), PyTuple_GET_ITEM(b, i))) {
+                        return 0;
+                    }
+                }
+                return 1;
+            }
+
+
+            CYKHASH_INLINE int pyobject_cmp(PyObject* a, PyObject* b) {
+                if (a == b) {
+                    return 1;
+                }
+                if (Py_TYPE(a) == Py_TYPE(b)) {
+                    // special handling for some built-in types which could have NaNs:
+                    if (PyFloat_CheckExact(a)) {
+                        return floatobject_cmp((PyFloatObject*)a, (PyFloatObject*)b);
+                    }
+                    if (PyComplex_CheckExact(a)) {
+                        return complexobject_cmp((PyComplexObject*)a, (PyComplexObject*)b);
+                    }
+                    if (PyTuple_CheckExact(a)) {
+                        return tupleobject_cmp((PyTupleObject*)a, (PyTupleObject*)b);
+                    }
+                    // frozenset isn't yet supported
+                }
+
+	            int result = PyObject_RichCompareBool(a, b, Py_EQ);
+	            if (result < 0) {
+		            PyErr_Clear();
+		            return 0;
+	            }
+	            return result;
+            }
+
+
+            ///hashes:
+
+            CYKHASH_INLINE Py_hash_t _Cykhash_HashDouble(double val) {
+                //Since Python3.10, nan is no longer has hash 0
+                if (Py_IS_NAN(val)) {
+                    return 0;
+                }
+            #if PY_VERSION_HEX < 0x030A0000
+                return _Py_HashDouble(val);
+            #else
+                return _Py_HashDouble(NULL, val);
+            #endif
+            }
+
+
+            CYKHASH_INLINE Py_hash_t floatobject_hash(PyFloatObject* key) {
+                return _Cykhash_HashDouble(PyFloat_AS_DOUBLE(key));
+            }
+
+
+            // replaces _Py_HashDouble with _Cykhash_HashDouble
+            #define _CykhashHASH_IMAG 1000003UL
+            CYKHASH_INLINE Py_hash_t complexobject_hash(PyComplexObject* key) {
+                Py_uhash_t realhash = (Py_uhash_t)_Cykhash_HashDouble(key->cval.real);
+                Py_uhash_t imaghash = (Py_uhash_t)_Cykhash_HashDouble(key->cval.imag);
+                if (realhash == (Py_uhash_t)-1 || imaghash == (Py_uhash_t)-1) {
+                    return -1;
+                }
+                Py_uhash_t combined = realhash + _CykhashHASH_IMAG * imaghash;
+                if (combined == (Py_uhash_t)-1) {
+                    return -2;
+                }
+                return (Py_hash_t)combined;
+            }
+
+
+            CYKHASH_INLINE uint32_t pyobject_hash(PyObject* key);
+
+            //we could use any hashing algorithm, this is the original CPython's for tuples
+
+            #if SIZEOF_PY_UHASH_T > 4
+            #define _CykhashHASH_XXPRIME_1 ((Py_uhash_t)11400714785074694791ULL)
+            #define _CykhashHASH_XXPRIME_2 ((Py_uhash_t)14029467366897019727ULL)
+            #define _CykhashHASH_XXPRIME_5 ((Py_uhash_t)2870177450012600261ULL)
+            #define _CykhashHASH_XXROTATE(x) ((x << 31) | (x >> 33))  /* Rotate left 31 bits */
+            #else
+            #define _CykhashHASH_XXPRIME_1 ((Py_uhash_t)2654435761UL)
+            #define _CykhashHASH_XXPRIME_2 ((Py_uhash_t)2246822519UL)
+            #define _CykhashHASH_XXPRIME_5 ((Py_uhash_t)374761393UL)
+            #define _CykhashHASH_XXROTATE(x) ((x << 13) | (x >> 19))  /* Rotate left 13 bits */
+            #endif
+
+            CYKHASH_INLINE Py_hash_t tupleobject_hash(PyTupleObject* key) {
+                Py_ssize_t i, len = Py_SIZE(key);
+                PyObject **item = key->ob_item;
+
+                Py_uhash_t acc = _CykhashHASH_XXPRIME_5;
+                for (i = 0; i < len; i++) {
+                    Py_uhash_t lane = pyobject_hash(item[i]);
+                    if (lane == (Py_uhash_t)-1) {
+                        return -1;
+                    }
+                    acc += lane * _CykhashHASH_XXPRIME_2;
+                    acc = _CykhashHASH_XXROTATE(acc);
+                    acc *= _CykhashHASH_XXPRIME_1;
+                }
+
+                /* Add input length, mangled to keep the historical value of hash(()). */
+                acc += len ^ (_CykhashHASH_XXPRIME_5 ^ 3527539UL);
+
+                if (acc == (Py_uhash_t)-1) {
+                    return 1546275796;
+                }
+                return acc;
+            }
+
+
+            CYKHASH_INLINE uint32_t pyobject_hash(PyObject* key) {
+                Py_hash_t hash;
+                // For PyObject_Hash holds:
+                //    hash(0.0) == 0 == hash(-0.0)
+                //    yet for different nan-objects different hash-values
+                //    are possible
+                if (PyFloat_CheckExact(key)) {
+                    // we cannot use kh_float64_hash_func
+                    // becase float(k) == k holds for any int-object k
+                    // and kh_float64_hash_func doesn't respect it
+                    hash = floatobject_hash((PyFloatObject*)key);
+                }
+                else if (PyComplex_CheckExact(key)) {
+                    // we cannot use kh_complex128_hash_func
+                    // becase complex(k,0) == k holds for any int-object k
+                    // and kh_complex128_hash_func doesn't respect it
+                    hash = complexobject_hash((PyComplexObject*)key);
+                }
+                else if (PyTuple_CheckExact(key)) {
+                    hash = tupleobject_hash((PyTupleObject*)key);
+                }
+                else {
+                    hash = PyObject_Hash(key);
+                }
+
+	            if (hash == -1) {
+		            PyErr_Clear();
+		            return 0;
+	            }
+                #if SIZEOF_PY_HASH_T == 4
+                    // it is already 32bit value
+                    return (uint32_t)hash;
+                #else
+                    // for 64bit builds,
+                    // we need information of the upper 32bits as well
+                    // uints avoid undefined behavior of signed ints
+                    return kh_int64_hash_func((uint64_t) hash);
+                #endif
+            }
+        #endif
+    """
+    pass
+
+
+
+cdef extern from *:
+    """
+        #ifndef CYKHASH_DEFINE_HASH_FUNS_PXI
+        #define CYKHASH_DEFINE_HASH_FUNS_PXI
+
+
+            // used hash-functions
+            #define cykh_int32_hash_func murmur2_32to32
+            #define cykh_int64_hash_func murmur2_64to32
+
+            #define cykh_float32_hash_func kh_float32_hash_func
+            #define cykh_float64_hash_func kh_float64_hash_func
+
+            #define cykh_pyobject_hash_func pyobject_hash
+
+            
+            // used equality-functions
+            #define cykh_int32_hash_equal kh_int32_hash_equal
+            #define cykh_int64_hash_equal kh_int64_hash_equal
+
+            #define cykh_float32_hash_equal kh_float32_hash_equal
+            #define cykh_float64_hash_equal kh_float64_hash_equal
+
+            #define cykh_pyobject_hash_equal pyobject_cmp
+
+        #endif
+    """
+    pass

--- a/pyrosm/vendor/cykhash/khash.pxi
+++ b/pyrosm/vendor/cykhash/khash.pxi
@@ -1,0 +1,530 @@
+
+#just use verbatim instead of h-file, so there is no need for setting include path for the compiler later on
+cdef extern from *:
+    """
+    /* The MIT License
+       Copyright (c) 2008, 2009, 2011 by Attractive Chaos <attractor@live.co.uk>
+       Permission is hereby granted, CYKHASH_FREE of charge, to any person obtaining
+       a copy of this software and associated documentation files (the
+       "Software"), to deal in the Software without restriction, including
+       without limitation the rights to use, copy, modify, merge, publish,
+       distribute, sublicense, and/or sell copies of the Software, and to
+       permit persons to whom the Software is furnished to do so, subject to
+       the following conditions:
+       The above copyright notice and this permission notice shall be
+       included in all copies or substantial portions of the Software.
+       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+       EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+       MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+       NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+       BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+       ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+       CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+       SOFTWARE.
+    */
+
+    /*
+      An example:
+    #include "khash.h"
+    KHASH_MAP_INIT_INT(32, char)
+    int main() {
+	    int ret, is_missing;
+	    khiter_t k;
+	    khash_t(32) *h = kh_init(32);
+	    k = kh_put(32, h, 5, &ret);
+	    kh_value(h, k) = 10;
+	    k = kh_get(32, h, 10);
+	    is_missing = (k == kh_end(h));
+	    k = kh_get(32, h, 5);
+	    kh_del(32, h, k);
+	    for (k = kh_begin(h); k != kh_end(h); ++k)
+		    if (kh_exist(h, k)) kh_value(h, k) = 1;
+	    kh_destroy(32, h);
+	    return 0;
+    }
+    */
+
+    /*
+      2013-05-02 (0.2.8):
+	    * Use quadratic probing. When the capacity is power of 2, stepping function
+	      i*(i+1)/2 guarantees to traverse each bucket. It is better than double
+	      hashing on cache performance and is more robust than linear probing.
+	      In theory, double hashing should be more robust than quadratic probing.
+	      However, my implementation is probably not for large hash tables, because
+	      the second hash function is closely tied to the first hash function,
+	      which reduce the effectiveness of double hashing.
+	    Reference: http://research.cs.vt.edu/AVresearch/hashing/quadratic.php
+      2011-12-29 (0.2.7):
+        * Minor code clean up; no actual effect.
+      2011-09-16 (0.2.6):
+	    * The capacity is a power of 2. This seems to dramatically improve the
+	      speed for simple keys. Thank Zilong Tan for the suggestion. Reference:
+	       - http://code.google.com/p/ulib/
+	       - http://nothings.org/computer/judy/
+	    * Allow to optionally use linear probing which usually has better
+	      performance for random input. Double hashing is still the default as it
+	      is more robust to certain non-random input.
+	    * Added Wang's integer hash function (not used by default). This hash
+	      function is more robust to certain non-random input.
+      2011-02-14 (0.2.5):
+        * Allow to declare global functions.
+      2009-09-26 (0.2.4):
+        * Improve portability
+      2008-09-19 (0.2.3):
+	    * Corrected the example
+	    * Improved interfaces
+      2008-09-11 (0.2.2):
+	    * Improved speed a little in kh_put()
+      2008-09-10 (0.2.1):
+	    * Added kh_clear()
+	    * Fixed a compiling error
+      2008-09-02 (0.2.0):
+	    * Changed to token concatenation which increases flexibility.
+      2008-08-31 (0.1.2):
+	    * Fixed a bug in kh_get(), which has not been tested previously.
+      2008-08-31 (0.1.1):
+	    * Added destructor
+    */
+
+
+    #ifndef __AC_KHASH_H
+    #define __AC_KHASH_H
+
+    /*!
+      @header
+      Generic hash table library.
+     */
+
+    #define AC_VERSION_KHASH_H "0.2.8"
+
+    #include <stdlib.h>
+    #include <string.h>
+    #include <limits.h>
+
+    /* compiler specific configuration */
+
+    #if UINT_MAX == 0xffffffffu
+    typedef unsigned int khuint32_t;
+    typedef int khint32_t;
+    #elif ULONG_MAX == 0xffffffffu
+    typedef unsigned long khuint32_t;
+    typedef long khint32_t;
+    #endif
+
+    #if ULONG_MAX == ULLONG_MAX
+    typedef unsigned long khuint64_t;
+    typedef long khint64_t;
+    #else
+    typedef unsigned long long khuint64_t;
+    typedef long long khint64_t;
+    #endif
+
+    #ifndef kh_inline
+    #ifdef _MSC_VER
+    #define kh_inline __inline
+    #else
+    #define kh_inline inline
+    #endif
+    #endif /* kh_inline */
+
+    #ifndef klib_unused
+    #if (defined __clang__ && __clang_major__ >= 3) || (defined __GNUC__ && __GNUC__ >= 3)
+    #define klib_unused __attribute__ ((__unused__))
+    #else
+    #define klib_unused
+    #endif
+    #endif /* klib_unused */
+
+    typedef khuint32_t khint_t;
+    typedef khint_t khiter_t;
+
+    #define __ac_isempty(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&2)
+    #define __ac_isdel(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&1)
+    #define __ac_iseither(flag, i) ((flag[i>>4]>>((i&0xfU)<<1))&3)
+    #define __ac_set_isdel_false(flag, i) (flag[i>>4]&=~(1ul<<((i&0xfU)<<1)))
+    #define __ac_set_isempty_false(flag, i) (flag[i>>4]&=~(2ul<<((i&0xfU)<<1)))
+    #define __ac_set_isboth_false(flag, i) (flag[i>>4]&=~(3ul<<((i&0xfU)<<1)))
+    #define __ac_set_isdel_true(flag, i) (flag[i>>4]|=1ul<<((i&0xfU)<<1))
+
+    #define __ac_fsize(m) ((m) < 16? 1 : (m)>>4)
+
+    #ifndef kroundup32
+    #define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+    #endif
+
+    #ifndef kCYKHASH_CALLOC
+    #define kCYKHASH_CALLOC(N,Z) CYKHASH_CALLOC(N,Z)
+    #endif
+    #ifndef kCYKHASH_MALLOC
+    #define kCYKHASH_MALLOC(Z) CYKHASH_MALLOC(Z)
+    #endif
+    #ifndef kCYKHASH_REALLOC
+    #define kCYKHASH_REALLOC(P,Z) CYKHASH_REALLOC(P,Z)
+    #endif
+    #ifndef kCYKHASH_FREE
+    #define kCYKHASH_FREE(P) CYKHASH_FREE(P)
+    #endif
+
+    static const double __ac_HASH_UPPER = 0.77;
+
+    #define __KHASH_TYPE(name, khkey_t, khval_t) \
+	    typedef struct kh_##name##_s { \
+		    khint_t n_buckets, size, n_occupied, upper_bound; \
+		    khuint32_t *flags; \
+		    khkey_t *keys; \
+		    khval_t *vals; \
+	    } kh_##name##_t;
+
+    #define __KHASH_PROTOTYPES(name, khkey_t, khval_t)	 					\
+	    extern kh_##name##_t *kh_init_##name(void);							\
+	    extern void kh_destroy_##name(kh_##name##_t *h);					\
+	    extern void kh_clear_##name(kh_##name##_t *h);						\
+	    extern khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key); 	\
+	    extern int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets); \
+	    extern khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret); \
+	    extern void kh_del_##name(kh_##name##_t *h, khint_t x);
+
+    #define __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	    SCOPE kh_##name##_t *kh_init_##name(void) {							\
+		    return (kh_##name##_t*)kCYKHASH_CALLOC(1, sizeof(kh_##name##_t));		\
+	    }																	\
+	    SCOPE void kh_destroy_##name(kh_##name##_t *h)						\
+	    {																	\
+		    if (h) {														\
+			    kCYKHASH_FREE((void *)h->keys); kCYKHASH_FREE(h->flags);					\
+			    kCYKHASH_FREE((void *)h->vals);										\
+			    kCYKHASH_FREE(h);													\
+		    }																\
+	    }																	\
+	    SCOPE void kh_clear_##name(kh_##name##_t *h)						\
+	    {																	\
+		    if (h && h->flags) {											\
+			    memset(h->flags, 0xaa, __ac_fsize(h->n_buckets) * sizeof(khuint32_t)); \
+			    h->size = h->n_occupied = 0;								\
+		    }																\
+	    }																	\
+	    SCOPE khint_t kh_get_##name(const kh_##name##_t *h, khkey_t key) 	\
+	    {																	\
+		    if (h->n_buckets) {												\
+			    khint_t k, i, last, mask, step = 0; \
+			    mask = h->n_buckets - 1;									\
+			    k = __hash_func(key); i = k & mask;							\
+			    last = i; \
+			    while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+				    i = (i + (++step)) & mask; \
+				    if (i == last) return h->n_buckets;						\
+			    }															\
+			    return __ac_iseither(h->flags, i)? h->n_buckets : i;		\
+		    } else return 0;												\
+	    }																	\
+	    SCOPE int kh_resize_##name(kh_##name##_t *h, khint_t new_n_buckets) \
+	    { /* This function uses 0.25*n_buckets bytes of working space instead of [sizeof(key_t+val_t)+.25]*n_buckets. */ \
+		    khuint32_t *new_flags = 0;										\
+		    khint_t j = 1;													\
+		    {																\
+			    kroundup32(new_n_buckets); 									\
+			    if (new_n_buckets < 4) new_n_buckets = 4;					\
+			    if (h->size >= (khint_t)(new_n_buckets * __ac_HASH_UPPER + 0.5)) j = 0;	/* requested size is too small */ \
+			    else { /* hash table size to be changed (shrink or expand); rehash */ \
+				    new_flags = (khuint32_t*)kCYKHASH_MALLOC(__ac_fsize(new_n_buckets) * sizeof(khuint32_t));	\
+				    if (!new_flags) return -1;								\
+				    memset(new_flags, 0xaa, __ac_fsize(new_n_buckets) * sizeof(khuint32_t)); \
+				    if (h->n_buckets < new_n_buckets) {	/* expand */		\
+					    khkey_t *new_keys = (khkey_t*)kCYKHASH_REALLOC((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+					    if (!new_keys) { kCYKHASH_FREE(new_flags); return -1; }		\
+					    h->keys = new_keys;									\
+					    if (kh_is_map) {									\
+						    khval_t *new_vals = (khval_t*)kCYKHASH_REALLOC((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+						    if (!new_vals) { kCYKHASH_FREE(new_flags); return -1; }	\
+						    h->vals = new_vals;								\
+					    }													\
+				    } /* otherwise shrink */								\
+			    }															\
+		    }																\
+		    if (j) { /* rehashing is needed */								\
+			    for (j = 0; j != h->n_buckets; ++j) {						\
+				    if (__ac_iseither(h->flags, j) == 0) {					\
+					    khkey_t key = h->keys[j];							\
+					    khval_t val;										\
+					    khint_t new_mask;									\
+					    new_mask = new_n_buckets - 1; 						\
+					    if (kh_is_map) val = h->vals[j];					\
+					    __ac_set_isdel_true(h->flags, j);					\
+					    while (1) { /* kick-out process; sort of like in Cuckoo hashing */ \
+						    khint_t k, i, step = 0; \
+						    k = __hash_func(key);							\
+						    i = k & new_mask;								\
+						    while (!__ac_isempty(new_flags, i)) i = (i + (++step)) & new_mask; \
+						    __ac_set_isempty_false(new_flags, i);			\
+						    if (i < h->n_buckets && __ac_iseither(h->flags, i) == 0) { /* kick out the existing element */ \
+							    { khkey_t tmp = h->keys[i]; h->keys[i] = key; key = tmp; } \
+							    if (kh_is_map) { khval_t tmp = h->vals[i]; h->vals[i] = val; val = tmp; } \
+							    __ac_set_isdel_true(h->flags, i); /* mark it as deleted in the old hash table */ \
+						    } else { /* write the element and jump out of the loop */ \
+							    h->keys[i] = key;							\
+							    if (kh_is_map) h->vals[i] = val;			\
+							    break;										\
+						    }												\
+					    }													\
+				    }														\
+			    }															\
+			    if (h->n_buckets > new_n_buckets) { /* shrink the hash table */ \
+				    h->keys = (khkey_t*)kCYKHASH_REALLOC((void *)h->keys, new_n_buckets * sizeof(khkey_t)); \
+				    if (kh_is_map) h->vals = (khval_t*)kCYKHASH_REALLOC((void *)h->vals, new_n_buckets * sizeof(khval_t)); \
+			    }															\
+			    kCYKHASH_FREE(h->flags); /* CYKHASH_FREE the working space */				\
+			    h->flags = new_flags;										\
+			    h->n_buckets = new_n_buckets;								\
+			    h->n_occupied = h->size;									\
+			    h->upper_bound = (khint_t)(h->n_buckets * __ac_HASH_UPPER + 0.5); \
+		    }																\
+		    return 0;														\
+	    }																	\
+	    SCOPE khint_t kh_put_##name(kh_##name##_t *h, khkey_t key, int *ret) \
+	    {																	\
+		    khint_t x;														\
+		    if (h->n_occupied >= h->upper_bound) { /* update the hash table */ \
+			    if (h->n_buckets > (h->size<<1)) {							\
+				    if (kh_resize_##name(h, h->n_buckets - 1) < 0) { /* clear "deleted" elements */ \
+					    *ret = -1; return h->n_buckets;						\
+				    }														\
+			    } else if (kh_resize_##name(h, h->n_buckets + 1) < 0) { /* expand the hash table */ \
+				    *ret = -1; return h->n_buckets;							\
+			    }															\
+		    } /* TODO: to implement automatically shrinking; resize() already support shrinking */ \
+		    {																\
+			    khint_t k, i, site, last, mask = h->n_buckets - 1, step = 0; \
+			    x = site = h->n_buckets; k = __hash_func(key); i = k & mask; \
+			    if (__ac_isempty(h->flags, i)) x = i; /* for speed up */	\
+			    else {														\
+				    last = i; \
+				    while (!__ac_isempty(h->flags, i) && (__ac_isdel(h->flags, i) || !__hash_equal(h->keys[i], key))) { \
+					    if (__ac_isdel(h->flags, i)) site = i;				\
+					    i = (i + (++step)) & mask; \
+					    if (i == last) { x = site; break; }					\
+				    }														\
+				    if (x == h->n_buckets) {								\
+					    if (__ac_isempty(h->flags, i) && site != h->n_buckets) x = site; \
+					    else x = i;											\
+				    }														\
+			    }															\
+		    }																\
+		    if (__ac_isempty(h->flags, x)) { /* not present at all */		\
+			    h->keys[x] = key;											\
+			    __ac_set_isboth_false(h->flags, x);							\
+			    ++h->size; ++h->n_occupied;									\
+			    *ret = 1;													\
+		    } else if (__ac_isdel(h->flags, x)) { /* deleted */				\
+			    h->keys[x] = key;											\
+			    __ac_set_isboth_false(h->flags, x);							\
+			    ++h->size;													\
+			    *ret = 2;													\
+		    } else *ret = 0; /* Don't touch h->keys[x] if present and not deleted */ \
+		    return x;														\
+	    }																	\
+	    SCOPE void kh_del_##name(kh_##name##_t *h, khint_t x)				\
+	    {																	\
+		    if (x != h->n_buckets && !__ac_iseither(h->flags, x)) {			\
+			    __ac_set_isdel_true(h->flags, x);							\
+			    --h->size;													\
+		    }																\
+	    }
+
+    #define KHASH_DECLARE(name, khkey_t, khval_t)		 					\
+	    __KHASH_TYPE(name, khkey_t, khval_t) 								\
+	    __KHASH_PROTOTYPES(name, khkey_t, khval_t)
+
+    #define KHASH_INIT2(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	    __KHASH_TYPE(name, khkey_t, khval_t) 								\
+	    __KHASH_IMPL(name, SCOPE, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+    #define KHASH_INIT(name, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal) \
+	    KHASH_INIT2(name, static kh_inline klib_unused, khkey_t, khval_t, kh_is_map, __hash_func, __hash_equal)
+
+    /* Other convenient macros... */
+
+    /*!
+      @abstract Type of the hash table.
+      @param  name  Name of the hash table [symbol]
+     */
+    #define khash_t(name) kh_##name##_t
+
+    /*! @function
+      @abstract     Initiate a hash table.
+      @param  name  Name of the hash table [symbol]
+      @return       Pointer to the hash table [khash_t(name)*]
+     */
+    #define kh_init(name) kh_init_##name()
+
+    /*! @function
+      @abstract     Destroy a hash table.
+      @param  name  Name of the hash table [symbol]
+      @param  h     Pointer to the hash table [khash_t(name)*]
+     */
+    #define kh_destroy(name, h) kh_destroy_##name(h)
+
+    /*! @function
+      @abstract     Reset a hash table without deallocating memory.
+      @param  name  Name of the hash table [symbol]
+      @param  h     Pointer to the hash table [khash_t(name)*]
+     */
+    #define kh_clear(name, h) kh_clear_##name(h)
+
+    /*! @function
+      @abstract     Resize a hash table.
+      @param  name  Name of the hash table [symbol]
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  s     New size [khint_t]
+     */
+    #define kh_resize(name, h, s) kh_resize_##name(h, s)
+
+    /*! @function
+      @abstract     Insert a key to the hash table.
+      @param  name  Name of the hash table [symbol]
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  k     Key [type of keys]
+      @param  r     Extra return code: -1 if the operation failed;
+                    0 if the key is present in the hash table;
+                    1 if the bucket is empty (never used); 2 if the element in
+				    the bucket has been deleted [int*]
+      @return       Iterator to the inserted element [khint_t]
+     */
+    #define kh_put(name, h, k, r) kh_put_##name(h, k, r)
+
+    /*! @function
+      @abstract     Retrieve a key from the hash table.
+      @param  name  Name of the hash table [symbol]
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  k     Key [type of keys]
+      @return       Iterator to the found element, or kh_end(h) if the element is absent [khint_t]
+     */
+    #define kh_get(name, h, k) kh_get_##name(h, k)
+
+    /*! @function
+      @abstract     Remove a key from the hash table.
+      @param  name  Name of the hash table [symbol]
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  k     Iterator to the element to be deleted [khint_t]
+     */
+    #define kh_del(name, h, k) kh_del_##name(h, k)
+
+    /*! @function
+      @abstract     Test whether a bucket contains data.
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  x     Iterator to the bucket [khint_t]
+      @return       1 if containing data; 0 otherwise [int]
+     */
+    #define kh_exist(h, x) (!__ac_iseither((h)->flags, (x)))
+
+    /*! @function
+      @abstract     Get key given an iterator
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  x     Iterator to the bucket [khint_t]
+      @return       Key [type of keys]
+     */
+    #define kh_key(h, x) ((h)->keys[x])
+
+    /*! @function
+      @abstract     Get value given an iterator
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  x     Iterator to the bucket [khint_t]
+      @return       Value [type of values]
+      @discussion   For hash sets, calling this results in segfault.
+     */
+    #define kh_val(h, x) ((h)->vals[x])
+
+    /*! @function
+      @abstract     Alias of kh_val()
+     */
+    #define kh_value(h, x) ((h)->vals[x])
+
+    /*! @function
+      @abstract     Get the start iterator
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @return       The start iterator [khint_t]
+     */
+    #define kh_begin(h) (khint_t)(0)
+
+    /*! @function
+      @abstract     Get the end iterator
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @return       The end iterator [khint_t]
+     */
+    #define kh_end(h) ((h)->n_buckets)
+
+    /*! @function
+      @abstract     Get the number of elements in the hash table
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @return       Number of elements in the hash table [khint_t]
+     */
+    #define kh_size(h) ((h)->size)
+
+    /*! @function
+      @abstract     Get the number of buckets in the hash table
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @return       Number of buckets in the hash table [khint_t]
+     */
+    #define kh_n_buckets(h) ((h)->n_buckets)
+
+    /*! @function
+      @abstract     Iterate over the entries in the hash table
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  kvar  Variable to which key will be assigned
+      @param  vvar  Variable to which value will be assigned
+      @param  code  Block of code to execute
+     */
+    #define kh_foreach(h, kvar, vvar, code) { khint_t __i;		\
+	    for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		    if (!kh_exist(h,__i)) continue;						\
+		    (kvar) = kh_key(h,__i);								\
+		    (vvar) = kh_val(h,__i);								\
+		    code;												\
+	    } }
+
+    /*! @function
+      @abstract     Iterate over the values in the hash table
+      @param  h     Pointer to the hash table [khash_t(name)*]
+      @param  vvar  Variable to which value will be assigned
+      @param  code  Block of code to execute
+     */
+    #define kh_foreach_value(h, vvar, code) { khint_t __i;		\
+	    for (__i = kh_begin(h); __i != kh_end(h); ++__i) {		\
+		    if (!kh_exist(h,__i)) continue;						\
+		    (vvar) = kh_val(h,__i);								\
+		    code;												\
+	    } }
+
+    #endif /* __AC_KHASH_H */ 
+    """
+    ctypedef uint32_t khint_t
+
+
+cdef extern from *:
+    """
+    khint_t element_n_to_bucket_n(khint_t element_n){
+        khint_t candidate = element_n;
+        kroundup32(candidate);
+        khint_t upper_bound = (khint_t)(candidate * __ac_HASH_UPPER + 0.5);
+        return (upper_bound < element_n) ? 2*candidate : candidate;
+        
+    }
+
+    khint_t element_n_from_size_hint(khint_t element_n, double size_hint){
+        if(size_hint>0.0){
+            return (khint_t)(element_n * size_hint);
+        } 
+        return element_n;
+        
+    }
+
+    khint_t bucket_n_from_size_hint(khint_t element_n, double size_hint){
+        if(size_hint>0.0){
+            return (khint_t)(element_n * size_hint);
+        } 
+        return element_n_to_bucket_n(element_n);
+        
+    }
+    """
+    khint_t element_n_to_bucket_n(khint_t element_n)
+    khint_t element_n_from_size_hint(khint_t element_n, double size_hint)
+    khint_t bucket_n_from_size_hint(khint_t element_n, double size_hint)

--- a/pyrosm/vendor/cykhash/khashmaps.pxd
+++ b/pyrosm/vendor/cykhash/khashmaps.pxd
@@ -1,0 +1,20 @@
+from libc.stdint cimport  uint64_t, uint32_t,  int64_t,  int32_t
+from cpython.object cimport PyObject
+
+from .floatdef cimport float64_t, float32_t
+
+### Common definitions:
+ctypedef PyObject* pyobject_t
+
+include "common.pxi"
+include "memory.pxi"
+include "khash.pxi"
+include "murmurhash.pxi"
+
+
+#utilities for int<->float
+include "hash_functions.pxi"
+
+# different implementation
+include "maps/map_header.pxi"
+

--- a/pyrosm/vendor/cykhash/khashmaps.pyx
+++ b/pyrosm/vendor/cykhash/khashmaps.pyx
@@ -1,0 +1,36 @@
+
+
+
+
+# different implementations:
+include "maps/map_impl.pxi"
+
+
+
+# backward compartibility:
+def Float64to64Map(*, number_of_elements_hint=None, for_int=True):
+    if for_int:
+        return Float64toInt64Map(number_of_elements_hint=number_of_elements_hint)
+    else:
+        return Float64toFloat64Map(number_of_elements_hint=number_of_elements_hint)
+
+
+def Int64to64Map(*, number_of_elements_hint=None, for_int=True):
+    if for_int:
+        return Int64toInt64Map(number_of_elements_hint=number_of_elements_hint)
+    else:
+        return Int64toFloat64Map(number_of_elements_hint=number_of_elements_hint)
+
+
+def Float32to32Map(*, number_of_elements_hint=None, for_int=True):
+    if for_int:
+        return Float32toInt32Map(number_of_elements_hint=number_of_elements_hint)
+    else:
+        return Float32toFloat32Map(number_of_elements_hint=number_of_elements_hint)
+
+
+def Int32to32Map(*, number_of_elements_hint=None, for_int=True):
+    if for_int:
+        return Int32toInt32Map(number_of_elements_hint=number_of_elements_hint)
+    else:
+        return Int32toFloat32Map(number_of_elements_hint=number_of_elements_hint)

--- a/pyrosm/vendor/cykhash/khashsets.pxd
+++ b/pyrosm/vendor/cykhash/khashsets.pxd
@@ -1,0 +1,21 @@
+from libc.stdint cimport  uint64_t, uint32_t,  int64_t,  int32_t
+from cpython.object cimport PyObject
+
+from .floatdef cimport float64_t, float32_t
+
+### Common definitions:
+ 
+ctypedef PyObject* pyobject_t
+
+include "common.pxi"
+include "memory.pxi"
+include "khash.pxi"
+include "murmurhash.pxi"
+
+
+#utilities for int<->float
+include "hash_functions.pxi"
+
+# different implementations
+include "sets/set_header.pxi"
+

--- a/pyrosm/vendor/cykhash/khashsets.pyx
+++ b/pyrosm/vendor/cykhash/khashsets.pyx
@@ -1,0 +1,4 @@
+
+
+# different implementations:
+include "sets/set_impl.pxi"

--- a/pyrosm/vendor/cykhash/maps/map_header.pxi
+++ b/pyrosm/vendor/cykhash/maps/map_header.pxi
@@ -1,0 +1,598 @@
+"""
+Template for maps
+
+WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
+"""
+
+
+include "map_init.pxi"
+
+cdef extern from *:
+
+    ctypedef struct kh_int64toint64map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        int64_t *keys
+        int64_t *vals  
+
+    kh_int64toint64map_t* kh_init_int64toint64map() nogil
+    void kh_destroy_int64toint64map(kh_int64toint64map_t*) nogil
+    void kh_clear_int64toint64map(kh_int64toint64map_t*) nogil
+    khint_t kh_get_int64toint64map(kh_int64toint64map_t*, int64_t) nogil
+    void kh_resize_int64toint64map(kh_int64toint64map_t*, khint_t) nogil
+    khint_t kh_put_int64toint64map(kh_int64toint64map_t*, int64_t, int* result) nogil
+    void kh_del_int64toint64map(kh_int64toint64map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_int64toint64map "kh_exist" (kh_int64toint64map_t*, khint_t) nogil
+
+cdef class Int64toInt64Map:
+    cdef kh_int64toint64map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, int64_t key) except *
+    cdef Int64toInt64MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, int64_t key, int64_t value) except *
+    cpdef int64_t cget(self, int64_t key) except *
+    cpdef void discard(self, int64_t key) except *
+    
+
+cdef struct int64toint64_key_val_pair:
+    int64_t key
+    int64_t val
+
+
+cdef class Int64toInt64MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Int64toInt64Map  parent
+
+    cdef bint has_next(self) except *
+    cdef int64toint64_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Int64toInt64MapView:
+    cdef Int64toInt64Map  parent
+    cdef int       view_type
+
+    cdef Int64toInt64MapIterator get_iter(self)
+
+
+cpdef Int64toInt64Map Int64toInt64Map_from_buffers(int64_t[:] keys, int64_t[:] vals, double size_hint=*)
+
+cpdef size_t Int64toInt64Map_to(Int64toInt64Map map, int64_t[:] keys, int64_t[:] vals, bint stop_at_unknown=*, int64_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_int64toint64map(Int64toInt64Map a, Int64toInt64Map b) except *
+cpdef Int64toInt64Map copy_int64toint64map(Int64toInt64Map s)
+cpdef bint are_equal_int64toint64map(Int64toInt64Map a, Int64toInt64Map b) except *
+cpdef void update_int64toint64map(Int64toInt64Map a, Int64toInt64Map b) except *
+
+cdef extern from *:
+
+    ctypedef struct kh_int64tofloat64map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        int64_t *keys
+        float64_t *vals  
+
+    kh_int64tofloat64map_t* kh_init_int64tofloat64map() nogil
+    void kh_destroy_int64tofloat64map(kh_int64tofloat64map_t*) nogil
+    void kh_clear_int64tofloat64map(kh_int64tofloat64map_t*) nogil
+    khint_t kh_get_int64tofloat64map(kh_int64tofloat64map_t*, int64_t) nogil
+    void kh_resize_int64tofloat64map(kh_int64tofloat64map_t*, khint_t) nogil
+    khint_t kh_put_int64tofloat64map(kh_int64tofloat64map_t*, int64_t, int* result) nogil
+    void kh_del_int64tofloat64map(kh_int64tofloat64map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_int64tofloat64map "kh_exist" (kh_int64tofloat64map_t*, khint_t) nogil
+
+cdef class Int64toFloat64Map:
+    cdef kh_int64tofloat64map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, int64_t key) except *
+    cdef Int64toFloat64MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, int64_t key, float64_t value) except *
+    cpdef float64_t cget(self, int64_t key) except *
+    cpdef void discard(self, int64_t key) except *
+    
+
+cdef struct int64tofloat64_key_val_pair:
+    int64_t key
+    float64_t val
+
+
+cdef class Int64toFloat64MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Int64toFloat64Map  parent
+
+    cdef bint has_next(self) except *
+    cdef int64tofloat64_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Int64toFloat64MapView:
+    cdef Int64toFloat64Map  parent
+    cdef int       view_type
+
+    cdef Int64toFloat64MapIterator get_iter(self)
+
+
+cpdef Int64toFloat64Map Int64toFloat64Map_from_buffers(int64_t[:] keys, float64_t[:] vals, double size_hint=*)
+
+cpdef size_t Int64toFloat64Map_to(Int64toFloat64Map map, int64_t[:] keys, float64_t[:] vals, bint stop_at_unknown=*, float64_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_int64tofloat64map(Int64toFloat64Map a, Int64toFloat64Map b) except *
+cpdef Int64toFloat64Map copy_int64tofloat64map(Int64toFloat64Map s)
+cpdef bint are_equal_int64tofloat64map(Int64toFloat64Map a, Int64toFloat64Map b) except *
+cpdef void update_int64tofloat64map(Int64toFloat64Map a, Int64toFloat64Map b) except *
+
+cdef extern from *:
+
+    ctypedef struct kh_float64toint64map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        float64_t *keys
+        int64_t *vals  
+
+    kh_float64toint64map_t* kh_init_float64toint64map() nogil
+    void kh_destroy_float64toint64map(kh_float64toint64map_t*) nogil
+    void kh_clear_float64toint64map(kh_float64toint64map_t*) nogil
+    khint_t kh_get_float64toint64map(kh_float64toint64map_t*, float64_t) nogil
+    void kh_resize_float64toint64map(kh_float64toint64map_t*, khint_t) nogil
+    khint_t kh_put_float64toint64map(kh_float64toint64map_t*, float64_t, int* result) nogil
+    void kh_del_float64toint64map(kh_float64toint64map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_float64toint64map "kh_exist" (kh_float64toint64map_t*, khint_t) nogil
+
+cdef class Float64toInt64Map:
+    cdef kh_float64toint64map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, float64_t key) except *
+    cdef Float64toInt64MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, float64_t key, int64_t value) except *
+    cpdef int64_t cget(self, float64_t key) except *
+    cpdef void discard(self, float64_t key) except *
+    
+
+cdef struct float64toint64_key_val_pair:
+    float64_t key
+    int64_t val
+
+
+cdef class Float64toInt64MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Float64toInt64Map  parent
+
+    cdef bint has_next(self) except *
+    cdef float64toint64_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Float64toInt64MapView:
+    cdef Float64toInt64Map  parent
+    cdef int       view_type
+
+    cdef Float64toInt64MapIterator get_iter(self)
+
+
+cpdef Float64toInt64Map Float64toInt64Map_from_buffers(float64_t[:] keys, int64_t[:] vals, double size_hint=*)
+
+cpdef size_t Float64toInt64Map_to(Float64toInt64Map map, float64_t[:] keys, int64_t[:] vals, bint stop_at_unknown=*, int64_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_float64toint64map(Float64toInt64Map a, Float64toInt64Map b) except *
+cpdef Float64toInt64Map copy_float64toint64map(Float64toInt64Map s)
+cpdef bint are_equal_float64toint64map(Float64toInt64Map a, Float64toInt64Map b) except *
+cpdef void update_float64toint64map(Float64toInt64Map a, Float64toInt64Map b) except *
+
+cdef extern from *:
+
+    ctypedef struct kh_float64tofloat64map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        float64_t *keys
+        float64_t *vals  
+
+    kh_float64tofloat64map_t* kh_init_float64tofloat64map() nogil
+    void kh_destroy_float64tofloat64map(kh_float64tofloat64map_t*) nogil
+    void kh_clear_float64tofloat64map(kh_float64tofloat64map_t*) nogil
+    khint_t kh_get_float64tofloat64map(kh_float64tofloat64map_t*, float64_t) nogil
+    void kh_resize_float64tofloat64map(kh_float64tofloat64map_t*, khint_t) nogil
+    khint_t kh_put_float64tofloat64map(kh_float64tofloat64map_t*, float64_t, int* result) nogil
+    void kh_del_float64tofloat64map(kh_float64tofloat64map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_float64tofloat64map "kh_exist" (kh_float64tofloat64map_t*, khint_t) nogil
+
+cdef class Float64toFloat64Map:
+    cdef kh_float64tofloat64map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, float64_t key) except *
+    cdef Float64toFloat64MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, float64_t key, float64_t value) except *
+    cpdef float64_t cget(self, float64_t key) except *
+    cpdef void discard(self, float64_t key) except *
+    
+
+cdef struct float64tofloat64_key_val_pair:
+    float64_t key
+    float64_t val
+
+
+cdef class Float64toFloat64MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Float64toFloat64Map  parent
+
+    cdef bint has_next(self) except *
+    cdef float64tofloat64_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Float64toFloat64MapView:
+    cdef Float64toFloat64Map  parent
+    cdef int       view_type
+
+    cdef Float64toFloat64MapIterator get_iter(self)
+
+
+cpdef Float64toFloat64Map Float64toFloat64Map_from_buffers(float64_t[:] keys, float64_t[:] vals, double size_hint=*)
+
+cpdef size_t Float64toFloat64Map_to(Float64toFloat64Map map, float64_t[:] keys, float64_t[:] vals, bint stop_at_unknown=*, float64_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_float64tofloat64map(Float64toFloat64Map a, Float64toFloat64Map b) except *
+cpdef Float64toFloat64Map copy_float64tofloat64map(Float64toFloat64Map s)
+cpdef bint are_equal_float64tofloat64map(Float64toFloat64Map a, Float64toFloat64Map b) except *
+cpdef void update_float64tofloat64map(Float64toFloat64Map a, Float64toFloat64Map b) except *
+
+cdef extern from *:
+
+    ctypedef struct kh_int32toint32map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        int32_t *keys
+        int32_t *vals  
+
+    kh_int32toint32map_t* kh_init_int32toint32map() nogil
+    void kh_destroy_int32toint32map(kh_int32toint32map_t*) nogil
+    void kh_clear_int32toint32map(kh_int32toint32map_t*) nogil
+    khint_t kh_get_int32toint32map(kh_int32toint32map_t*, int32_t) nogil
+    void kh_resize_int32toint32map(kh_int32toint32map_t*, khint_t) nogil
+    khint_t kh_put_int32toint32map(kh_int32toint32map_t*, int32_t, int* result) nogil
+    void kh_del_int32toint32map(kh_int32toint32map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_int32toint32map "kh_exist" (kh_int32toint32map_t*, khint_t) nogil
+
+cdef class Int32toInt32Map:
+    cdef kh_int32toint32map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, int32_t key) except *
+    cdef Int32toInt32MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, int32_t key, int32_t value) except *
+    cpdef int32_t cget(self, int32_t key) except *
+    cpdef void discard(self, int32_t key) except *
+    
+
+cdef struct int32toint32_key_val_pair:
+    int32_t key
+    int32_t val
+
+
+cdef class Int32toInt32MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Int32toInt32Map  parent
+
+    cdef bint has_next(self) except *
+    cdef int32toint32_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Int32toInt32MapView:
+    cdef Int32toInt32Map  parent
+    cdef int       view_type
+
+    cdef Int32toInt32MapIterator get_iter(self)
+
+
+cpdef Int32toInt32Map Int32toInt32Map_from_buffers(int32_t[:] keys, int32_t[:] vals, double size_hint=*)
+
+cpdef size_t Int32toInt32Map_to(Int32toInt32Map map, int32_t[:] keys, int32_t[:] vals, bint stop_at_unknown=*, int32_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_int32toint32map(Int32toInt32Map a, Int32toInt32Map b) except *
+cpdef Int32toInt32Map copy_int32toint32map(Int32toInt32Map s)
+cpdef bint are_equal_int32toint32map(Int32toInt32Map a, Int32toInt32Map b) except *
+cpdef void update_int32toint32map(Int32toInt32Map a, Int32toInt32Map b) except *
+
+cdef extern from *:
+
+    ctypedef struct kh_int32tofloat32map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        int32_t *keys
+        float32_t *vals  
+
+    kh_int32tofloat32map_t* kh_init_int32tofloat32map() nogil
+    void kh_destroy_int32tofloat32map(kh_int32tofloat32map_t*) nogil
+    void kh_clear_int32tofloat32map(kh_int32tofloat32map_t*) nogil
+    khint_t kh_get_int32tofloat32map(kh_int32tofloat32map_t*, int32_t) nogil
+    void kh_resize_int32tofloat32map(kh_int32tofloat32map_t*, khint_t) nogil
+    khint_t kh_put_int32tofloat32map(kh_int32tofloat32map_t*, int32_t, int* result) nogil
+    void kh_del_int32tofloat32map(kh_int32tofloat32map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_int32tofloat32map "kh_exist" (kh_int32tofloat32map_t*, khint_t) nogil
+
+cdef class Int32toFloat32Map:
+    cdef kh_int32tofloat32map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, int32_t key) except *
+    cdef Int32toFloat32MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, int32_t key, float32_t value) except *
+    cpdef float32_t cget(self, int32_t key) except *
+    cpdef void discard(self, int32_t key) except *
+    
+
+cdef struct int32tofloat32_key_val_pair:
+    int32_t key
+    float32_t val
+
+
+cdef class Int32toFloat32MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Int32toFloat32Map  parent
+
+    cdef bint has_next(self) except *
+    cdef int32tofloat32_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Int32toFloat32MapView:
+    cdef Int32toFloat32Map  parent
+    cdef int       view_type
+
+    cdef Int32toFloat32MapIterator get_iter(self)
+
+
+cpdef Int32toFloat32Map Int32toFloat32Map_from_buffers(int32_t[:] keys, float32_t[:] vals, double size_hint=*)
+
+cpdef size_t Int32toFloat32Map_to(Int32toFloat32Map map, int32_t[:] keys, float32_t[:] vals, bint stop_at_unknown=*, float32_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_int32tofloat32map(Int32toFloat32Map a, Int32toFloat32Map b) except *
+cpdef Int32toFloat32Map copy_int32tofloat32map(Int32toFloat32Map s)
+cpdef bint are_equal_int32tofloat32map(Int32toFloat32Map a, Int32toFloat32Map b) except *
+cpdef void update_int32tofloat32map(Int32toFloat32Map a, Int32toFloat32Map b) except *
+
+cdef extern from *:
+
+    ctypedef struct kh_float32toint32map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        float32_t *keys
+        int32_t *vals  
+
+    kh_float32toint32map_t* kh_init_float32toint32map() nogil
+    void kh_destroy_float32toint32map(kh_float32toint32map_t*) nogil
+    void kh_clear_float32toint32map(kh_float32toint32map_t*) nogil
+    khint_t kh_get_float32toint32map(kh_float32toint32map_t*, float32_t) nogil
+    void kh_resize_float32toint32map(kh_float32toint32map_t*, khint_t) nogil
+    khint_t kh_put_float32toint32map(kh_float32toint32map_t*, float32_t, int* result) nogil
+    void kh_del_float32toint32map(kh_float32toint32map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_float32toint32map "kh_exist" (kh_float32toint32map_t*, khint_t) nogil
+
+cdef class Float32toInt32Map:
+    cdef kh_float32toint32map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, float32_t key) except *
+    cdef Float32toInt32MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, float32_t key, int32_t value) except *
+    cpdef int32_t cget(self, float32_t key) except *
+    cpdef void discard(self, float32_t key) except *
+    
+
+cdef struct float32toint32_key_val_pair:
+    float32_t key
+    int32_t val
+
+
+cdef class Float32toInt32MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Float32toInt32Map  parent
+
+    cdef bint has_next(self) except *
+    cdef float32toint32_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Float32toInt32MapView:
+    cdef Float32toInt32Map  parent
+    cdef int       view_type
+
+    cdef Float32toInt32MapIterator get_iter(self)
+
+
+cpdef Float32toInt32Map Float32toInt32Map_from_buffers(float32_t[:] keys, int32_t[:] vals, double size_hint=*)
+
+cpdef size_t Float32toInt32Map_to(Float32toInt32Map map, float32_t[:] keys, int32_t[:] vals, bint stop_at_unknown=*, int32_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_float32toint32map(Float32toInt32Map a, Float32toInt32Map b) except *
+cpdef Float32toInt32Map copy_float32toint32map(Float32toInt32Map s)
+cpdef bint are_equal_float32toint32map(Float32toInt32Map a, Float32toInt32Map b) except *
+cpdef void update_float32toint32map(Float32toInt32Map a, Float32toInt32Map b) except *
+
+cdef extern from *:
+
+    ctypedef struct kh_float32tofloat32map_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        float32_t *keys
+        float32_t *vals  
+
+    kh_float32tofloat32map_t* kh_init_float32tofloat32map() nogil
+    void kh_destroy_float32tofloat32map(kh_float32tofloat32map_t*) nogil
+    void kh_clear_float32tofloat32map(kh_float32tofloat32map_t*) nogil
+    khint_t kh_get_float32tofloat32map(kh_float32tofloat32map_t*, float32_t) nogil
+    void kh_resize_float32tofloat32map(kh_float32tofloat32map_t*, khint_t) nogil
+    khint_t kh_put_float32tofloat32map(kh_float32tofloat32map_t*, float32_t, int* result) nogil
+    void kh_del_float32tofloat32map(kh_float32tofloat32map_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_float32tofloat32map "kh_exist" (kh_float32tofloat32map_t*, khint_t) nogil
+
+cdef class Float32toFloat32Map:
+    cdef kh_float32tofloat32map_t *table
+    cdef bint for_int
+
+    cdef bint contains(self, float32_t key) except *
+    cdef Float32toFloat32MapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, float32_t key, float32_t value) except *
+    cpdef float32_t cget(self, float32_t key) except *
+    cpdef void discard(self, float32_t key) except *
+    
+
+cdef struct float32tofloat32_key_val_pair:
+    float32_t key
+    float32_t val
+
+
+cdef class Float32toFloat32MapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef Float32toFloat32Map  parent
+
+    cdef bint has_next(self) except *
+    cdef float32tofloat32_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+
+cdef class Float32toFloat32MapView:
+    cdef Float32toFloat32Map  parent
+    cdef int       view_type
+
+    cdef Float32toFloat32MapIterator get_iter(self)
+
+
+cpdef Float32toFloat32Map Float32toFloat32Map_from_buffers(float32_t[:] keys, float32_t[:] vals, double size_hint=*)
+
+cpdef size_t Float32toFloat32Map_to(Float32toFloat32Map map, float32_t[:] keys, float32_t[:] vals, bint stop_at_unknown=*, float32_t default_value=*) except *
+
+
+
+# other help functions:
+cpdef void swap_float32tofloat32map(Float32toFloat32Map a, Float32toFloat32Map b) except *
+cpdef Float32toFloat32Map copy_float32tofloat32map(Float32toFloat32Map s)
+cpdef bint are_equal_float32tofloat32map(Float32toFloat32Map a, Float32toFloat32Map b) except *
+cpdef void update_float32tofloat32map(Float32toFloat32Map a, Float32toFloat32Map b) except *
+
+
+##TODO: unify with others
+
+
+cdef extern from *:
+
+    ctypedef struct kh_pyobjectmap_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        pyobject_t *keys
+        pyobject_t *vals  
+
+    kh_pyobjectmap_t* kh_init_pyobjectmap() nogil
+    void kh_destroy_pyobjectmap(kh_pyobjectmap_t*) nogil
+    void kh_clear_pyobjectmap(kh_pyobjectmap_t*) nogil
+    khint_t kh_get_pyobjectmap(kh_pyobjectmap_t*, pyobject_t) nogil
+    void kh_resize_pyobjectmap(kh_pyobjectmap_t*, khint_t) nogil
+    khint_t kh_put_pyobjectmap(kh_pyobjectmap_t*, pyobject_t, int* result) nogil
+    void kh_del_pyobjectmap(kh_pyobjectmap_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_pyobjectmap "kh_exist" (kh_pyobjectmap_t*, khint_t) nogil
+
+
+cdef class PyObjectMap:
+    cdef kh_pyobjectmap_t *table
+
+    cdef bint contains(self, pyobject_t key) except *
+    cdef PyObjectMapIterator get_iter(self, int view_type)
+    cdef khint_t size(self) 
+    cpdef void cput(self, object key, object value) except *
+    cpdef object cget(self, object key)
+    cpdef void discard(self, object key) except *
+    
+
+cdef struct pyobject_key_val_pair:
+    pyobject_t key
+    pyobject_t val
+
+
+cdef class PyObjectMapIterator:
+    cdef khint_t   it
+    cdef int       view_type
+    cdef PyObjectMap  parent
+
+    cdef bint has_next(self) except *
+    cdef pyobject_key_val_pair next(self) except *
+    cdef void __move(self) except *
+
+cdef class PyObjectMapView:
+    cdef PyObjectMap  parent
+    cdef int       view_type
+
+    cdef PyObjectMapIterator get_iter(self)
+
+cpdef PyObjectMap PyObjectMap_from_buffers(object[:] keys, object[:] vals, double size_hint=*)
+
+cpdef size_t PyObjectMap_to(PyObjectMap map, object[:] keys, object[:] vals, bint stop_at_unknown=*, object default_value=*) except *
+
+# other help functions:
+cpdef void swap_pyobjectmap(PyObjectMap a, PyObjectMap b) except *
+cpdef PyObjectMap copy_pyobjectmap(PyObjectMap s)
+cpdef bint are_equal_pyobjectmap(PyObjectMap a, PyObjectMap b) except *
+cpdef void update_pyobjectmap(PyObjectMap a, PyObjectMap b) except *
+
+
+
+
+

--- a/pyrosm/vendor/cykhash/maps/map_impl.pxi
+++ b/pyrosm/vendor/cykhash/maps/map_impl.pxi
@@ -1,0 +1,2674 @@
+"""
+Template for maps
+
+WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
+"""
+
+
+from cpython.ref cimport Py_INCREF,Py_DECREF
+
+
+
+
+
+cdef class Int64toInt64Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Int64toInt64Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_int64toint64map()
+        if number_of_elements_hint is not None:
+            kh_resize_int64toint64map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef int64_t key
+        cdef int64_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_int64toint64map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, int64_t key) except *:
+        cdef khint_t k
+        k = kh_get_int64toint64map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_int64toint64map(self.table, k)
+
+    cdef bint contains(self, int64_t key) except *:
+        cdef khint_t k
+        k = kh_get_int64toint64map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, int64_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, int64_t key, int64_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_int64toint64map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef int64_t cget(self, int64_t key) except *:
+        k = kh_get_int64toint64map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Int64toInt64MapIterator get_iter(self, int view_type):
+        return Int64toInt64MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Int64toInt64Map tmp=Int64toInt64Map()
+        swap_int64toint64map(self, tmp)
+
+    def copy(self):
+        return copy_int64toint64map(self)
+
+    def update(self, other):
+        if isinstance(other, Int64toInt64Map):
+            update_int64toint64map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Int64toInt64MapView(self, 0)
+
+    def values(self):
+        return Int64toInt64MapView(self, 1)
+
+    def items(self):
+        return Int64toInt64MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_int64toint64map(self,other)
+
+
+### Iterator:
+cdef class Int64toInt64MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_int64toint64map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef int64toint64_key_val_pair next(self) except *:
+        cdef int64toint64_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Int64toInt64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef int64toint64_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Int64toInt64MapView:
+    cdef Int64toInt64MapIterator get_iter(self):
+        return Int64toInt64MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Int64toInt64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Int64toInt64Map Int64toInt64Map_from_buffers(int64_t[:] keys, int64_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Int64toInt64Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef int64_t DEFAULT_VALUE_int64toint64 = 0
+cpdef size_t Int64toInt64Map_to(Int64toInt64Map map, int64_t[:] keys, int64_t[:] vals, bint stop_at_unknown=True, int64_t default_value=DEFAULT_VALUE_int64toint64) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_int64toint64map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_int64toint64map(Int64toInt64Map a, Int64toInt64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_int64toint64map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Int64toInt64Map copy_int64toint64map(Int64toInt64Map s):
+    if s is None:
+        return None
+    cdef Int64toInt64Map result = Int64toInt64Map(number_of_elements_hint=s.size())
+    cdef Int64toInt64MapIterator it=s.get_iter(2)
+    cdef int64toint64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_int64toint64map(Int64toInt64Map a, Int64toInt64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Int64toInt64MapIterator it=a.get_iter(2)
+    cdef int64toint64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_int64toint64map(Int64toInt64Map a, Int64toInt64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Int64toInt64MapIterator it=b.get_iter(2)
+    cdef int64toint64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class Int64toFloat64Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Int64toFloat64Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_int64tofloat64map()
+        if number_of_elements_hint is not None:
+            kh_resize_int64tofloat64map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef int64_t key
+        cdef float64_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_int64tofloat64map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, int64_t key) except *:
+        cdef khint_t k
+        k = kh_get_int64tofloat64map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_int64tofloat64map(self.table, k)
+
+    cdef bint contains(self, int64_t key) except *:
+        cdef khint_t k
+        k = kh_get_int64tofloat64map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, int64_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, int64_t key, float64_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_int64tofloat64map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef float64_t cget(self, int64_t key) except *:
+        k = kh_get_int64tofloat64map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Int64toFloat64MapIterator get_iter(self, int view_type):
+        return Int64toFloat64MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Int64toFloat64Map tmp=Int64toFloat64Map()
+        swap_int64tofloat64map(self, tmp)
+
+    def copy(self):
+        return copy_int64tofloat64map(self)
+
+    def update(self, other):
+        if isinstance(other, Int64toFloat64Map):
+            update_int64tofloat64map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Int64toFloat64MapView(self, 0)
+
+    def values(self):
+        return Int64toFloat64MapView(self, 1)
+
+    def items(self):
+        return Int64toFloat64MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_int64tofloat64map(self,other)
+
+
+### Iterator:
+cdef class Int64toFloat64MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_int64tofloat64map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef int64tofloat64_key_val_pair next(self) except *:
+        cdef int64tofloat64_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Int64toFloat64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef int64tofloat64_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Int64toFloat64MapView:
+    cdef Int64toFloat64MapIterator get_iter(self):
+        return Int64toFloat64MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Int64toFloat64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Int64toFloat64Map Int64toFloat64Map_from_buffers(int64_t[:] keys, float64_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Int64toFloat64Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef float64_t DEFAULT_VALUE_int64tofloat64 = float("nan")
+cpdef size_t Int64toFloat64Map_to(Int64toFloat64Map map, int64_t[:] keys, float64_t[:] vals, bint stop_at_unknown=True, float64_t default_value=DEFAULT_VALUE_int64tofloat64) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_int64tofloat64map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_int64tofloat64map(Int64toFloat64Map a, Int64toFloat64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_int64tofloat64map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Int64toFloat64Map copy_int64tofloat64map(Int64toFloat64Map s):
+    if s is None:
+        return None
+    cdef Int64toFloat64Map result = Int64toFloat64Map(number_of_elements_hint=s.size())
+    cdef Int64toFloat64MapIterator it=s.get_iter(2)
+    cdef int64tofloat64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_int64tofloat64map(Int64toFloat64Map a, Int64toFloat64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Int64toFloat64MapIterator it=a.get_iter(2)
+    cdef int64tofloat64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_int64tofloat64map(Int64toFloat64Map a, Int64toFloat64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Int64toFloat64MapIterator it=b.get_iter(2)
+    cdef int64tofloat64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class Float64toInt64Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Float64toInt64Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_float64toint64map()
+        if number_of_elements_hint is not None:
+            kh_resize_float64toint64map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef float64_t key
+        cdef int64_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_float64toint64map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, float64_t key) except *:
+        cdef khint_t k
+        k = kh_get_float64toint64map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_float64toint64map(self.table, k)
+
+    cdef bint contains(self, float64_t key) except *:
+        cdef khint_t k
+        k = kh_get_float64toint64map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, float64_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, float64_t key, int64_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_float64toint64map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef int64_t cget(self, float64_t key) except *:
+        k = kh_get_float64toint64map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Float64toInt64MapIterator get_iter(self, int view_type):
+        return Float64toInt64MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Float64toInt64Map tmp=Float64toInt64Map()
+        swap_float64toint64map(self, tmp)
+
+    def copy(self):
+        return copy_float64toint64map(self)
+
+    def update(self, other):
+        if isinstance(other, Float64toInt64Map):
+            update_float64toint64map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Float64toInt64MapView(self, 0)
+
+    def values(self):
+        return Float64toInt64MapView(self, 1)
+
+    def items(self):
+        return Float64toInt64MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_float64toint64map(self,other)
+
+
+### Iterator:
+cdef class Float64toInt64MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_float64toint64map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef float64toint64_key_val_pair next(self) except *:
+        cdef float64toint64_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Float64toInt64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef float64toint64_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Float64toInt64MapView:
+    cdef Float64toInt64MapIterator get_iter(self):
+        return Float64toInt64MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Float64toInt64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Float64toInt64Map Float64toInt64Map_from_buffers(float64_t[:] keys, int64_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Float64toInt64Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef int64_t DEFAULT_VALUE_float64toint64 = 0
+cpdef size_t Float64toInt64Map_to(Float64toInt64Map map, float64_t[:] keys, int64_t[:] vals, bint stop_at_unknown=True, int64_t default_value=DEFAULT_VALUE_float64toint64) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_float64toint64map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_float64toint64map(Float64toInt64Map a, Float64toInt64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_float64toint64map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Float64toInt64Map copy_float64toint64map(Float64toInt64Map s):
+    if s is None:
+        return None
+    cdef Float64toInt64Map result = Float64toInt64Map(number_of_elements_hint=s.size())
+    cdef Float64toInt64MapIterator it=s.get_iter(2)
+    cdef float64toint64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_float64toint64map(Float64toInt64Map a, Float64toInt64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Float64toInt64MapIterator it=a.get_iter(2)
+    cdef float64toint64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_float64toint64map(Float64toInt64Map a, Float64toInt64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Float64toInt64MapIterator it=b.get_iter(2)
+    cdef float64toint64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class Float64toFloat64Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Float64toFloat64Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_float64tofloat64map()
+        if number_of_elements_hint is not None:
+            kh_resize_float64tofloat64map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef float64_t key
+        cdef float64_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_float64tofloat64map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, float64_t key) except *:
+        cdef khint_t k
+        k = kh_get_float64tofloat64map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_float64tofloat64map(self.table, k)
+
+    cdef bint contains(self, float64_t key) except *:
+        cdef khint_t k
+        k = kh_get_float64tofloat64map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, float64_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, float64_t key, float64_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_float64tofloat64map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef float64_t cget(self, float64_t key) except *:
+        k = kh_get_float64tofloat64map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Float64toFloat64MapIterator get_iter(self, int view_type):
+        return Float64toFloat64MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Float64toFloat64Map tmp=Float64toFloat64Map()
+        swap_float64tofloat64map(self, tmp)
+
+    def copy(self):
+        return copy_float64tofloat64map(self)
+
+    def update(self, other):
+        if isinstance(other, Float64toFloat64Map):
+            update_float64tofloat64map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Float64toFloat64MapView(self, 0)
+
+    def values(self):
+        return Float64toFloat64MapView(self, 1)
+
+    def items(self):
+        return Float64toFloat64MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_float64tofloat64map(self,other)
+
+
+### Iterator:
+cdef class Float64toFloat64MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_float64tofloat64map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef float64tofloat64_key_val_pair next(self) except *:
+        cdef float64tofloat64_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Float64toFloat64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef float64tofloat64_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Float64toFloat64MapView:
+    cdef Float64toFloat64MapIterator get_iter(self):
+        return Float64toFloat64MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Float64toFloat64Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Float64toFloat64Map Float64toFloat64Map_from_buffers(float64_t[:] keys, float64_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Float64toFloat64Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef float64_t DEFAULT_VALUE_float64tofloat64 = float("nan")
+cpdef size_t Float64toFloat64Map_to(Float64toFloat64Map map, float64_t[:] keys, float64_t[:] vals, bint stop_at_unknown=True, float64_t default_value=DEFAULT_VALUE_float64tofloat64) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_float64tofloat64map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_float64tofloat64map(Float64toFloat64Map a, Float64toFloat64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_float64tofloat64map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Float64toFloat64Map copy_float64tofloat64map(Float64toFloat64Map s):
+    if s is None:
+        return None
+    cdef Float64toFloat64Map result = Float64toFloat64Map(number_of_elements_hint=s.size())
+    cdef Float64toFloat64MapIterator it=s.get_iter(2)
+    cdef float64tofloat64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_float64tofloat64map(Float64toFloat64Map a, Float64toFloat64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Float64toFloat64MapIterator it=a.get_iter(2)
+    cdef float64tofloat64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_float64tofloat64map(Float64toFloat64Map a, Float64toFloat64Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Float64toFloat64MapIterator it=b.get_iter(2)
+    cdef float64tofloat64_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class Int32toInt32Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Int32toInt32Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_int32toint32map()
+        if number_of_elements_hint is not None:
+            kh_resize_int32toint32map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef int32_t key
+        cdef int32_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_int32toint32map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, int32_t key) except *:
+        cdef khint_t k
+        k = kh_get_int32toint32map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_int32toint32map(self.table, k)
+
+    cdef bint contains(self, int32_t key) except *:
+        cdef khint_t k
+        k = kh_get_int32toint32map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, int32_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, int32_t key, int32_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_int32toint32map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef int32_t cget(self, int32_t key) except *:
+        k = kh_get_int32toint32map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Int32toInt32MapIterator get_iter(self, int view_type):
+        return Int32toInt32MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Int32toInt32Map tmp=Int32toInt32Map()
+        swap_int32toint32map(self, tmp)
+
+    def copy(self):
+        return copy_int32toint32map(self)
+
+    def update(self, other):
+        if isinstance(other, Int32toInt32Map):
+            update_int32toint32map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Int32toInt32MapView(self, 0)
+
+    def values(self):
+        return Int32toInt32MapView(self, 1)
+
+    def items(self):
+        return Int32toInt32MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_int32toint32map(self,other)
+
+
+### Iterator:
+cdef class Int32toInt32MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_int32toint32map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef int32toint32_key_val_pair next(self) except *:
+        cdef int32toint32_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Int32toInt32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef int32toint32_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Int32toInt32MapView:
+    cdef Int32toInt32MapIterator get_iter(self):
+        return Int32toInt32MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Int32toInt32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Int32toInt32Map Int32toInt32Map_from_buffers(int32_t[:] keys, int32_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Int32toInt32Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef int32_t DEFAULT_VALUE_int32toint32 = 0
+cpdef size_t Int32toInt32Map_to(Int32toInt32Map map, int32_t[:] keys, int32_t[:] vals, bint stop_at_unknown=True, int32_t default_value=DEFAULT_VALUE_int32toint32) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_int32toint32map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_int32toint32map(Int32toInt32Map a, Int32toInt32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_int32toint32map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Int32toInt32Map copy_int32toint32map(Int32toInt32Map s):
+    if s is None:
+        return None
+    cdef Int32toInt32Map result = Int32toInt32Map(number_of_elements_hint=s.size())
+    cdef Int32toInt32MapIterator it=s.get_iter(2)
+    cdef int32toint32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_int32toint32map(Int32toInt32Map a, Int32toInt32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Int32toInt32MapIterator it=a.get_iter(2)
+    cdef int32toint32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_int32toint32map(Int32toInt32Map a, Int32toInt32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Int32toInt32MapIterator it=b.get_iter(2)
+    cdef int32toint32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class Int32toFloat32Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Int32toFloat32Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_int32tofloat32map()
+        if number_of_elements_hint is not None:
+            kh_resize_int32tofloat32map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef int32_t key
+        cdef float32_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_int32tofloat32map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, int32_t key) except *:
+        cdef khint_t k
+        k = kh_get_int32tofloat32map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_int32tofloat32map(self.table, k)
+
+    cdef bint contains(self, int32_t key) except *:
+        cdef khint_t k
+        k = kh_get_int32tofloat32map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, int32_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, int32_t key, float32_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_int32tofloat32map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef float32_t cget(self, int32_t key) except *:
+        k = kh_get_int32tofloat32map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Int32toFloat32MapIterator get_iter(self, int view_type):
+        return Int32toFloat32MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Int32toFloat32Map tmp=Int32toFloat32Map()
+        swap_int32tofloat32map(self, tmp)
+
+    def copy(self):
+        return copy_int32tofloat32map(self)
+
+    def update(self, other):
+        if isinstance(other, Int32toFloat32Map):
+            update_int32tofloat32map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Int32toFloat32MapView(self, 0)
+
+    def values(self):
+        return Int32toFloat32MapView(self, 1)
+
+    def items(self):
+        return Int32toFloat32MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_int32tofloat32map(self,other)
+
+
+### Iterator:
+cdef class Int32toFloat32MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_int32tofloat32map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef int32tofloat32_key_val_pair next(self) except *:
+        cdef int32tofloat32_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Int32toFloat32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef int32tofloat32_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Int32toFloat32MapView:
+    cdef Int32toFloat32MapIterator get_iter(self):
+        return Int32toFloat32MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Int32toFloat32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Int32toFloat32Map Int32toFloat32Map_from_buffers(int32_t[:] keys, float32_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Int32toFloat32Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef float32_t DEFAULT_VALUE_int32tofloat32 = float("nan")
+cpdef size_t Int32toFloat32Map_to(Int32toFloat32Map map, int32_t[:] keys, float32_t[:] vals, bint stop_at_unknown=True, float32_t default_value=DEFAULT_VALUE_int32tofloat32) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_int32tofloat32map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_int32tofloat32map(Int32toFloat32Map a, Int32toFloat32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_int32tofloat32map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Int32toFloat32Map copy_int32tofloat32map(Int32toFloat32Map s):
+    if s is None:
+        return None
+    cdef Int32toFloat32Map result = Int32toFloat32Map(number_of_elements_hint=s.size())
+    cdef Int32toFloat32MapIterator it=s.get_iter(2)
+    cdef int32tofloat32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_int32tofloat32map(Int32toFloat32Map a, Int32toFloat32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Int32toFloat32MapIterator it=a.get_iter(2)
+    cdef int32tofloat32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_int32tofloat32map(Int32toFloat32Map a, Int32toFloat32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Int32toFloat32MapIterator it=b.get_iter(2)
+    cdef int32tofloat32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class Float32toInt32Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Float32toInt32Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_float32toint32map()
+        if number_of_elements_hint is not None:
+            kh_resize_float32toint32map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef float32_t key
+        cdef int32_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_float32toint32map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, float32_t key) except *:
+        cdef khint_t k
+        k = kh_get_float32toint32map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_float32toint32map(self.table, k)
+
+    cdef bint contains(self, float32_t key) except *:
+        cdef khint_t k
+        k = kh_get_float32toint32map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, float32_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, float32_t key, int32_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_float32toint32map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef int32_t cget(self, float32_t key) except *:
+        k = kh_get_float32toint32map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Float32toInt32MapIterator get_iter(self, int view_type):
+        return Float32toInt32MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Float32toInt32Map tmp=Float32toInt32Map()
+        swap_float32toint32map(self, tmp)
+
+    def copy(self):
+        return copy_float32toint32map(self)
+
+    def update(self, other):
+        if isinstance(other, Float32toInt32Map):
+            update_float32toint32map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Float32toInt32MapView(self, 0)
+
+    def values(self):
+        return Float32toInt32MapView(self, 1)
+
+    def items(self):
+        return Float32toInt32MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_float32toint32map(self,other)
+
+
+### Iterator:
+cdef class Float32toInt32MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_float32toint32map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef float32toint32_key_val_pair next(self) except *:
+        cdef float32toint32_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Float32toInt32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef float32toint32_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Float32toInt32MapView:
+    cdef Float32toInt32MapIterator get_iter(self):
+        return Float32toInt32MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Float32toInt32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Float32toInt32Map Float32toInt32Map_from_buffers(float32_t[:] keys, int32_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Float32toInt32Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef int32_t DEFAULT_VALUE_float32toint32 = 0
+cpdef size_t Float32toInt32Map_to(Float32toInt32Map map, float32_t[:] keys, int32_t[:] vals, bint stop_at_unknown=True, int32_t default_value=DEFAULT_VALUE_float32toint32) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_float32toint32map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_float32toint32map(Float32toInt32Map a, Float32toInt32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_float32toint32map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Float32toInt32Map copy_float32toint32map(Float32toInt32Map s):
+    if s is None:
+        return None
+    cdef Float32toInt32Map result = Float32toInt32Map(number_of_elements_hint=s.size())
+    cdef Float32toInt32MapIterator it=s.get_iter(2)
+    cdef float32toint32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_float32toint32map(Float32toInt32Map a, Float32toInt32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Float32toInt32MapIterator it=a.get_iter(2)
+    cdef float32toint32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_float32toint32map(Float32toInt32Map a, Float32toInt32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Float32toInt32MapIterator it=b.get_iter(2)
+    cdef float32toint32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class Float32toFloat32Map:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return Float32toFloat32Map(((key, value) for key in iterable))
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_float32tofloat32map()
+        if number_of_elements_hint is not None:
+            kh_resize_float32tofloat32map(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef float32_t key
+        cdef float32_t val
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+    def __dealloc__(self):
+        if self.table is not NULL:
+            kh_destroy_float32tofloat32map(self.table)
+            self.table = NULL
+
+    cpdef void discard(self, float32_t key) except *:
+        cdef khint_t k
+        k = kh_get_float32tofloat32map(self.table, key)
+        if k != self.table.n_buckets:
+            kh_del_float32tofloat32map(self.table, k)
+
+    cdef bint contains(self, float32_t key) except *:
+        cdef khint_t k
+        k = kh_get_float32tofloat32map(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, float32_t key):
+        return self.contains(key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, float32_t key, float32_t val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+
+        k = kh_put_float32tofloat32map(self.table, key, &ret)
+        self.table.keys[k] = key
+        self.table.vals[k] = val
+
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef float32_t cget(self, float32_t key) except *:
+        k = kh_get_float32tofloat32map(self.table, key)
+        if k != self.table.n_buckets:
+            return self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+        
+
+
+    cdef Float32toFloat32MapIterator get_iter(self, int view_type):
+        return Float32toFloat32MapIterator(self, view_type)
+
+    def clear(self):
+        cdef Float32toFloat32Map tmp=Float32toFloat32Map()
+        swap_float32tofloat32map(self, tmp)
+
+    def copy(self):
+        return copy_float32tofloat32map(self)
+
+    def update(self, other):
+        if isinstance(other, Float32toFloat32Map):
+            update_float32tofloat32map(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return Float32toFloat32MapView(self, 0)
+
+    def values(self):
+        return Float32toFloat32MapView(self, 1)
+
+    def items(self):
+        return Float32toFloat32MapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_float32tofloat32map(self,other)
+
+
+### Iterator:
+cdef class Float32toFloat32MapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_float32tofloat32map(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef float32tofloat32_key_val_pair next(self) except *:
+        cdef float32tofloat32_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, Float32toFloat32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef float32tofloat32_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return pair.key
+            if self.view_type == 1:           # vals
+                return pair.val
+            else:                        # items
+                return (pair.key, pair.val)
+        else:
+            raise StopIteration
+
+
+cdef class Float32toFloat32MapView:
+    cdef Float32toFloat32MapIterator get_iter(self):
+        return Float32toFloat32MapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, Float32toFloat32Map parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef Float32toFloat32Map Float32toFloat32Map_from_buffers(float32_t[:] keys, float32_t[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Float32toFloat32Map(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef float32_t DEFAULT_VALUE_float32tofloat32 = float("nan")
+cpdef size_t Float32toFloat32Map_to(Float32toFloat32Map map, float32_t[:] keys, float32_t[:] vals, bint stop_at_unknown=True, float32_t default_value=DEFAULT_VALUE_float32tofloat32) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_float32tofloat32map(map.table, keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_float32tofloat32map(Float32toFloat32Map a, Float32toFloat32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_float32tofloat32map_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef Float32toFloat32Map copy_float32tofloat32map(Float32toFloat32Map s):
+    if s is None:
+        return None
+    cdef Float32toFloat32Map result = Float32toFloat32Map(number_of_elements_hint=s.size())
+    cdef Float32toFloat32MapIterator it=s.get_iter(2)
+    cdef float32tofloat32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(p.key, p.val)
+    return result
+
+
+cpdef bint are_equal_float32tofloat32map(Float32toFloat32Map a, Float32toFloat32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef Float32toFloat32MapIterator it=a.get_iter(2)
+    cdef float32tofloat32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_float32tofloat32map(Float32toFloat32Map a, Float32toFloat32Map b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Float32toFloat32MapIterator it=b.get_iter(2)
+    cdef float32tofloat32_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(p.key, p.val)
+
+
+cdef class PyObjectMap:
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        return PyObjectMap((key, value) for key in iterable)
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_pyobjectmap()
+        if number_of_elements_hint is not None:
+            kh_resize_pyobjectmap(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        if iterable is not None:
+            for key, val in iterable:
+                    self.cput(key, val)
+
+ 
+    cpdef void discard(self, object key) except *:
+        cdef khint_t k
+        k = kh_get_pyobjectmap(self.table, <pyobject_t>key)
+        if k != self.table.n_buckets:
+            Py_DECREF(<object>(self.table.keys[k]))
+            Py_DECREF(<object>(self.table.vals[k]))
+            kh_del_pyobjectmap(self.table, k)
+
+    def __dealloc__(self):
+        cdef Py_ssize_t i
+        if self.table is not NULL:
+            for i in range(self.table.size):
+                if kh_exist_pyobjectmap(self.table, i):
+                    Py_DECREF(<object>(self.table.keys[i]))
+                    Py_DECREF(<object>(self.table.vals[i]))
+            kh_destroy_pyobjectmap(self.table)
+            self.table = NULL
+
+    cdef bint contains(self, pyobject_t key) except *:
+        cdef khint_t k
+        k = kh_get_pyobjectmap(self.table, key)
+        return k != self.table.n_buckets
+
+    def __contains__(self, object key):
+        return self.contains(<pyobject_t>key)
+
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+
+    cpdef void cput(self, object key, object val) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+        k = kh_put_pyobjectmap(self.table, <pyobject_t>key, &ret)
+        if not ret:
+            Py_DECREF(<object>(self.table.vals[k]))
+        else:
+            Py_INCREF(key)
+        Py_INCREF(val)
+        self.table.vals[k] = <pyobject_t> val
+ 
+    def __setitem__(self, key, val):
+        self.cput(key, val)
+
+    cpdef object cget(self, object key):
+        k = kh_get_pyobjectmap(self.table, <pyobject_t>key)
+        if k != self.table.n_buckets:
+            return <object>self.table.vals[k]
+        else:
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        return self.cget(key)
+
+    cdef PyObjectMapIterator get_iter(self, int view_type):
+        return PyObjectMapIterator(self, view_type)
+
+    def clear(self):
+        cdef PyObjectMap tmp=PyObjectMap()
+        swap_pyobjectmap(self, tmp)
+
+    def copy(self):
+        return copy_pyobjectmap(self)
+
+    def update(self, other):
+        if isinstance(other, PyObjectMap):
+            update_pyobjectmap(self, other)
+            return
+        for key,val in other:
+            self[key]=val
+
+    def setdefault(self, key, default):
+        try:
+            return self[key]
+        except KeyError:
+            self[key]=default
+            return default
+
+    def get(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("get() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("get() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("get() takes no keyword arguments")
+        key = args[0]
+        try:
+            return self[key]
+        except KeyError:
+            if len(args)==1:
+                return None
+            return args[1]
+
+    def pop(self, *args, **kwargs):
+        if len(args)==0:
+            raise TypeError("pop() expected at least 1 arguments, got 0")
+        if len(args)>2:
+            raise TypeError("pop() expected at most 2 arguments, got {0}".format(len(args)))
+        if kwargs:
+            raise TypeError("pop() takes no keyword arguments")
+        key = args[0]
+        try:
+            val = self[key]
+        except KeyError as e:
+            if len(args)==1:
+                raise e from None
+            return args[1]
+        del self[key]
+        return val
+
+    def popitem(self):
+        if self.size()== 0:
+            raise KeyError("popitem(): dictionary is empty")
+        key = next(iter(self))
+        val = self.pop(key)
+        return (key, val)
+
+    def keys(self):
+        return PyObjectMapView(self, 0)
+
+    def values(self):
+        return PyObjectMapView(self, 1)
+
+    def items(self):
+        return PyObjectMapView(self, 2)
+
+    def __iter__(self):
+        return iter(self.keys())
+
+    def __delitem__(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def __eq__(self, other):
+        return are_equal_pyobjectmap(self,other)
+
+
+### Iterator:
+cdef class PyObjectMapIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_pyobjectmap(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()       
+    cdef pyobject_key_val_pair next(self) except *:
+        cdef pyobject_key_val_pair result 
+        result.key = self.parent.table.keys[self.it]
+        result.val = self.parent.table.vals[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+    def __cinit__(self, PyObjectMap parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        cdef pyobject_key_val_pair pair
+        if self.has_next():
+            pair=self.next()
+
+            if self.view_type == 0:           # keys
+                return <object>pair.key
+            if self.view_type == 1:           # vals
+                return <object>pair.val
+            else:                            # items
+                return (<object>pair.key, <object>pair.val)
+
+        else:
+            raise StopIteration
+
+
+cdef class PyObjectMapView:
+    cdef PyObjectMapIterator get_iter(self):
+        return PyObjectMapIterator(self.parent, self.view_type)  
+
+    def __cinit__(self, PyObjectMap parent, view_type):
+        self.parent = parent
+        self.view_type = view_type
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def __len__(self):
+        return self.parent.size()
+
+    def __contains__(self, x):
+        for y in self:
+            if x==y:
+                return True
+        return False
+
+##########################      Utils:
+cpdef PyObjectMap PyObjectMap_from_buffers(object[:] keys, object[:] vals, double size_hint=0.0):
+    cdef Py_ssize_t n = len(keys)
+    cdef Py_ssize_t b = len(vals)
+    if b < n:
+        n = b
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=PyObjectMap(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.cput(keys[i], vals[i])
+    return res
+
+cdef object DEFAULT_VALUE_pyobject = None
+cpdef size_t PyObjectMap_to(PyObjectMap map, object[:] keys, object[:] vals, bint stop_at_unknown=True, object default_value=None) except *:
+    """returns number of found keys"""
+    if map is None:
+        raise TypeError("'NoneType' is not a map")
+    cdef size_t n = len(keys)
+    if n != len(vals):
+        raise ValueError("Different lengths of keys and vals arrays")
+    cdef size_t i
+    cdef khint_t k
+    cdef size_t res = 0
+    for i in range(n):
+        k = kh_get_pyobjectmap(map.table,<pyobject_t> keys[i])
+        if k != map.table.n_buckets:
+            vals[i] = <object>map.table.vals[k]
+            res += 1
+        else:
+            vals[i] = default_value
+            if stop_at_unknown:
+                return res
+    return res
+
+cpdef void swap_pyobjectmap(PyObjectMap a, PyObjectMap b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_pyobjectmap_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+
+cpdef PyObjectMap copy_pyobjectmap(PyObjectMap s):
+    if s is None:
+        return None
+    cdef PyObjectMap result = PyObjectMap(number_of_elements_hint=s.size())
+    cdef PyObjectMapIterator it=s.get_iter(2)
+    cdef pyobject_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        result.cput(<object>p.key, <object>p.val)
+    return result
+
+
+cpdef bint are_equal_pyobjectmap(PyObjectMap a, PyObjectMap b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    if a.size()!=b.size():
+        return False
+    cdef PyObjectMapIterator it=a.get_iter(2)
+    cdef pyobject_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        if not b.contains(p.key):
+            return False
+    return True
+
+
+cpdef void update_pyobjectmap(PyObjectMap a, PyObjectMap b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef PyObjectMapIterator it=b.get_iter(2)
+    cdef pyobject_key_val_pair p
+    while it.has_next():
+        p = it.next()
+        a.cput(<object>p.key, <object>p.val)

--- a/pyrosm/vendor/cykhash/maps/map_init.pxi
+++ b/pyrosm/vendor/cykhash/maps/map_init.pxi
@@ -1,0 +1,84 @@
+"""
+Template for maps
+
+WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
+"""
+
+
+
+###################  INTS:
+
+cdef extern from *:
+    """
+    // preprocessor creates needed struct-type and all function definitions
+    #define CYKHASH_MAP_INIT_INT64(name, khval_t)		\
+        KHASH_INIT(name, int64_t, khval_t, 1, cykh_float64_hash_func, cykh_int64_hash_equal)
+  
+    CYKHASH_MAP_INIT_INT64(int64toint64map, int64_t)
+    CYKHASH_MAP_INIT_INT64(int64tofloat64map, float64_t)
+    """
+    pass
+
+cdef extern from *:
+    """
+    // preprocessor creates needed struct-type and all function definitions
+    #define CYKHASH_MAP_INIT_INT32(name, khval_t)		\
+        KHASH_INIT(name, int32_t, khval_t, 1, cykh_float32_hash_func, cykh_int32_hash_equal)
+  
+    CYKHASH_MAP_INIT_INT32(int32toint32map, int32_t)
+    CYKHASH_MAP_INIT_INT32(int32tofloat32map, float32_t)
+    """
+    pass
+
+
+
+
+################   FLOATS:
+
+
+# see float_utils.pxi for definitions
+
+cdef extern from *:
+    """
+    // preprocessor creates needed struct-type and all function definitions
+    #define CYKHASH_MAP_INIT_FLOAT64(name, khval_t)								\
+	    KHASH_INIT(name, khfloat64_t, khval_t, 1, cykh_float64_hash_func, cykh_float64_hash_equal)
+
+    CYKHASH_MAP_INIT_FLOAT64(float64toint64map, int64_t)
+    CYKHASH_MAP_INIT_FLOAT64(float64tofloat64map, float64_t)
+
+    """
+    pass
+
+
+# see float_utils.pxi for definitions
+
+cdef extern from *:
+    """
+    // preprocessor creates needed struct-type and all function definitions
+    #define CYKHASH_MAP_INIT_FLOAT32(name, khval_t)								\
+	    KHASH_INIT(name, khfloat32_t, khval_t, 1, cykh_float32_hash_func, cykh_float32_hash_equal)
+
+    CYKHASH_MAP_INIT_FLOAT32(float32toint32map, int32_t)
+    CYKHASH_MAP_INIT_FLOAT32(float32tofloat32map, float32_t)
+
+    """
+    pass
+
+
+
+################   OBJECT:
+cdef extern from *:
+    """
+    // preprocessor creates needed struct-type and all function definitions
+
+    // map with keys of type pyobject -> result pyobject
+    #define CYKHASH_MAP_INIT_PYOBJECT(name, khval_t)										\
+	    KHASH_INIT(name, khpyobject_t, khval_t, 1, cykh_pyobject_hash_func, cykh_pyobject_hash_equal)
+
+    //preprocessor creates needed struct-type and all function definitions 
+    //set with keys of type pyobject -> resulting typename: kh_pyobjectmap_t;
+    CYKHASH_MAP_INIT_PYOBJECT(pyobjectmap, pyobject_t)
+
+    """
+    pass

--- a/pyrosm/vendor/cykhash/memory.pxi
+++ b/pyrosm/vendor/cykhash/memory.pxi
@@ -1,0 +1,70 @@
+
+
+cdef extern from *:
+    """ 
+        #ifndef CYKHASH_MEMORY_PXI
+        #define CYKHASH_MEMORY_PXI
+        #include <Python.h>
+
+        // cykhash should report usage to tracemalloc
+        #if PY_VERSION_HEX >= 0x03060000
+        #include <pymem.h>
+        #if PY_VERSION_HEX < 0x03070000
+        #define PyTraceMalloc_Track _PyTraceMalloc_Track
+        #define PyTraceMalloc_Untrack _PyTraceMalloc_Untrack
+        #endif
+        #else
+        #define PyTraceMalloc_Track(...)
+        #define PyTraceMalloc_Untrack(...)
+        #endif
+
+
+        static const int CYKHASH_TRACE_DOMAIN = 414141;
+        CYKHASH_INLINE void *cykhash_traced_malloc(size_t size){
+            void * ptr = malloc(size);
+            if(ptr!=NULL){
+                PyTraceMalloc_Track(CYKHASH_TRACE_DOMAIN, (uintptr_t)ptr, size);
+            }
+            return ptr;
+        }
+
+        CYKHASH_INLINE void *cykhash_traced_calloc(size_t num, size_t size){
+            void * ptr = calloc(num, size);
+            if(ptr!=NULL){
+                PyTraceMalloc_Track(CYKHASH_TRACE_DOMAIN, (uintptr_t)ptr, num*size);
+            }
+            return ptr;
+        }
+
+        CYKHASH_INLINE void *cykhash_traced_realloc(void* old_ptr, size_t size){
+            void * ptr = realloc(old_ptr, size);
+            if(ptr!=NULL){
+                if(old_ptr != ptr){
+                    PyTraceMalloc_Untrack(CYKHASH_TRACE_DOMAIN, (uintptr_t)old_ptr);
+                }
+                PyTraceMalloc_Track(CYKHASH_TRACE_DOMAIN, (uintptr_t)ptr, size);
+            }
+            return ptr;
+        }
+
+        CYKHASH_INLINE void cykhash_traced_free(void* ptr){
+            if(ptr!=NULL){
+                PyTraceMalloc_Untrack(CYKHASH_TRACE_DOMAIN, (uintptr_t)ptr);
+            }
+            free(ptr);
+        }
+
+
+        #define CYKHASH_MALLOC cykhash_traced_malloc
+        #define CYKHASH_REALLOC cykhash_traced_realloc
+        #define CYKHASH_CALLOC cykhash_traced_calloc
+        #define CYKHASH_FREE cykhash_traced_free
+      
+        #endif
+    """
+    const int CYKHASH_TRACE_DOMAIN
+    void *cykhash_traced_malloc(size_t size)
+    void *cykhash_traced_calloc(size_t num, size_t size)
+    void *cykhash_traced_realloc(void* old_ptr, size_t size)
+    void cykhash_traced_free(void* ptr)
+

--- a/pyrosm/vendor/cykhash/murmurhash.pxi
+++ b/pyrosm/vendor/cykhash/murmurhash.pxi
@@ -1,0 +1,105 @@
+
+cdef extern from *:
+    """
+        #ifndef CYKHASH_MURMURHASH_PXI
+        #define CYKHASH_MURMURHASH_PXI
+            #include <stdint.h>
+            //
+            //specializations of https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp
+            //
+
+            const uint32_t SEED = 0xc70f6907UL;
+            // 'm' and 'r' are mixing constants generated offline.
+            // They're not really 'magic', they just happen to work well.
+            const uint32_t M_32 = 0x5bd1e995;
+            const int R_32 = 24;
+            CYKHASH_INLINE uint32_t murmur2_32to32(uint32_t k){
+                // Initialize the hash to a 'random' value
+                uint32_t h = SEED ^ 4;
+
+                //handle 4 bytes:
+                k *= M_32;
+                k ^= k >> R_32;
+                k *= M_32;
+
+                h *= M_32;
+                h ^= k;
+
+                // Do a few final mixes of the hash to ensure the "last few
+                // bytes" are well-incorporated.
+                // TODO: really needed, we have no "last few bytes"?
+                h ^= h >> 13;
+                h *= M_32;
+                h ^= h >> 15;
+                return h;
+            }
+
+
+            
+            #if INTPTR_MAX == INT64_MAX
+               // 64-bit
+                const uint64_t SEED_64 = 0xc70f6907b8107a18ULL;
+                const uint64_t M_64=     0xc6a4a7935bd1e995ULL;
+                const int R_64 = 47;
+                CYKHASH_INLINE uint32_t murmur2_64to32(uint64_t k){
+                      uint64_t h = SEED_64 ^ (8 * M_64);
+
+                      k *= M_64; 
+                      k ^= k >> R_64; 
+                      k *= M_64; 
+                        
+                      h ^= k;
+                      h *= M_64; 
+
+                      h ^= h >> R_64;
+                      h *= M_64;
+                      h ^= h >> R_64;
+
+                      // if hash h is good, we just can xor both halfs 
+                      // (or take any 32 bit out of h)
+                      return (uint32_t)((h>>32)^h);
+                }
+            #elif INTPTR_MAX == INT32_MAX
+                // 32-bit
+                // uint64_t mult is slow for 32 bit, so falling back to murmur2_32to32 algorithm
+                CYKHASH_INLINE uint32_t murmur2_32_32to32(uint32_t k1, uint32_t k2){
+                    // Initialize the hash to a 'random' value
+                    uint32_t h = SEED ^ 4;
+
+                    //handle first 4 bytes:
+                    k1 *= M_32;
+                    k1 ^= k1 >> R_32;
+                    k1 *= M_32;
+
+                    h *= M_32;
+                    h ^= k1;
+
+                    //handle second 4 bytes:
+                    k2 *= M_32;
+                    k2 ^= k2 >> R_32;
+                    k2 *= M_32;
+
+                    h *= M_32;
+                    h ^= k2;
+
+                    // Do a few final mixes of the hash to ensure the "last few
+                    // bytes" are well-incorporated.
+                    // TODO: really needed, we have no "last few bytes"?
+                    h ^= h >> 13;
+                    h *= M_32;
+                    h ^= h >> 15;
+                    return h;
+                }
+
+                CYKHASH_INLINE uint32_t murmur2_64to32(uint64_t k){
+                      uint32_t k1=(uint32_t)k;
+                      uint32_t k2=(uint32_t)(k>>32);
+
+                      return murmur2_32_32to32(k1, k2);
+                }
+            #else
+            #error Unknown pointer size or missing size macros!
+            #endif
+        #endif
+    """
+    pass

--- a/pyrosm/vendor/cykhash/sets/set_header.pxi
+++ b/pyrosm/vendor/cykhash/sets/set_header.pxi
@@ -1,0 +1,358 @@
+
+"""
+Template for sets
+
+WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
+"""
+
+include "set_init.pxi"
+
+
+cdef extern from *:
+
+    ctypedef struct kh_int64set_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        int64_t *keys
+        #size_t *vals  //dummy
+
+    kh_int64set_t* kh_init_int64set() nogil
+    void kh_destroy_int64set(kh_int64set_t*) nogil
+    void kh_clear_int64set(kh_int64set_t*) nogil
+    khint_t kh_get_int64set(kh_int64set_t*, int64_t) nogil
+    void kh_resize_int64set(kh_int64set_t*, khint_t) nogil
+    khint_t kh_put_int64set(kh_int64set_t*, int64_t, int*) nogil
+    void kh_del_int64set(kh_int64set_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_int64set "kh_exist" (kh_int64set_t*, khint_t) nogil
+
+
+cdef class Int64Set:
+    cdef kh_int64set_t *table
+
+    cdef bint contains(self, int64_t key) except *
+    cdef Int64SetIterator get_iter(self)
+    cdef khint_t size(self) 
+    cpdef void add(self, int64_t key) except *
+    cpdef void discard(self, int64_t key) except *
+    
+
+cdef class Int64SetIterator:
+    cdef khint_t   it
+    cdef Int64Set  parent
+
+    cdef bint has_next(self) except *
+    cdef int64_t next(self) except *
+    cdef void __move(self) except *
+
+
+cpdef Int64Set Int64Set_from_buffer(int64_t[:] buf, double size_hint=*)
+
+
+from libc.stdint cimport  uint8_t
+cpdef void isin_int64(int64_t[:] query, Int64Set db, uint8_t[:] result) except *
+
+cpdef bint all_int64(int64_t[:] query, Int64Set db) except *
+cpdef bint all_int64_from_iter(object query, Int64Set db) except *
+
+cpdef bint none_int64(int64_t[:] query, Int64Set db) except *
+cpdef bint none_int64_from_iter(object query, Int64Set db) except *
+
+cpdef bint any_int64(int64_t[:] query, Int64Set db) except *
+cpdef bint any_int64_from_iter(object query, Int64Set db) except *
+
+cpdef size_t count_if_int64(int64_t[:] query, Int64Set db) except *
+cpdef size_t count_if_int64_from_iter(object query, Int64Set db) except *
+
+cpdef void swap_int64(Int64Set a, Int64Set b) except *
+
+# for drop-in replacements:
+cpdef bint aredisjoint_int64(Int64Set a, Int64Set b) except *
+cpdef bint issubset_int64(Int64Set s, Int64Set sub) except *
+cpdef Int64Set copy_int64(Int64Set s)
+cpdef void update_int64(Int64Set s, Int64Set other) except *
+cpdef Int64Set intersect_int64(Int64Set a, Int64Set b)
+cpdef Int64Set difference_int64(Int64Set a, Int64Set b)
+cpdef Int64Set symmetric_difference_int64(Int64Set a, Int64Set b)
+
+
+
+cdef extern from *:
+
+    ctypedef struct kh_float64set_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        float64_t *keys
+        #size_t *vals  //dummy
+
+    kh_float64set_t* kh_init_float64set() nogil
+    void kh_destroy_float64set(kh_float64set_t*) nogil
+    void kh_clear_float64set(kh_float64set_t*) nogil
+    khint_t kh_get_float64set(kh_float64set_t*, float64_t) nogil
+    void kh_resize_float64set(kh_float64set_t*, khint_t) nogil
+    khint_t kh_put_float64set(kh_float64set_t*, float64_t, int*) nogil
+    void kh_del_float64set(kh_float64set_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_float64set "kh_exist" (kh_float64set_t*, khint_t) nogil
+
+
+cdef class Float64Set:
+    cdef kh_float64set_t *table
+
+    cdef bint contains(self, float64_t key) except *
+    cdef Float64SetIterator get_iter(self)
+    cdef khint_t size(self) 
+    cpdef void add(self, float64_t key) except *
+    cpdef void discard(self, float64_t key) except *
+    
+
+cdef class Float64SetIterator:
+    cdef khint_t   it
+    cdef Float64Set  parent
+
+    cdef bint has_next(self) except *
+    cdef float64_t next(self) except *
+    cdef void __move(self) except *
+
+
+cpdef Float64Set Float64Set_from_buffer(float64_t[:] buf, double size_hint=*)
+
+
+from libc.stdint cimport  uint8_t
+cpdef void isin_float64(float64_t[:] query, Float64Set db, uint8_t[:] result) except *
+
+cpdef bint all_float64(float64_t[:] query, Float64Set db) except *
+cpdef bint all_float64_from_iter(object query, Float64Set db) except *
+
+cpdef bint none_float64(float64_t[:] query, Float64Set db) except *
+cpdef bint none_float64_from_iter(object query, Float64Set db) except *
+
+cpdef bint any_float64(float64_t[:] query, Float64Set db) except *
+cpdef bint any_float64_from_iter(object query, Float64Set db) except *
+
+cpdef size_t count_if_float64(float64_t[:] query, Float64Set db) except *
+cpdef size_t count_if_float64_from_iter(object query, Float64Set db) except *
+
+cpdef void swap_float64(Float64Set a, Float64Set b) except *
+
+# for drop-in replacements:
+cpdef bint aredisjoint_float64(Float64Set a, Float64Set b) except *
+cpdef bint issubset_float64(Float64Set s, Float64Set sub) except *
+cpdef Float64Set copy_float64(Float64Set s)
+cpdef void update_float64(Float64Set s, Float64Set other) except *
+cpdef Float64Set intersect_float64(Float64Set a, Float64Set b)
+cpdef Float64Set difference_float64(Float64Set a, Float64Set b)
+cpdef Float64Set symmetric_difference_float64(Float64Set a, Float64Set b)
+
+
+
+cdef extern from *:
+
+    ctypedef struct kh_int32set_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        int32_t *keys
+        #size_t *vals  //dummy
+
+    kh_int32set_t* kh_init_int32set() nogil
+    void kh_destroy_int32set(kh_int32set_t*) nogil
+    void kh_clear_int32set(kh_int32set_t*) nogil
+    khint_t kh_get_int32set(kh_int32set_t*, int32_t) nogil
+    void kh_resize_int32set(kh_int32set_t*, khint_t) nogil
+    khint_t kh_put_int32set(kh_int32set_t*, int32_t, int*) nogil
+    void kh_del_int32set(kh_int32set_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_int32set "kh_exist" (kh_int32set_t*, khint_t) nogil
+
+
+cdef class Int32Set:
+    cdef kh_int32set_t *table
+
+    cdef bint contains(self, int32_t key) except *
+    cdef Int32SetIterator get_iter(self)
+    cdef khint_t size(self) 
+    cpdef void add(self, int32_t key) except *
+    cpdef void discard(self, int32_t key) except *
+    
+
+cdef class Int32SetIterator:
+    cdef khint_t   it
+    cdef Int32Set  parent
+
+    cdef bint has_next(self) except *
+    cdef int32_t next(self) except *
+    cdef void __move(self) except *
+
+
+cpdef Int32Set Int32Set_from_buffer(int32_t[:] buf, double size_hint=*)
+
+
+from libc.stdint cimport  uint8_t
+cpdef void isin_int32(int32_t[:] query, Int32Set db, uint8_t[:] result) except *
+
+cpdef bint all_int32(int32_t[:] query, Int32Set db) except *
+cpdef bint all_int32_from_iter(object query, Int32Set db) except *
+
+cpdef bint none_int32(int32_t[:] query, Int32Set db) except *
+cpdef bint none_int32_from_iter(object query, Int32Set db) except *
+
+cpdef bint any_int32(int32_t[:] query, Int32Set db) except *
+cpdef bint any_int32_from_iter(object query, Int32Set db) except *
+
+cpdef size_t count_if_int32(int32_t[:] query, Int32Set db) except *
+cpdef size_t count_if_int32_from_iter(object query, Int32Set db) except *
+
+cpdef void swap_int32(Int32Set a, Int32Set b) except *
+
+# for drop-in replacements:
+cpdef bint aredisjoint_int32(Int32Set a, Int32Set b) except *
+cpdef bint issubset_int32(Int32Set s, Int32Set sub) except *
+cpdef Int32Set copy_int32(Int32Set s)
+cpdef void update_int32(Int32Set s, Int32Set other) except *
+cpdef Int32Set intersect_int32(Int32Set a, Int32Set b)
+cpdef Int32Set difference_int32(Int32Set a, Int32Set b)
+cpdef Int32Set symmetric_difference_int32(Int32Set a, Int32Set b)
+
+
+
+cdef extern from *:
+
+    ctypedef struct kh_float32set_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        float32_t *keys
+        #size_t *vals  //dummy
+
+    kh_float32set_t* kh_init_float32set() nogil
+    void kh_destroy_float32set(kh_float32set_t*) nogil
+    void kh_clear_float32set(kh_float32set_t*) nogil
+    khint_t kh_get_float32set(kh_float32set_t*, float32_t) nogil
+    void kh_resize_float32set(kh_float32set_t*, khint_t) nogil
+    khint_t kh_put_float32set(kh_float32set_t*, float32_t, int*) nogil
+    void kh_del_float32set(kh_float32set_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_float32set "kh_exist" (kh_float32set_t*, khint_t) nogil
+
+
+cdef class Float32Set:
+    cdef kh_float32set_t *table
+
+    cdef bint contains(self, float32_t key) except *
+    cdef Float32SetIterator get_iter(self)
+    cdef khint_t size(self) 
+    cpdef void add(self, float32_t key) except *
+    cpdef void discard(self, float32_t key) except *
+    
+
+cdef class Float32SetIterator:
+    cdef khint_t   it
+    cdef Float32Set  parent
+
+    cdef bint has_next(self) except *
+    cdef float32_t next(self) except *
+    cdef void __move(self) except *
+
+
+cpdef Float32Set Float32Set_from_buffer(float32_t[:] buf, double size_hint=*)
+
+
+from libc.stdint cimport  uint8_t
+cpdef void isin_float32(float32_t[:] query, Float32Set db, uint8_t[:] result) except *
+
+cpdef bint all_float32(float32_t[:] query, Float32Set db) except *
+cpdef bint all_float32_from_iter(object query, Float32Set db) except *
+
+cpdef bint none_float32(float32_t[:] query, Float32Set db) except *
+cpdef bint none_float32_from_iter(object query, Float32Set db) except *
+
+cpdef bint any_float32(float32_t[:] query, Float32Set db) except *
+cpdef bint any_float32_from_iter(object query, Float32Set db) except *
+
+cpdef size_t count_if_float32(float32_t[:] query, Float32Set db) except *
+cpdef size_t count_if_float32_from_iter(object query, Float32Set db) except *
+
+cpdef void swap_float32(Float32Set a, Float32Set b) except *
+
+# for drop-in replacements:
+cpdef bint aredisjoint_float32(Float32Set a, Float32Set b) except *
+cpdef bint issubset_float32(Float32Set s, Float32Set sub) except *
+cpdef Float32Set copy_float32(Float32Set s)
+cpdef void update_float32(Float32Set s, Float32Set other) except *
+cpdef Float32Set intersect_float32(Float32Set a, Float32Set b)
+cpdef Float32Set difference_float32(Float32Set a, Float32Set b)
+cpdef Float32Set symmetric_difference_float32(Float32Set a, Float32Set b)
+
+
+
+cdef extern from *:
+
+    ctypedef struct kh_pyobjectset_t:
+        khint_t n_buckets, size, n_occupied, upper_bound
+        uint32_t *flags
+        pyobject_t *keys
+        #size_t *vals  //dummy
+
+    kh_pyobjectset_t* kh_init_pyobjectset() nogil
+    void kh_destroy_pyobjectset(kh_pyobjectset_t*) nogil
+    void kh_clear_pyobjectset(kh_pyobjectset_t*) nogil
+    khint_t kh_get_pyobjectset(kh_pyobjectset_t*, pyobject_t) nogil
+    void kh_resize_pyobjectset(kh_pyobjectset_t*, khint_t) nogil
+    khint_t kh_put_pyobjectset(kh_pyobjectset_t*, pyobject_t, int*) nogil
+    void kh_del_pyobjectset(kh_pyobjectset_t*, khint_t) nogil
+
+    #specializing "kh_exist"-macro 
+    bint kh_exist_pyobjectset "kh_exist" (kh_pyobjectset_t*, khint_t) nogil
+
+
+cdef class PyObjectSet:
+    cdef kh_pyobjectset_t *table
+
+    cdef bint contains(self, object key) except *
+    cdef PyObjectSetIterator get_iter(self)
+    cdef khint_t size(self) 
+    cpdef void add(self, object key) except *
+    cpdef void discard(self, object key) except *
+    
+
+cdef class PyObjectSetIterator:
+    cdef khint_t   it
+    cdef PyObjectSet  parent
+
+    cdef bint has_next(self) except *
+    cdef object next(self)
+    cdef void __move(self) except *
+
+
+cpdef PyObjectSet PyObjectSet_from_buffer(object[:] buf, double size_hint=*)
+
+
+from libc.stdint cimport  uint8_t
+cpdef void isin_pyobject(object[:] query, PyObjectSet db, uint8_t[:] result) except *
+
+cpdef bint all_pyobject(object[:] query, PyObjectSet db) except *
+cpdef bint all_pyobject_from_iter(object query, PyObjectSet db) except *
+
+cpdef bint none_pyobject(object[:] query, PyObjectSet db) except *
+cpdef bint none_pyobject_from_iter(object query, PyObjectSet db) except *
+
+cpdef bint any_pyobject(object[:] query, PyObjectSet db) except *
+cpdef bint any_pyobject_from_iter(object query, PyObjectSet db) except *
+
+cpdef size_t count_if_pyobject(object[:] query, PyObjectSet db) except *
+cpdef size_t count_if_pyobject_from_iter(object query, PyObjectSet db) except *
+
+cpdef void swap_pyobject(PyObjectSet a, PyObjectSet b) except *
+
+# for drop-in replacements:
+cpdef bint aredisjoint_pyobject(PyObjectSet a, PyObjectSet b) except *
+cpdef bint issubset_pyobject(PyObjectSet s, PyObjectSet sub) except *
+cpdef PyObjectSet copy_pyobject(PyObjectSet s)
+cpdef void update_pyobject(PyObjectSet s, PyObjectSet other) except *
+cpdef PyObjectSet intersect_pyobject(PyObjectSet a, PyObjectSet b)
+cpdef PyObjectSet difference_pyobject(PyObjectSet a, PyObjectSet b)
+cpdef PyObjectSet symmetric_difference_pyobject(PyObjectSet a, PyObjectSet b)
+

--- a/pyrosm/vendor/cykhash/sets/set_impl.pxi
+++ b/pyrosm/vendor/cykhash/sets/set_impl.pxi
@@ -1,0 +1,2726 @@
+
+"""
+Template for sets
+
+WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
+"""
+
+
+from cpython.ref cimport Py_INCREF,Py_DECREF
+
+
+
+
+#### special for PyObject:
+
+
+cdef void _dealloc_int64(kh_int64set_t *table) nogil:
+    if table is not NULL:
+        kh_destroy_int64set(table)
+
+cdef bint _contains_int64(kh_int64set_t *table, int64_t key) nogil:
+    cdef khint_t k
+    k = kh_get_int64set(table, key)
+    return k != table.n_buckets
+
+cdef void _add_int64(kh_int64set_t *table, int64_t key) nogil:
+    cdef:
+        khint_t k
+        int ret = 0
+
+    k = kh_put_int64set(table, key, &ret)
+    table.keys[k] = key
+
+cdef void _discard_int64(kh_int64set_t *table, int64_t key) nogil:
+    cdef khint_t k
+    k = kh_get_int64set(table, key)
+    if k != table.n_buckets:
+        kh_del_int64set(table, k)
+
+
+### Iterator:
+cdef class Int64SetIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_int64set(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()  
+    cdef int64_t next(self) except *:
+        cdef int64_t result = self.parent.table.keys[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+
+    def __cinit__(self, Int64Set parent):
+        self.parent = parent
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        if self.has_next():
+            return self.next()
+        else:
+            raise StopIteration
+
+#### the same for all:
+
+cdef class Int64Set:
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        iterable - initial elements in the set
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_int64set()
+        if number_of_elements_hint is not None:    
+            kh_resize_int64set(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef int64_t el
+        if iterable is not None:
+            for el in iterable:
+                self.add(el)
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+        
+
+    def __dealloc__(self):
+        _dealloc_int64(self.table)
+        self.table = NULL
+
+    def __contains__(self, int64_t key):
+        return self.contains(key)
+
+
+    cdef bint contains(self, int64_t key) except *:
+        return _contains_int64(self.table, key)
+
+
+    cpdef void add(self, int64_t key) except *:
+        _add_int64(self.table, key)
+
+    
+    cpdef void discard(self, int64_t key) except *:
+        _discard_int64(self.table, key)
+
+
+    cdef Int64SetIterator get_iter(self):
+        return Int64SetIterator(self)
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def get_state_info(self):
+        """
+        returns information about state of the set
+
+        >>> from cykhash import Int64Set
+        >>> info = Int64Set([1]).get_state_info()
+        >>> info["n_buckets"]
+        4
+        >>> info["n_occupied"]
+        1
+
+        """
+        return {"n_buckets" : self.table.n_buckets, 
+                "n_occupied" : self.table.n_occupied, 
+                "upper_bound" : self.table.upper_bound}
+
+    ### drop-in for set:
+    def isdisjoint(self, other):
+        if isinstance(other, Int64Set):
+            return aredisjoint_int64(self, other)
+        cdef int64_t el
+        for el in other:
+            if self.contains(el):
+                return False
+        return True
+
+    def issuperset(self, other):
+        if isinstance(other, Int64Set):
+            return issubset_int64(self, other)
+        cdef int64_t el
+        for el in other:
+            if not self.contains(el):
+                return False
+        return True
+
+    def issubset(self, other):
+        if isinstance(other, Int64Set):
+            return issubset_int64(other, self)
+        cdef int64_t el
+        cdef Int64Set mem=Int64Set()
+        for el in other:
+            if self.contains(el):
+                mem.add(el)
+        return mem.size()==self.size()
+
+    def __repr__(self):
+        return "{"+','.join(map(str, self))+"}"
+
+    def __le__(self, Int64Set other):
+        return issubset_int64(other, self)
+
+    def __lt__(self, Int64Set other):
+        return issubset_int64(other, self) and self.size()<other.size()
+
+    def __ge__(self, Int64Set other):
+        return issubset_int64(self,  other)
+
+    def __gt__(self, Int64Set other):
+        return issubset_int64(self, other) and self.size()>other.size()
+
+    def __eq__(self, Int64Set other):
+        return issubset_int64(self, other) and self.size()==other.size()
+
+    def __or__(self, Int64Set other):
+        cdef Int64Set res = copy_int64(self)
+        update_int64(res, other)
+        return res
+
+    def __ior__(self, Int64Set other):
+        update_int64(self, other)
+        return self
+
+    def __and__(self, Int64Set other):
+        return intersect_int64(self, other)
+
+    def __iand__(self, Int64Set other):
+        cdef Int64Set res = intersect_int64(self, other)
+        swap_int64(self, res)
+        return self
+
+    def __sub__(self, Int64Set other):
+        return difference_int64(self, other)
+
+    def __isub__(self, Int64Set other):
+        cdef Int64Set res = difference_int64(self, other)
+        swap_int64(self, res)
+        return self
+
+    def __xor__(self, Int64Set other):
+        return symmetric_difference_int64(self, other)
+
+    def __ixor__(self, Int64Set other):
+        cdef Int64Set res = symmetric_difference_int64(self, other)
+        swap_int64(self, res)
+        return self
+
+    def copy(self):
+        return copy_int64(self)
+
+    def union(self, *others):
+        cdef Int64Set res = copy_int64(self)
+        for o in others:
+            res.update(o)
+        return res
+
+    def update(self, other):
+        if isinstance(other, Int64Set):
+            update_int64(self, other)
+            return
+        cdef int64_t el
+        for el in other:
+            self.add(el)
+
+    def intersection(self, *others):
+        cdef Int64Set res = copy_int64(self)
+        for o in others:
+            res.intersection_update(o)
+        return res
+
+    def intersection_update(self, other):
+        cdef Int64Set res 
+        cdef int64_t el
+        if isinstance(other, Int64Set):
+            res = intersect_int64(self, other)
+        else:
+            res = Int64Set()
+            for el in other:
+                if self.contains(el):
+                    res.add(el)
+        swap_int64(self, res)
+
+    def difference_update(self, other):
+        cdef Int64Set res 
+        cdef int64_t el
+        if isinstance(other, Int64Set):
+            res = difference_int64(self, other)
+            swap_int64(self, res)
+        else:
+            for el in other:
+                self.discard(el)
+
+    def difference(self, *others):
+        cdef Int64Set res = copy_int64(self)
+        for o in others:
+            res.difference_update(o)
+        return res
+
+    def symmetric_difference_update(self, other):
+        cdef Int64Set res 
+        cdef int64_t el
+        if isinstance(other, Int64Set):
+            res = symmetric_difference_int64(self, other)
+        else:
+            res = self.copy()
+            for el in other:
+                if self.contains(el):
+                    res.discard(el)
+                else:
+                    res.add(el)
+        swap_int64(self, res)
+
+    def symmetric_difference(self, *others):
+        cdef Int64Set res = copy_int64(self)
+        for o in others:
+            res.symmetric_difference_update(o)
+        return res
+
+    def clear(self):
+        cdef Int64Set res = Int64Set()
+        swap_int64(self, res)
+
+    def remove(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def pop(self):
+        if self.size()== 0:
+            raise KeyError("pop from empty set")
+        cdef Int64SetIterator it = self.get_iter()
+        cdef int64_t el = it.next()
+        self.discard(el)
+        return el
+        
+
+
+
+### Utils:
+
+def Int64Set_from(it):
+    """
+        creates Int64Set from an iterator. 
+        Use Int64Set_from_buffer for a faster version if iterator is buffer of correct type
+    """
+    res=Int64Set()
+    for i in it:
+        res.add(i)
+    return res
+
+cpdef Int64Set Int64Set_from_buffer(int64_t[:] buf, double size_hint=0.0):
+    """
+        creates Int64Set from the given buffer buf. 
+        Use slower Int64Set_from if series is given as iterator without buffer protocol.
+        size_hint is an estimation of the ratio of unique elements. The default value of 0.0 means all elements in buf are expected to be unique
+        Giving a good estimate will avoid rehashing (if estimate is too low) and having too big table (if estimate is too high).
+    """
+    cdef Py_ssize_t n = len(buf)
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Int64Set(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.add(buf[i])
+    return res
+    
+
+cpdef void isin_int64(int64_t[:] query, Int64Set db, uint8_t[:] result) except *:
+    """
+        given query, db writes for every element of query True/False into result depending on whether query-element is in db (=True) or not (=False). 
+        result should have the same length as query.
+    """
+    cdef size_t i
+    cdef size_t n=len(query)
+    if n!=len(result):
+        raise ValueError("Different sizes for query({n}) and result({m})".format(n=n, m=len(result)))
+    for i in range(n):
+        result[i]=db is not None and db.contains(query[i])
+
+cpdef bint all_int64(int64_t[:] query, Int64Set db) except *:
+    """
+        True if all elements of query are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    if db is None:
+        return n==0
+    for i in range(n):
+        if not db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint all_int64_from_iter(object query, Int64Set db) except *:
+    """
+        True if all elements of query (as iterator) are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef int64_t el
+    for el in query:
+        if db is None or not db.contains(el):
+            return False
+    return True
+
+cpdef bint none_int64(int64_t[:] query, Int64Set db) except *:
+    """
+        True if none of elements in query is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    for i in range(n):
+        if db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint none_int64_from_iter(object query, Int64Set db) except *:
+    """
+        True if none of elements in query (as iterator) is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef int64_t el
+    for el in query:
+        if db.contains(el):
+            return False
+    return True
+
+cpdef bint any_int64(int64_t[:] query, Int64Set db) except *:
+    """
+        True if one of elements in query is in db, False otherwise.
+    """
+    return not none_int64(query, db)
+
+cpdef bint any_int64_from_iter(object query, Int64Set db) except *:
+    """
+        True if one of elements in query (as iterator) is in db, False otherwise.
+    """
+    return not none_int64_from_iter(query, db)
+
+cpdef size_t count_if_int64(int64_t[:] query, Int64Set db) except *:
+    """
+        returns the number of (non-unique) elements in query, which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef size_t i
+    cdef size_t n=len(query)
+    cdef size_t res=0
+    for i in range(n):
+        if db.contains(query[i]):
+            res+=1
+    return res
+
+cpdef size_t count_if_int64_from_iter(object query, Int64Set db) except *:
+    """
+        returns the number of (non-unique) elements in query (as iter), which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef int64_t el
+    cdef size_t res=0
+    for el in query:
+        if db.contains(el):
+            res+=1
+    return res
+
+cpdef bint aredisjoint_int64(Int64Set a, Int64Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Int64SetIterator it
+    cdef Int64Set s
+    cdef int64_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            return False
+    return True
+
+cpdef Int64Set intersect_int64(Int64Set a, Int64Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Int64Set result = Int64Set()
+    cdef Int64SetIterator it
+    cdef Int64Set s
+    cdef int64_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            result.add(el)
+    return result
+
+cpdef bint issubset_int64(Int64Set s, Int64Set sub) except *:
+    if s is None or sub is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    if s.size() < sub.size():
+        return False
+
+    cdef Int64SetIterator it=sub.get_iter()
+    cdef int64_t el
+    while it.has_next():
+        el = it.next()
+        if not s.contains(el):
+            return False
+    return True
+
+cpdef Int64Set copy_int64(Int64Set s):
+    if s is None:
+        return None
+    cdef Int64Set result = Int64Set(number_of_elements_hint=s.size())
+    cdef Int64SetIterator it=s.get_iter()
+    cdef int64_t el
+    while it.has_next():
+        el = it.next()
+        result.add(el)
+    return result
+
+cpdef void update_int64(Int64Set s, Int64Set other) except *:
+    if s is None or other is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Int64SetIterator it=other.get_iter()
+    cdef int64_t el
+    while it.has_next():
+        el = it.next()
+        s.add(el)
+
+cpdef void swap_int64(Int64Set a, Int64Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_int64set_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+cpdef Int64Set difference_int64(Int64Set a, Int64Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef int64_t el
+    cdef Int64Set result = Int64Set()
+    cdef Int64SetIterator it = a.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not b.contains(el):
+            result.add(el)
+    return result
+
+
+cpdef Int64Set symmetric_difference_int64(Int64Set a, Int64Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef int64_t el
+    cdef Int64Set result = Int64Set()
+    cdef Int64SetIterator it = a.get_iter()
+    while it.has_next():
+          el = it.next()
+          if not b.contains(el):
+                result.add(el)
+    it = b.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not a.contains(el):
+            result.add(el)
+    return result
+
+
+#### special for PyObject:
+
+
+cdef void _dealloc_float64(kh_float64set_t *table) nogil:
+    if table is not NULL:
+        kh_destroy_float64set(table)
+
+cdef bint _contains_float64(kh_float64set_t *table, float64_t key) nogil:
+    cdef khint_t k
+    k = kh_get_float64set(table, key)
+    return k != table.n_buckets
+
+cdef void _add_float64(kh_float64set_t *table, float64_t key) nogil:
+    cdef:
+        khint_t k
+        int ret = 0
+
+    k = kh_put_float64set(table, key, &ret)
+    table.keys[k] = key
+
+cdef void _discard_float64(kh_float64set_t *table, float64_t key) nogil:
+    cdef khint_t k
+    k = kh_get_float64set(table, key)
+    if k != table.n_buckets:
+        kh_del_float64set(table, k)
+
+
+### Iterator:
+cdef class Float64SetIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_float64set(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()  
+    cdef float64_t next(self) except *:
+        cdef float64_t result = self.parent.table.keys[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+
+    def __cinit__(self, Float64Set parent):
+        self.parent = parent
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        if self.has_next():
+            return self.next()
+        else:
+            raise StopIteration
+
+#### the same for all:
+
+cdef class Float64Set:
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        iterable - initial elements in the set
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_float64set()
+        if number_of_elements_hint is not None:    
+            kh_resize_float64set(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef float64_t el
+        if iterable is not None:
+            for el in iterable:
+                self.add(el)
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+        
+
+    def __dealloc__(self):
+        _dealloc_float64(self.table)
+        self.table = NULL
+
+    def __contains__(self, float64_t key):
+        return self.contains(key)
+
+
+    cdef bint contains(self, float64_t key) except *:
+        return _contains_float64(self.table, key)
+
+
+    cpdef void add(self, float64_t key) except *:
+        _add_float64(self.table, key)
+
+    
+    cpdef void discard(self, float64_t key) except *:
+        _discard_float64(self.table, key)
+
+
+    cdef Float64SetIterator get_iter(self):
+        return Float64SetIterator(self)
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def get_state_info(self):
+        """
+        returns information about state of the set
+
+        >>> from cykhash import Float64Set
+        >>> info = Float64Set([1]).get_state_info()
+        >>> info["n_buckets"]
+        4
+        >>> info["n_occupied"]
+        1
+
+        """
+        return {"n_buckets" : self.table.n_buckets, 
+                "n_occupied" : self.table.n_occupied, 
+                "upper_bound" : self.table.upper_bound}
+
+    ### drop-in for set:
+    def isdisjoint(self, other):
+        if isinstance(other, Float64Set):
+            return aredisjoint_float64(self, other)
+        cdef float64_t el
+        for el in other:
+            if self.contains(el):
+                return False
+        return True
+
+    def issuperset(self, other):
+        if isinstance(other, Float64Set):
+            return issubset_float64(self, other)
+        cdef float64_t el
+        for el in other:
+            if not self.contains(el):
+                return False
+        return True
+
+    def issubset(self, other):
+        if isinstance(other, Float64Set):
+            return issubset_float64(other, self)
+        cdef float64_t el
+        cdef Float64Set mem=Float64Set()
+        for el in other:
+            if self.contains(el):
+                mem.add(el)
+        return mem.size()==self.size()
+
+    def __repr__(self):
+        return "{"+','.join(map(str, self))+"}"
+
+    def __le__(self, Float64Set other):
+        return issubset_float64(other, self)
+
+    def __lt__(self, Float64Set other):
+        return issubset_float64(other, self) and self.size()<other.size()
+
+    def __ge__(self, Float64Set other):
+        return issubset_float64(self,  other)
+
+    def __gt__(self, Float64Set other):
+        return issubset_float64(self, other) and self.size()>other.size()
+
+    def __eq__(self, Float64Set other):
+        return issubset_float64(self, other) and self.size()==other.size()
+
+    def __or__(self, Float64Set other):
+        cdef Float64Set res = copy_float64(self)
+        update_float64(res, other)
+        return res
+
+    def __ior__(self, Float64Set other):
+        update_float64(self, other)
+        return self
+
+    def __and__(self, Float64Set other):
+        return intersect_float64(self, other)
+
+    def __iand__(self, Float64Set other):
+        cdef Float64Set res = intersect_float64(self, other)
+        swap_float64(self, res)
+        return self
+
+    def __sub__(self, Float64Set other):
+        return difference_float64(self, other)
+
+    def __isub__(self, Float64Set other):
+        cdef Float64Set res = difference_float64(self, other)
+        swap_float64(self, res)
+        return self
+
+    def __xor__(self, Float64Set other):
+        return symmetric_difference_float64(self, other)
+
+    def __ixor__(self, Float64Set other):
+        cdef Float64Set res = symmetric_difference_float64(self, other)
+        swap_float64(self, res)
+        return self
+
+    def copy(self):
+        return copy_float64(self)
+
+    def union(self, *others):
+        cdef Float64Set res = copy_float64(self)
+        for o in others:
+            res.update(o)
+        return res
+
+    def update(self, other):
+        if isinstance(other, Float64Set):
+            update_float64(self, other)
+            return
+        cdef float64_t el
+        for el in other:
+            self.add(el)
+
+    def intersection(self, *others):
+        cdef Float64Set res = copy_float64(self)
+        for o in others:
+            res.intersection_update(o)
+        return res
+
+    def intersection_update(self, other):
+        cdef Float64Set res 
+        cdef float64_t el
+        if isinstance(other, Float64Set):
+            res = intersect_float64(self, other)
+        else:
+            res = Float64Set()
+            for el in other:
+                if self.contains(el):
+                    res.add(el)
+        swap_float64(self, res)
+
+    def difference_update(self, other):
+        cdef Float64Set res 
+        cdef float64_t el
+        if isinstance(other, Float64Set):
+            res = difference_float64(self, other)
+            swap_float64(self, res)
+        else:
+            for el in other:
+                self.discard(el)
+
+    def difference(self, *others):
+        cdef Float64Set res = copy_float64(self)
+        for o in others:
+            res.difference_update(o)
+        return res
+
+    def symmetric_difference_update(self, other):
+        cdef Float64Set res 
+        cdef float64_t el
+        if isinstance(other, Float64Set):
+            res = symmetric_difference_float64(self, other)
+        else:
+            res = self.copy()
+            for el in other:
+                if self.contains(el):
+                    res.discard(el)
+                else:
+                    res.add(el)
+        swap_float64(self, res)
+
+    def symmetric_difference(self, *others):
+        cdef Float64Set res = copy_float64(self)
+        for o in others:
+            res.symmetric_difference_update(o)
+        return res
+
+    def clear(self):
+        cdef Float64Set res = Float64Set()
+        swap_float64(self, res)
+
+    def remove(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def pop(self):
+        if self.size()== 0:
+            raise KeyError("pop from empty set")
+        cdef Float64SetIterator it = self.get_iter()
+        cdef float64_t el = it.next()
+        self.discard(el)
+        return el
+        
+
+
+
+### Utils:
+
+def Float64Set_from(it):
+    """
+        creates Float64Set from an iterator. 
+        Use Float64Set_from_buffer for a faster version if iterator is buffer of correct type
+    """
+    res=Float64Set()
+    for i in it:
+        res.add(i)
+    return res
+
+cpdef Float64Set Float64Set_from_buffer(float64_t[:] buf, double size_hint=0.0):
+    """
+        creates Float64Set from the given buffer buf. 
+        Use slower Float64Set_from if series is given as iterator without buffer protocol.
+        size_hint is an estimation of the ratio of unique elements. The default value of 0.0 means all elements in buf are expected to be unique
+        Giving a good estimate will avoid rehashing (if estimate is too low) and having too big table (if estimate is too high).
+    """
+    cdef Py_ssize_t n = len(buf)
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Float64Set(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.add(buf[i])
+    return res
+    
+
+cpdef void isin_float64(float64_t[:] query, Float64Set db, uint8_t[:] result) except *:
+    """
+        given query, db writes for every element of query True/False into result depending on whether query-element is in db (=True) or not (=False). 
+        result should have the same length as query.
+    """
+    cdef size_t i
+    cdef size_t n=len(query)
+    if n!=len(result):
+        raise ValueError("Different sizes for query({n}) and result({m})".format(n=n, m=len(result)))
+    for i in range(n):
+        result[i]=db is not None and db.contains(query[i])
+
+cpdef bint all_float64(float64_t[:] query, Float64Set db) except *:
+    """
+        True if all elements of query are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    if db is None:
+        return n==0
+    for i in range(n):
+        if not db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint all_float64_from_iter(object query, Float64Set db) except *:
+    """
+        True if all elements of query (as iterator) are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef float64_t el
+    for el in query:
+        if db is None or not db.contains(el):
+            return False
+    return True
+
+cpdef bint none_float64(float64_t[:] query, Float64Set db) except *:
+    """
+        True if none of elements in query is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    for i in range(n):
+        if db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint none_float64_from_iter(object query, Float64Set db) except *:
+    """
+        True if none of elements in query (as iterator) is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef float64_t el
+    for el in query:
+        if db.contains(el):
+            return False
+    return True
+
+cpdef bint any_float64(float64_t[:] query, Float64Set db) except *:
+    """
+        True if one of elements in query is in db, False otherwise.
+    """
+    return not none_float64(query, db)
+
+cpdef bint any_float64_from_iter(object query, Float64Set db) except *:
+    """
+        True if one of elements in query (as iterator) is in db, False otherwise.
+    """
+    return not none_float64_from_iter(query, db)
+
+cpdef size_t count_if_float64(float64_t[:] query, Float64Set db) except *:
+    """
+        returns the number of (non-unique) elements in query, which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef size_t i
+    cdef size_t n=len(query)
+    cdef size_t res=0
+    for i in range(n):
+        if db.contains(query[i]):
+            res+=1
+    return res
+
+cpdef size_t count_if_float64_from_iter(object query, Float64Set db) except *:
+    """
+        returns the number of (non-unique) elements in query (as iter), which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef float64_t el
+    cdef size_t res=0
+    for el in query:
+        if db.contains(el):
+            res+=1
+    return res
+
+cpdef bint aredisjoint_float64(Float64Set a, Float64Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Float64SetIterator it
+    cdef Float64Set s
+    cdef float64_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            return False
+    return True
+
+cpdef Float64Set intersect_float64(Float64Set a, Float64Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Float64Set result = Float64Set()
+    cdef Float64SetIterator it
+    cdef Float64Set s
+    cdef float64_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            result.add(el)
+    return result
+
+cpdef bint issubset_float64(Float64Set s, Float64Set sub) except *:
+    if s is None or sub is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    if s.size() < sub.size():
+        return False
+
+    cdef Float64SetIterator it=sub.get_iter()
+    cdef float64_t el
+    while it.has_next():
+        el = it.next()
+        if not s.contains(el):
+            return False
+    return True
+
+cpdef Float64Set copy_float64(Float64Set s):
+    if s is None:
+        return None
+    cdef Float64Set result = Float64Set(number_of_elements_hint=s.size())
+    cdef Float64SetIterator it=s.get_iter()
+    cdef float64_t el
+    while it.has_next():
+        el = it.next()
+        result.add(el)
+    return result
+
+cpdef void update_float64(Float64Set s, Float64Set other) except *:
+    if s is None or other is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Float64SetIterator it=other.get_iter()
+    cdef float64_t el
+    while it.has_next():
+        el = it.next()
+        s.add(el)
+
+cpdef void swap_float64(Float64Set a, Float64Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_float64set_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+cpdef Float64Set difference_float64(Float64Set a, Float64Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef float64_t el
+    cdef Float64Set result = Float64Set()
+    cdef Float64SetIterator it = a.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not b.contains(el):
+            result.add(el)
+    return result
+
+
+cpdef Float64Set symmetric_difference_float64(Float64Set a, Float64Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef float64_t el
+    cdef Float64Set result = Float64Set()
+    cdef Float64SetIterator it = a.get_iter()
+    while it.has_next():
+          el = it.next()
+          if not b.contains(el):
+                result.add(el)
+    it = b.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not a.contains(el):
+            result.add(el)
+    return result
+
+
+#### special for PyObject:
+
+
+cdef void _dealloc_int32(kh_int32set_t *table) nogil:
+    if table is not NULL:
+        kh_destroy_int32set(table)
+
+cdef bint _contains_int32(kh_int32set_t *table, int32_t key) nogil:
+    cdef khint_t k
+    k = kh_get_int32set(table, key)
+    return k != table.n_buckets
+
+cdef void _add_int32(kh_int32set_t *table, int32_t key) nogil:
+    cdef:
+        khint_t k
+        int ret = 0
+
+    k = kh_put_int32set(table, key, &ret)
+    table.keys[k] = key
+
+cdef void _discard_int32(kh_int32set_t *table, int32_t key) nogil:
+    cdef khint_t k
+    k = kh_get_int32set(table, key)
+    if k != table.n_buckets:
+        kh_del_int32set(table, k)
+
+
+### Iterator:
+cdef class Int32SetIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_int32set(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()  
+    cdef int32_t next(self) except *:
+        cdef int32_t result = self.parent.table.keys[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+
+    def __cinit__(self, Int32Set parent):
+        self.parent = parent
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        if self.has_next():
+            return self.next()
+        else:
+            raise StopIteration
+
+#### the same for all:
+
+cdef class Int32Set:
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        iterable - initial elements in the set
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_int32set()
+        if number_of_elements_hint is not None:    
+            kh_resize_int32set(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef int32_t el
+        if iterable is not None:
+            for el in iterable:
+                self.add(el)
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+        
+
+    def __dealloc__(self):
+        _dealloc_int32(self.table)
+        self.table = NULL
+
+    def __contains__(self, int32_t key):
+        return self.contains(key)
+
+
+    cdef bint contains(self, int32_t key) except *:
+        return _contains_int32(self.table, key)
+
+
+    cpdef void add(self, int32_t key) except *:
+        _add_int32(self.table, key)
+
+    
+    cpdef void discard(self, int32_t key) except *:
+        _discard_int32(self.table, key)
+
+
+    cdef Int32SetIterator get_iter(self):
+        return Int32SetIterator(self)
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def get_state_info(self):
+        """
+        returns information about state of the set
+
+        >>> from cykhash import Int32Set
+        >>> info = Int32Set([1]).get_state_info()
+        >>> info["n_buckets"]
+        4
+        >>> info["n_occupied"]
+        1
+
+        """
+        return {"n_buckets" : self.table.n_buckets, 
+                "n_occupied" : self.table.n_occupied, 
+                "upper_bound" : self.table.upper_bound}
+
+    ### drop-in for set:
+    def isdisjoint(self, other):
+        if isinstance(other, Int32Set):
+            return aredisjoint_int32(self, other)
+        cdef int32_t el
+        for el in other:
+            if self.contains(el):
+                return False
+        return True
+
+    def issuperset(self, other):
+        if isinstance(other, Int32Set):
+            return issubset_int32(self, other)
+        cdef int32_t el
+        for el in other:
+            if not self.contains(el):
+                return False
+        return True
+
+    def issubset(self, other):
+        if isinstance(other, Int32Set):
+            return issubset_int32(other, self)
+        cdef int32_t el
+        cdef Int32Set mem=Int32Set()
+        for el in other:
+            if self.contains(el):
+                mem.add(el)
+        return mem.size()==self.size()
+
+    def __repr__(self):
+        return "{"+','.join(map(str, self))+"}"
+
+    def __le__(self, Int32Set other):
+        return issubset_int32(other, self)
+
+    def __lt__(self, Int32Set other):
+        return issubset_int32(other, self) and self.size()<other.size()
+
+    def __ge__(self, Int32Set other):
+        return issubset_int32(self,  other)
+
+    def __gt__(self, Int32Set other):
+        return issubset_int32(self, other) and self.size()>other.size()
+
+    def __eq__(self, Int32Set other):
+        return issubset_int32(self, other) and self.size()==other.size()
+
+    def __or__(self, Int32Set other):
+        cdef Int32Set res = copy_int32(self)
+        update_int32(res, other)
+        return res
+
+    def __ior__(self, Int32Set other):
+        update_int32(self, other)
+        return self
+
+    def __and__(self, Int32Set other):
+        return intersect_int32(self, other)
+
+    def __iand__(self, Int32Set other):
+        cdef Int32Set res = intersect_int32(self, other)
+        swap_int32(self, res)
+        return self
+
+    def __sub__(self, Int32Set other):
+        return difference_int32(self, other)
+
+    def __isub__(self, Int32Set other):
+        cdef Int32Set res = difference_int32(self, other)
+        swap_int32(self, res)
+        return self
+
+    def __xor__(self, Int32Set other):
+        return symmetric_difference_int32(self, other)
+
+    def __ixor__(self, Int32Set other):
+        cdef Int32Set res = symmetric_difference_int32(self, other)
+        swap_int32(self, res)
+        return self
+
+    def copy(self):
+        return copy_int32(self)
+
+    def union(self, *others):
+        cdef Int32Set res = copy_int32(self)
+        for o in others:
+            res.update(o)
+        return res
+
+    def update(self, other):
+        if isinstance(other, Int32Set):
+            update_int32(self, other)
+            return
+        cdef int32_t el
+        for el in other:
+            self.add(el)
+
+    def intersection(self, *others):
+        cdef Int32Set res = copy_int32(self)
+        for o in others:
+            res.intersection_update(o)
+        return res
+
+    def intersection_update(self, other):
+        cdef Int32Set res 
+        cdef int32_t el
+        if isinstance(other, Int32Set):
+            res = intersect_int32(self, other)
+        else:
+            res = Int32Set()
+            for el in other:
+                if self.contains(el):
+                    res.add(el)
+        swap_int32(self, res)
+
+    def difference_update(self, other):
+        cdef Int32Set res 
+        cdef int32_t el
+        if isinstance(other, Int32Set):
+            res = difference_int32(self, other)
+            swap_int32(self, res)
+        else:
+            for el in other:
+                self.discard(el)
+
+    def difference(self, *others):
+        cdef Int32Set res = copy_int32(self)
+        for o in others:
+            res.difference_update(o)
+        return res
+
+    def symmetric_difference_update(self, other):
+        cdef Int32Set res 
+        cdef int32_t el
+        if isinstance(other, Int32Set):
+            res = symmetric_difference_int32(self, other)
+        else:
+            res = self.copy()
+            for el in other:
+                if self.contains(el):
+                    res.discard(el)
+                else:
+                    res.add(el)
+        swap_int32(self, res)
+
+    def symmetric_difference(self, *others):
+        cdef Int32Set res = copy_int32(self)
+        for o in others:
+            res.symmetric_difference_update(o)
+        return res
+
+    def clear(self):
+        cdef Int32Set res = Int32Set()
+        swap_int32(self, res)
+
+    def remove(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def pop(self):
+        if self.size()== 0:
+            raise KeyError("pop from empty set")
+        cdef Int32SetIterator it = self.get_iter()
+        cdef int32_t el = it.next()
+        self.discard(el)
+        return el
+        
+
+
+
+### Utils:
+
+def Int32Set_from(it):
+    """
+        creates Int32Set from an iterator. 
+        Use Int32Set_from_buffer for a faster version if iterator is buffer of correct type
+    """
+    res=Int32Set()
+    for i in it:
+        res.add(i)
+    return res
+
+cpdef Int32Set Int32Set_from_buffer(int32_t[:] buf, double size_hint=0.0):
+    """
+        creates Int32Set from the given buffer buf. 
+        Use slower Int32Set_from if series is given as iterator without buffer protocol.
+        size_hint is an estimation of the ratio of unique elements. The default value of 0.0 means all elements in buf are expected to be unique
+        Giving a good estimate will avoid rehashing (if estimate is too low) and having too big table (if estimate is too high).
+    """
+    cdef Py_ssize_t n = len(buf)
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Int32Set(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.add(buf[i])
+    return res
+    
+
+cpdef void isin_int32(int32_t[:] query, Int32Set db, uint8_t[:] result) except *:
+    """
+        given query, db writes for every element of query True/False into result depending on whether query-element is in db (=True) or not (=False). 
+        result should have the same length as query.
+    """
+    cdef size_t i
+    cdef size_t n=len(query)
+    if n!=len(result):
+        raise ValueError("Different sizes for query({n}) and result({m})".format(n=n, m=len(result)))
+    for i in range(n):
+        result[i]=db is not None and db.contains(query[i])
+
+cpdef bint all_int32(int32_t[:] query, Int32Set db) except *:
+    """
+        True if all elements of query are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    if db is None:
+        return n==0
+    for i in range(n):
+        if not db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint all_int32_from_iter(object query, Int32Set db) except *:
+    """
+        True if all elements of query (as iterator) are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef int32_t el
+    for el in query:
+        if db is None or not db.contains(el):
+            return False
+    return True
+
+cpdef bint none_int32(int32_t[:] query, Int32Set db) except *:
+    """
+        True if none of elements in query is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    for i in range(n):
+        if db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint none_int32_from_iter(object query, Int32Set db) except *:
+    """
+        True if none of elements in query (as iterator) is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef int32_t el
+    for el in query:
+        if db.contains(el):
+            return False
+    return True
+
+cpdef bint any_int32(int32_t[:] query, Int32Set db) except *:
+    """
+        True if one of elements in query is in db, False otherwise.
+    """
+    return not none_int32(query, db)
+
+cpdef bint any_int32_from_iter(object query, Int32Set db) except *:
+    """
+        True if one of elements in query (as iterator) is in db, False otherwise.
+    """
+    return not none_int32_from_iter(query, db)
+
+cpdef size_t count_if_int32(int32_t[:] query, Int32Set db) except *:
+    """
+        returns the number of (non-unique) elements in query, which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef size_t i
+    cdef size_t n=len(query)
+    cdef size_t res=0
+    for i in range(n):
+        if db.contains(query[i]):
+            res+=1
+    return res
+
+cpdef size_t count_if_int32_from_iter(object query, Int32Set db) except *:
+    """
+        returns the number of (non-unique) elements in query (as iter), which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef int32_t el
+    cdef size_t res=0
+    for el in query:
+        if db.contains(el):
+            res+=1
+    return res
+
+cpdef bint aredisjoint_int32(Int32Set a, Int32Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Int32SetIterator it
+    cdef Int32Set s
+    cdef int32_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            return False
+    return True
+
+cpdef Int32Set intersect_int32(Int32Set a, Int32Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Int32Set result = Int32Set()
+    cdef Int32SetIterator it
+    cdef Int32Set s
+    cdef int32_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            result.add(el)
+    return result
+
+cpdef bint issubset_int32(Int32Set s, Int32Set sub) except *:
+    if s is None or sub is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    if s.size() < sub.size():
+        return False
+
+    cdef Int32SetIterator it=sub.get_iter()
+    cdef int32_t el
+    while it.has_next():
+        el = it.next()
+        if not s.contains(el):
+            return False
+    return True
+
+cpdef Int32Set copy_int32(Int32Set s):
+    if s is None:
+        return None
+    cdef Int32Set result = Int32Set(number_of_elements_hint=s.size())
+    cdef Int32SetIterator it=s.get_iter()
+    cdef int32_t el
+    while it.has_next():
+        el = it.next()
+        result.add(el)
+    return result
+
+cpdef void update_int32(Int32Set s, Int32Set other) except *:
+    if s is None or other is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Int32SetIterator it=other.get_iter()
+    cdef int32_t el
+    while it.has_next():
+        el = it.next()
+        s.add(el)
+
+cpdef void swap_int32(Int32Set a, Int32Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_int32set_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+cpdef Int32Set difference_int32(Int32Set a, Int32Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef int32_t el
+    cdef Int32Set result = Int32Set()
+    cdef Int32SetIterator it = a.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not b.contains(el):
+            result.add(el)
+    return result
+
+
+cpdef Int32Set symmetric_difference_int32(Int32Set a, Int32Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef int32_t el
+    cdef Int32Set result = Int32Set()
+    cdef Int32SetIterator it = a.get_iter()
+    while it.has_next():
+          el = it.next()
+          if not b.contains(el):
+                result.add(el)
+    it = b.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not a.contains(el):
+            result.add(el)
+    return result
+
+
+#### special for PyObject:
+
+
+cdef void _dealloc_float32(kh_float32set_t *table) nogil:
+    if table is not NULL:
+        kh_destroy_float32set(table)
+
+cdef bint _contains_float32(kh_float32set_t *table, float32_t key) nogil:
+    cdef khint_t k
+    k = kh_get_float32set(table, key)
+    return k != table.n_buckets
+
+cdef void _add_float32(kh_float32set_t *table, float32_t key) nogil:
+    cdef:
+        khint_t k
+        int ret = 0
+
+    k = kh_put_float32set(table, key, &ret)
+    table.keys[k] = key
+
+cdef void _discard_float32(kh_float32set_t *table, float32_t key) nogil:
+    cdef khint_t k
+    k = kh_get_float32set(table, key)
+    if k != table.n_buckets:
+        kh_del_float32set(table, k)
+
+
+### Iterator:
+cdef class Float32SetIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_float32set(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+      
+    # doesn't work if there was change between last has_next() and next()  
+    cdef float32_t next(self) except *:
+        cdef float32_t result = self.parent.table.keys[self.it]
+        self.it+=1#ensure at least one move!
+        return result
+
+
+    def __cinit__(self, Float32Set parent):
+        self.parent = parent
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        if self.has_next():
+            return self.next()
+        else:
+            raise StopIteration
+
+#### the same for all:
+
+cdef class Float32Set:
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        iterable - initial elements in the set
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_float32set()
+        if number_of_elements_hint is not None:    
+            kh_resize_float32set(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef float32_t el
+        if iterable is not None:
+            for el in iterable:
+                self.add(el)
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+        
+
+    def __dealloc__(self):
+        _dealloc_float32(self.table)
+        self.table = NULL
+
+    def __contains__(self, float32_t key):
+        return self.contains(key)
+
+
+    cdef bint contains(self, float32_t key) except *:
+        return _contains_float32(self.table, key)
+
+
+    cpdef void add(self, float32_t key) except *:
+        _add_float32(self.table, key)
+
+    
+    cpdef void discard(self, float32_t key) except *:
+        _discard_float32(self.table, key)
+
+
+    cdef Float32SetIterator get_iter(self):
+        return Float32SetIterator(self)
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def get_state_info(self):
+        """
+        returns information about state of the set
+
+        >>> from cykhash import Float32Set
+        >>> info = Float32Set([1]).get_state_info()
+        >>> info["n_buckets"]
+        4
+        >>> info["n_occupied"]
+        1
+
+        """
+        return {"n_buckets" : self.table.n_buckets, 
+                "n_occupied" : self.table.n_occupied, 
+                "upper_bound" : self.table.upper_bound}
+
+    ### drop-in for set:
+    def isdisjoint(self, other):
+        if isinstance(other, Float32Set):
+            return aredisjoint_float32(self, other)
+        cdef float32_t el
+        for el in other:
+            if self.contains(el):
+                return False
+        return True
+
+    def issuperset(self, other):
+        if isinstance(other, Float32Set):
+            return issubset_float32(self, other)
+        cdef float32_t el
+        for el in other:
+            if not self.contains(el):
+                return False
+        return True
+
+    def issubset(self, other):
+        if isinstance(other, Float32Set):
+            return issubset_float32(other, self)
+        cdef float32_t el
+        cdef Float32Set mem=Float32Set()
+        for el in other:
+            if self.contains(el):
+                mem.add(el)
+        return mem.size()==self.size()
+
+    def __repr__(self):
+        return "{"+','.join(map(str, self))+"}"
+
+    def __le__(self, Float32Set other):
+        return issubset_float32(other, self)
+
+    def __lt__(self, Float32Set other):
+        return issubset_float32(other, self) and self.size()<other.size()
+
+    def __ge__(self, Float32Set other):
+        return issubset_float32(self,  other)
+
+    def __gt__(self, Float32Set other):
+        return issubset_float32(self, other) and self.size()>other.size()
+
+    def __eq__(self, Float32Set other):
+        return issubset_float32(self, other) and self.size()==other.size()
+
+    def __or__(self, Float32Set other):
+        cdef Float32Set res = copy_float32(self)
+        update_float32(res, other)
+        return res
+
+    def __ior__(self, Float32Set other):
+        update_float32(self, other)
+        return self
+
+    def __and__(self, Float32Set other):
+        return intersect_float32(self, other)
+
+    def __iand__(self, Float32Set other):
+        cdef Float32Set res = intersect_float32(self, other)
+        swap_float32(self, res)
+        return self
+
+    def __sub__(self, Float32Set other):
+        return difference_float32(self, other)
+
+    def __isub__(self, Float32Set other):
+        cdef Float32Set res = difference_float32(self, other)
+        swap_float32(self, res)
+        return self
+
+    def __xor__(self, Float32Set other):
+        return symmetric_difference_float32(self, other)
+
+    def __ixor__(self, Float32Set other):
+        cdef Float32Set res = symmetric_difference_float32(self, other)
+        swap_float32(self, res)
+        return self
+
+    def copy(self):
+        return copy_float32(self)
+
+    def union(self, *others):
+        cdef Float32Set res = copy_float32(self)
+        for o in others:
+            res.update(o)
+        return res
+
+    def update(self, other):
+        if isinstance(other, Float32Set):
+            update_float32(self, other)
+            return
+        cdef float32_t el
+        for el in other:
+            self.add(el)
+
+    def intersection(self, *others):
+        cdef Float32Set res = copy_float32(self)
+        for o in others:
+            res.intersection_update(o)
+        return res
+
+    def intersection_update(self, other):
+        cdef Float32Set res 
+        cdef float32_t el
+        if isinstance(other, Float32Set):
+            res = intersect_float32(self, other)
+        else:
+            res = Float32Set()
+            for el in other:
+                if self.contains(el):
+                    res.add(el)
+        swap_float32(self, res)
+
+    def difference_update(self, other):
+        cdef Float32Set res 
+        cdef float32_t el
+        if isinstance(other, Float32Set):
+            res = difference_float32(self, other)
+            swap_float32(self, res)
+        else:
+            for el in other:
+                self.discard(el)
+
+    def difference(self, *others):
+        cdef Float32Set res = copy_float32(self)
+        for o in others:
+            res.difference_update(o)
+        return res
+
+    def symmetric_difference_update(self, other):
+        cdef Float32Set res 
+        cdef float32_t el
+        if isinstance(other, Float32Set):
+            res = symmetric_difference_float32(self, other)
+        else:
+            res = self.copy()
+            for el in other:
+                if self.contains(el):
+                    res.discard(el)
+                else:
+                    res.add(el)
+        swap_float32(self, res)
+
+    def symmetric_difference(self, *others):
+        cdef Float32Set res = copy_float32(self)
+        for o in others:
+            res.symmetric_difference_update(o)
+        return res
+
+    def clear(self):
+        cdef Float32Set res = Float32Set()
+        swap_float32(self, res)
+
+    def remove(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def pop(self):
+        if self.size()== 0:
+            raise KeyError("pop from empty set")
+        cdef Float32SetIterator it = self.get_iter()
+        cdef float32_t el = it.next()
+        self.discard(el)
+        return el
+        
+
+
+
+### Utils:
+
+def Float32Set_from(it):
+    """
+        creates Float32Set from an iterator. 
+        Use Float32Set_from_buffer for a faster version if iterator is buffer of correct type
+    """
+    res=Float32Set()
+    for i in it:
+        res.add(i)
+    return res
+
+cpdef Float32Set Float32Set_from_buffer(float32_t[:] buf, double size_hint=0.0):
+    """
+        creates Float32Set from the given buffer buf. 
+        Use slower Float32Set_from if series is given as iterator without buffer protocol.
+        size_hint is an estimation of the ratio of unique elements. The default value of 0.0 means all elements in buf are expected to be unique
+        Giving a good estimate will avoid rehashing (if estimate is too low) and having too big table (if estimate is too high).
+    """
+    cdef Py_ssize_t n = len(buf)
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=Float32Set(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.add(buf[i])
+    return res
+    
+
+cpdef void isin_float32(float32_t[:] query, Float32Set db, uint8_t[:] result) except *:
+    """
+        given query, db writes for every element of query True/False into result depending on whether query-element is in db (=True) or not (=False). 
+        result should have the same length as query.
+    """
+    cdef size_t i
+    cdef size_t n=len(query)
+    if n!=len(result):
+        raise ValueError("Different sizes for query({n}) and result({m})".format(n=n, m=len(result)))
+    for i in range(n):
+        result[i]=db is not None and db.contains(query[i])
+
+cpdef bint all_float32(float32_t[:] query, Float32Set db) except *:
+    """
+        True if all elements of query are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    if db is None:
+        return n==0
+    for i in range(n):
+        if not db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint all_float32_from_iter(object query, Float32Set db) except *:
+    """
+        True if all elements of query (as iterator) are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef float32_t el
+    for el in query:
+        if db is None or not db.contains(el):
+            return False
+    return True
+
+cpdef bint none_float32(float32_t[:] query, Float32Set db) except *:
+    """
+        True if none of elements in query is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    for i in range(n):
+        if db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint none_float32_from_iter(object query, Float32Set db) except *:
+    """
+        True if none of elements in query (as iterator) is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef float32_t el
+    for el in query:
+        if db.contains(el):
+            return False
+    return True
+
+cpdef bint any_float32(float32_t[:] query, Float32Set db) except *:
+    """
+        True if one of elements in query is in db, False otherwise.
+    """
+    return not none_float32(query, db)
+
+cpdef bint any_float32_from_iter(object query, Float32Set db) except *:
+    """
+        True if one of elements in query (as iterator) is in db, False otherwise.
+    """
+    return not none_float32_from_iter(query, db)
+
+cpdef size_t count_if_float32(float32_t[:] query, Float32Set db) except *:
+    """
+        returns the number of (non-unique) elements in query, which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef size_t i
+    cdef size_t n=len(query)
+    cdef size_t res=0
+    for i in range(n):
+        if db.contains(query[i]):
+            res+=1
+    return res
+
+cpdef size_t count_if_float32_from_iter(object query, Float32Set db) except *:
+    """
+        returns the number of (non-unique) elements in query (as iter), which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef float32_t el
+    cdef size_t res=0
+    for el in query:
+        if db.contains(el):
+            res+=1
+    return res
+
+cpdef bint aredisjoint_float32(Float32Set a, Float32Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Float32SetIterator it
+    cdef Float32Set s
+    cdef float32_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            return False
+    return True
+
+cpdef Float32Set intersect_float32(Float32Set a, Float32Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef Float32Set result = Float32Set()
+    cdef Float32SetIterator it
+    cdef Float32Set s
+    cdef float32_t el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            result.add(el)
+    return result
+
+cpdef bint issubset_float32(Float32Set s, Float32Set sub) except *:
+    if s is None or sub is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    if s.size() < sub.size():
+        return False
+
+    cdef Float32SetIterator it=sub.get_iter()
+    cdef float32_t el
+    while it.has_next():
+        el = it.next()
+        if not s.contains(el):
+            return False
+    return True
+
+cpdef Float32Set copy_float32(Float32Set s):
+    if s is None:
+        return None
+    cdef Float32Set result = Float32Set(number_of_elements_hint=s.size())
+    cdef Float32SetIterator it=s.get_iter()
+    cdef float32_t el
+    while it.has_next():
+        el = it.next()
+        result.add(el)
+    return result
+
+cpdef void update_float32(Float32Set s, Float32Set other) except *:
+    if s is None or other is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef Float32SetIterator it=other.get_iter()
+    cdef float32_t el
+    while it.has_next():
+        el = it.next()
+        s.add(el)
+
+cpdef void swap_float32(Float32Set a, Float32Set b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_float32set_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+cpdef Float32Set difference_float32(Float32Set a, Float32Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef float32_t el
+    cdef Float32Set result = Float32Set()
+    cdef Float32SetIterator it = a.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not b.contains(el):
+            result.add(el)
+    return result
+
+
+cpdef Float32Set symmetric_difference_float32(Float32Set a, Float32Set b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef float32_t el
+    cdef Float32Set result = Float32Set()
+    cdef Float32SetIterator it = a.get_iter()
+    while it.has_next():
+          el = it.next()
+          if not b.contains(el):
+                result.add(el)
+    it = b.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not a.contains(el):
+            result.add(el)
+    return result
+
+
+#### special for PyObject:
+
+
+cdef void _dealloc_pyobject(kh_pyobjectset_t *table) except *:
+    cdef khint_t i = 0
+    if table is not NULL:
+        for i in range(table.size):
+            if kh_exist_pyobjectset(table, i):
+                Py_DECREF(<object>table.keys[i])
+        kh_destroy_pyobjectset(table)
+
+cdef bint _contains_pyobject(kh_pyobjectset_t *table, object key) nogil:
+        cdef khint_t k
+        k = kh_get_pyobjectset(table, <pyobject_t>key)
+        return k != table.n_buckets
+
+cdef void _add_pyobject(kh_pyobjectset_t *table, object key) except *:
+        cdef:
+            khint_t k
+            int ret = 0
+            pyobject_t key_ptr = <pyobject_t> key
+        k = kh_put_pyobjectset(table, key_ptr, &ret)
+        if ret: 
+            #element was really added, so we need to increase reference
+            Py_INCREF(key)
+
+cdef void _discard_pyobject(kh_pyobjectset_t *table, object key) except *:
+    cdef khint_t k
+    cdef pyobject_t key_ptr = <pyobject_t> key
+    k = kh_get_pyobjectset(table, key_ptr)
+    if k != table.n_buckets:
+        Py_DECREF(<object>table.keys[k])
+        kh_del_pyobjectset(table, k)
+
+
+### Iterator:
+cdef class PyObjectSetIterator:
+
+    cdef void __move(self) except *:
+        while self.it<self.parent.table.n_buckets and not kh_exist_pyobjectset(self.parent.table, self.it):
+              self.it+=1       
+
+    cdef bint has_next(self) except *:
+        self.__move()
+        return self.it < self.parent.table.n_buckets
+        
+
+    # doesn't work if there was change between last has_next() and next() 
+    cdef object next(self):
+        cdef pyobject_t result = self.parent.table.keys[self.it]
+        self.it+=1#ensure at least one move!
+        return <object>result
+
+
+    def __cinit__(self, PyObjectSet parent):
+        self.parent = parent
+        #search the start:
+        self.it = 0
+        self.__move()
+
+    def __next__(self):
+        if self.has_next():
+            return self.next()
+        else:
+            raise StopIteration
+
+#### the same for all:
+
+cdef class PyObjectSet:
+
+    def __cinit__(self, iterable=None, *, number_of_elements_hint=None):
+        """
+        iterable - initial elements in the set
+        number_of_elements_hint - number of elements without the need of reallocation.
+        """
+        self.table = kh_init_pyobjectset()
+        if number_of_elements_hint is not None:    
+            kh_resize_pyobjectset(self.table, element_n_to_bucket_n(number_of_elements_hint))
+        cdef object el
+        if iterable is not None:
+            for el in iterable:
+                self.add(el)
+
+    def __len__(self):
+        return self.size()
+  
+    cdef khint_t size(self):
+        return self.table.size
+        
+
+    def __dealloc__(self):
+        _dealloc_pyobject(self.table)
+        self.table = NULL
+
+    def __contains__(self, object key):
+        return self.contains(key)
+
+
+    cdef bint contains(self, object key) except *:
+        return _contains_pyobject(self.table, key)
+
+
+    cpdef void add(self, object key) except *:
+        _add_pyobject(self.table, key)
+
+    
+    cpdef void discard(self, object key) except *:
+        _discard_pyobject(self.table, key)
+
+
+    cdef PyObjectSetIterator get_iter(self):
+        return PyObjectSetIterator(self)
+
+    def __iter__(self):
+        return self.get_iter()
+
+    def get_state_info(self):
+        """
+        returns information about state of the set
+
+        >>> from cykhash import PyObjectSet
+        >>> info = PyObjectSet([1]).get_state_info()
+        >>> info["n_buckets"]
+        4
+        >>> info["n_occupied"]
+        1
+
+        """
+        return {"n_buckets" : self.table.n_buckets, 
+                "n_occupied" : self.table.n_occupied, 
+                "upper_bound" : self.table.upper_bound}
+
+    ### drop-in for set:
+    def isdisjoint(self, other):
+        if isinstance(other, PyObjectSet):
+            return aredisjoint_pyobject(self, other)
+        cdef object el
+        for el in other:
+            if self.contains(el):
+                return False
+        return True
+
+    def issuperset(self, other):
+        if isinstance(other, PyObjectSet):
+            return issubset_pyobject(self, other)
+        cdef object el
+        for el in other:
+            if not self.contains(el):
+                return False
+        return True
+
+    def issubset(self, other):
+        if isinstance(other, PyObjectSet):
+            return issubset_pyobject(other, self)
+        cdef object el
+        cdef PyObjectSet mem=PyObjectSet()
+        for el in other:
+            if self.contains(el):
+                mem.add(el)
+        return mem.size()==self.size()
+
+    def __repr__(self):
+        return "{"+','.join(map(str, self))+"}"
+
+    def __le__(self, PyObjectSet other):
+        return issubset_pyobject(other, self)
+
+    def __lt__(self, PyObjectSet other):
+        return issubset_pyobject(other, self) and self.size()<other.size()
+
+    def __ge__(self, PyObjectSet other):
+        return issubset_pyobject(self,  other)
+
+    def __gt__(self, PyObjectSet other):
+        return issubset_pyobject(self, other) and self.size()>other.size()
+
+    def __eq__(self, PyObjectSet other):
+        return issubset_pyobject(self, other) and self.size()==other.size()
+
+    def __or__(self, PyObjectSet other):
+        cdef PyObjectSet res = copy_pyobject(self)
+        update_pyobject(res, other)
+        return res
+
+    def __ior__(self, PyObjectSet other):
+        update_pyobject(self, other)
+        return self
+
+    def __and__(self, PyObjectSet other):
+        return intersect_pyobject(self, other)
+
+    def __iand__(self, PyObjectSet other):
+        cdef PyObjectSet res = intersect_pyobject(self, other)
+        swap_pyobject(self, res)
+        return self
+
+    def __sub__(self, PyObjectSet other):
+        return difference_pyobject(self, other)
+
+    def __isub__(self, PyObjectSet other):
+        cdef PyObjectSet res = difference_pyobject(self, other)
+        swap_pyobject(self, res)
+        return self
+
+    def __xor__(self, PyObjectSet other):
+        return symmetric_difference_pyobject(self, other)
+
+    def __ixor__(self, PyObjectSet other):
+        cdef PyObjectSet res = symmetric_difference_pyobject(self, other)
+        swap_pyobject(self, res)
+        return self
+
+    def copy(self):
+        return copy_pyobject(self)
+
+    def union(self, *others):
+        cdef PyObjectSet res = copy_pyobject(self)
+        for o in others:
+            res.update(o)
+        return res
+
+    def update(self, other):
+        if isinstance(other, PyObjectSet):
+            update_pyobject(self, other)
+            return
+        cdef object el
+        for el in other:
+            self.add(el)
+
+    def intersection(self, *others):
+        cdef PyObjectSet res = copy_pyobject(self)
+        for o in others:
+            res.intersection_update(o)
+        return res
+
+    def intersection_update(self, other):
+        cdef PyObjectSet res 
+        cdef object el
+        if isinstance(other, PyObjectSet):
+            res = intersect_pyobject(self, other)
+        else:
+            res = PyObjectSet()
+            for el in other:
+                if self.contains(el):
+                    res.add(el)
+        swap_pyobject(self, res)
+
+    def difference_update(self, other):
+        cdef PyObjectSet res 
+        cdef object el
+        if isinstance(other, PyObjectSet):
+            res = difference_pyobject(self, other)
+            swap_pyobject(self, res)
+        else:
+            for el in other:
+                self.discard(el)
+
+    def difference(self, *others):
+        cdef PyObjectSet res = copy_pyobject(self)
+        for o in others:
+            res.difference_update(o)
+        return res
+
+    def symmetric_difference_update(self, other):
+        cdef PyObjectSet res 
+        cdef object el
+        if isinstance(other, PyObjectSet):
+            res = symmetric_difference_pyobject(self, other)
+        else:
+            res = self.copy()
+            for el in other:
+                if self.contains(el):
+                    res.discard(el)
+                else:
+                    res.add(el)
+        swap_pyobject(self, res)
+
+    def symmetric_difference(self, *others):
+        cdef PyObjectSet res = copy_pyobject(self)
+        for o in others:
+            res.symmetric_difference_update(o)
+        return res
+
+    def clear(self):
+        cdef PyObjectSet res = PyObjectSet()
+        swap_pyobject(self, res)
+
+    def remove(self, key):
+        cdef size_t old=self.size()
+        self.discard(key)
+        if old==self.size():
+            raise KeyError(key)
+
+    def pop(self):
+        if self.size()== 0:
+            raise KeyError("pop from empty set")
+        cdef PyObjectSetIterator it = self.get_iter()
+        cdef object el = it.next()
+        self.discard(el)
+        return el
+        
+
+
+
+### Utils:
+
+def PyObjectSet_from(it):
+    """
+        creates PyObjectSet from an iterator. 
+        Use PyObjectSet_from_buffer for a faster version if iterator is buffer of correct type
+    """
+    res=PyObjectSet()
+    for i in it:
+        res.add(i)
+    return res
+
+cpdef PyObjectSet PyObjectSet_from_buffer(object[:] buf, double size_hint=0.0):
+    """
+        creates PyObjectSet from the given buffer buf. 
+        Use slower PyObjectSet_from if series is given as iterator without buffer protocol.
+        size_hint is an estimation of the ratio of unique elements. The default value of 0.0 means all elements in buf are expected to be unique
+        Giving a good estimate will avoid rehashing (if estimate is too low) and having too big table (if estimate is too high).
+    """
+    cdef Py_ssize_t n = len(buf)
+    cdef Py_ssize_t at_least_needed = element_n_from_size_hint(<khint_t>n, size_hint)
+    res=PyObjectSet(number_of_elements_hint=at_least_needed)
+    cdef Py_ssize_t i
+    for i in range(n):
+        res.add(buf[i])
+    return res
+    
+
+cpdef void isin_pyobject(object[:] query, PyObjectSet db, uint8_t[:] result) except *:
+    """
+        given query, db writes for every element of query True/False into result depending on whether query-element is in db (=True) or not (=False). 
+        result should have the same length as query.
+    """
+    cdef size_t i
+    cdef size_t n=len(query)
+    if n!=len(result):
+        raise ValueError("Different sizes for query({n}) and result({m})".format(n=n, m=len(result)))
+    for i in range(n):
+        result[i]=db is not None and db.contains(query[i])
+
+cpdef bint all_pyobject(object[:] query, PyObjectSet db) except *:
+    """
+        True if all elements of query are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    if db is None:
+        return n==0
+    for i in range(n):
+        if not db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint all_pyobject_from_iter(object query, PyObjectSet db) except *:
+    """
+        True if all elements of query (as iterator) are in db, False otherwise.
+    """
+    if query is None:
+        return True
+    cdef object el
+    for el in query:
+        if db is None or not db.contains(el):
+            return False
+    return True
+
+cpdef bint none_pyobject(object[:] query, PyObjectSet db) except *:
+    """
+        True if none of elements in query is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef size_t i
+    cdef size_t n=len(query)
+    for i in range(n):
+        if db.contains(query[i]):
+            return False
+    return True
+
+cpdef bint none_pyobject_from_iter(object query, PyObjectSet db) except *:
+    """
+        True if none of elements in query (as iterator) is in db, False otherwise.
+    """
+    if query is None or db is None:
+        return True
+    cdef object el
+    for el in query:
+        if db.contains(el):
+            return False
+    return True
+
+cpdef bint any_pyobject(object[:] query, PyObjectSet db) except *:
+    """
+        True if one of elements in query is in db, False otherwise.
+    """
+    return not none_pyobject(query, db)
+
+cpdef bint any_pyobject_from_iter(object query, PyObjectSet db) except *:
+    """
+        True if one of elements in query (as iterator) is in db, False otherwise.
+    """
+    return not none_pyobject_from_iter(query, db)
+
+cpdef size_t count_if_pyobject(object[:] query, PyObjectSet db) except *:
+    """
+        returns the number of (non-unique) elements in query, which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef size_t i
+    cdef size_t n=len(query)
+    cdef size_t res=0
+    for i in range(n):
+        if db.contains(query[i]):
+            res+=1
+    return res
+
+cpdef size_t count_if_pyobject_from_iter(object query, PyObjectSet db) except *:
+    """
+        returns the number of (non-unique) elements in query (as iter), which are also in db
+    """
+    if query is None or db is None:
+        return 0
+    cdef object el
+    cdef size_t res=0
+    for el in query:
+        if db.contains(el):
+            res+=1
+    return res
+
+cpdef bint aredisjoint_pyobject(PyObjectSet a, PyObjectSet b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef PyObjectSetIterator it
+    cdef PyObjectSet s
+    cdef object el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            return False
+    return True
+
+cpdef PyObjectSet intersect_pyobject(PyObjectSet a, PyObjectSet b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef PyObjectSet result = PyObjectSet()
+    cdef PyObjectSetIterator it
+    cdef PyObjectSet s
+    cdef object el
+    if a.size()<b.size():
+        it=a.get_iter()
+        s =b
+    else:
+        it=b.get_iter()
+        s =a
+    while it.has_next():
+        el = it.next()
+        if s.contains(el):
+            result.add(el)
+    return result
+
+cpdef bint issubset_pyobject(PyObjectSet s, PyObjectSet sub) except *:
+    if s is None or sub is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    if s.size() < sub.size():
+        return False
+
+    cdef PyObjectSetIterator it=sub.get_iter()
+    cdef object el
+    while it.has_next():
+        el = it.next()
+        if not s.contains(el):
+            return False
+    return True
+
+cpdef PyObjectSet copy_pyobject(PyObjectSet s):
+    if s is None:
+        return None
+    cdef PyObjectSet result = PyObjectSet(number_of_elements_hint=s.size())
+    cdef PyObjectSetIterator it=s.get_iter()
+    cdef object el
+    while it.has_next():
+        el = it.next()
+        result.add(el)
+    return result
+
+cpdef void update_pyobject(PyObjectSet s, PyObjectSet other) except *:
+    if s is None or other is None:
+        raise TypeError("'NoneType' object is not iterable")
+    cdef PyObjectSetIterator it=other.get_iter()
+    cdef object el
+    while it.has_next():
+        el = it.next()
+        s.add(el)
+
+cpdef void swap_pyobject(PyObjectSet a, PyObjectSet b) except *:
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef kh_pyobjectset_t *tmp=a.table
+    a.table=b.table
+    b.table=tmp
+
+cpdef PyObjectSet difference_pyobject(PyObjectSet a, PyObjectSet b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef object el
+    cdef PyObjectSet result = PyObjectSet()
+    cdef PyObjectSetIterator it = a.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not b.contains(el):
+            result.add(el)
+    return result
+
+
+cpdef PyObjectSet symmetric_difference_pyobject(PyObjectSet a, PyObjectSet b):
+    if a is None or b is None:
+        raise TypeError("'NoneType' object is not iterable")
+
+    cdef object el
+    cdef PyObjectSet result = PyObjectSet()
+    cdef PyObjectSetIterator it = a.get_iter()
+    while it.has_next():
+          el = it.next()
+          if not b.contains(el):
+                result.add(el)
+    it = b.get_iter()
+    while it.has_next():
+        el = it.next()
+        if not a.contains(el):
+            result.add(el)
+    return result
+

--- a/pyrosm/vendor/cykhash/sets/set_init.pxi
+++ b/pyrosm/vendor/cykhash/sets/set_init.pxi
@@ -1,0 +1,19 @@
+
+"""
+Template for sets
+
+WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
+"""
+
+
+cdef extern from *:
+    """
+    // preprocessor creates needed struct-type and all function definitions   
+    KHASH_INIT(int64set,         int64_t, char, 0,    cykh_int64_hash_func,    cykh_int64_hash_equal)
+    KHASH_INIT(int32set,         int32_t, char, 0,    cykh_int32_hash_func,    cykh_int32_hash_equal)
+    KHASH_INIT(float64set,   khfloat64_t, char, 0,  cykh_float64_hash_func,  cykh_float64_hash_equal)
+    KHASH_INIT(float32set,   khfloat32_t, char, 0,  cykh_float32_hash_func,  cykh_float32_hash_equal)
+    KHASH_INIT(pyobjectset, khpyobject_t, char, 0, cykh_pyobject_hash_func, cykh_pyobject_hash_equal) 
+    """
+    pass
+

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ requirements = [
     "setuptools>=18.0",
     "geopandas>=0.12.0",
     "shapely>=2.1",
-    "cykhash",
     "protobuf>=6.33.5",
     "certifi",
 ]
@@ -47,7 +46,12 @@ if _linetrace:
     _directives["linetrace"] = True
     _directives["profile"] = True
 _ext_modules = cythonize(
-    str(Path("pyrosm") / "*.pyx"),
+    [
+        str(Path("pyrosm") / "*.pyx"),
+        # Vendored cykhash (see pyrosm/vendor/README.md); only the two modules
+        # pyrosm reads OSM ids with are built.
+        str(Path("pyrosm") / "vendor" / "cykhash" / "*.pyx"),
+    ],
     annotate=False,
     compiler_directives=_directives,
     force=_linetrace,
@@ -74,9 +78,10 @@ setup(
     include_package_data=True,
     # The Cython-generated C sources sit next to the .pyx files and are picked up
     # by include_package_data, which shipped 14 MB of them inside every binary
-    # wheel. They are only needed to build, so keep them out of the installation
-    # (the sdist keeps them, so a source build needs no Cython).
-    exclude_package_data={"pyrosm": ["*.c"]},
+    # wheel. They are build artifacts, so keep them out of the installation; the
+    # sdist still carries them. The empty key applies to every package, the
+    # vendored ones included.
+    exclude_package_data={"": ["*.c"]},
     zip_safe=False,
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
`cykhash` publishes no wheels — every release on PyPI is an sdist — and pyrosm needs it at runtime, not only to build. So `pip install pyrosm` compiled it from source on every platform, including the ones where pyrosm ships a binary wheel: the user needed a C compiler, the Python headers and Cython. After #374 (slim wheels, Linux ARM) this was what still stood between a user and a toolchain-free install. conda installs were unaffected, since conda-forge builds cykhash.

cykhash 2.0.1 (MIT) is now vendored under `pyrosm/vendor/cykhash/`, and the dependency is gone from `install_requires` and `[build-system].requires`.

- Only the two modules pyrosm uses are vendored and built: `khashsets` (`Int64Set`, `Int64Set_from_buffer`, `isin_int64`, `any_int64_from_iter`) and `khashmaps` (`Int64toInt64Map`, `Int64toInt64Map_from_buffers`, `Int64toInt64Map_to`). `unique` and `utils` are not.
- Every `.pyx`, `.pxd` and `.pxi` is byte-for-byte upstream. The one exception is the package initializer, which is a docstring here because pyrosm imports the extension modules directly. [pyrosm/vendor/README.md](https://github.com/pyrosm/pyrosm/blob/vendor-cykhash/pyrosm/vendor/README.md) records the upstream URL, the version, the file list and the update procedure, and the upstream `LICENSE` sits next to the code.
- The modules are namespaced as `pyrosm.vendor.cykhash.*`, so they cannot collide with a cykhash the user has installed for something else. Verified: both import in one process as distinct classes.
- `khash.pxi` embeds klib's `khash.h` verbatim, so there is no external C header and no include-path configuration.

## Effect

| | before | after |
| --- | --- | --- |
| wheel (macOS arm64, cp312) | 3.08 MB | 3.54 MB |
| unpacked | 5.43 MB | 7.37 MB |
| compiler needed to `pip install` | yes | no |

The read path is unchanged: row counts, row order, `id`/`highway` hashes, geometry WKB hashes and the node `lon`/`lat` columns are identical before and after across `get_network()`, `get_network(nodes=True)`, `get_buildings()` and the driving/cycling networks on both bundled extracts. End-to-end read times are unchanged, and the vendored module matches an upstream build from the same toolchain (0.080 s vs 0.079 s on a 3M-id map build + 1M-query lookup).

One consequence worth recording: conda-forge's cykhash build is roughly 1.2x faster than any build from this toolchain on that microbenchmark, so a conda user moves from conda-forge's binary to the vendored one. It does not show up in end-to-end read times, where the id map is a small share of the work.

Fixes the remaining install barrier discussed in #374.

AI assistants: Claude Opus 5 (claude-opus-5[1m], xhigh reasoning) via Claude Code 2.1.220; OpenAI gpt-5.6-sol (xhigh reasoning) via Codex CLI 0.146.0.
