### PR TITLE
fix: prevent IndexError in NodeLocations.gather with empty coordinate store

### DIFF
--- a/pyrosm/node_lookup.pyx
+++ b/pyrosm/node_lookup.pyx
@@ -61,8 +61,12 @@ cdef class NodeLocations:
         idx = np.empty(len(keys), dtype=np.int64)
         Int64toInt64Map_to(self._id2idx, keys, idx, stop_at_unknown=False, default_value=-1)
         safe = np.where(idx >= 0, idx, 0)
-        lon = np.asarray(self._lon)[safe]
-        lat = np.asarray(self._lat)[safe]
+        if len(self._lon) > 0:
+            lon = np.asarray(self._lon)[safe]
+            lat = np.asarray(self._lat)[safe]
+        else:
+            lon = np.zeros(len(keys), dtype=np.float64)
+            lat = np.zeros(len(keys), dtype=np.float64)
         return idx, lon, lat
 
     cdef dict _base_record(self, long long idx):


### PR DESCRIPTION
## Summary

Fixes `IndexError: index 0 is out of bounds for axis 0 with size 0` in `NodeLocations.gather()` when the coordinate store is empty.

When a PBF file yields no nodes, the coordinate arrays (`_lon`, `_lat`) are empty. `gather()` replaces unknown node indices (`-1`) with `0` via `np.where`, then indexes the empty arrays at position `0` — which is out of bounds.

## Root Cause

```python
safe = np.where(idx >= 0, idx, 0)  # unknown nodes → index 0
lon = np.asarray(self._lon)[safe]   # IndexError when _lon is empty
```

The `safe` array always contains at least one `0` (for unknown nodes), but when the store is empty, `_lon` and `_lat` have size 0.

## Fix

Guard the indexing: when the store is empty, return zero-filled placeholder arrays. Callers already mask via `idx >= 0`, so placeholder values are never consumed.

```python
if len(self._lon) > 0:
    lon = np.asarray(self._lon)[safe]
    lat = np.asarray(self._lat)[safe]
else:
    lon = np.zeros(len(keys), dtype=np.float64)
    lat = np.zeros(len(keys), dtype=np.float64)
```

## Reproduction

```python
import numpy as np, pandas as pd
from pyrosm.node_lookup import NodeLocations

empty = pd.DataFrame({
    "id": np.array([], dtype=np.int64),
    "lon": np.array([], dtype=float),
    "lat": np.array([], dtype=float),
})
NodeLocations(empty).gather(np.array([123], dtype=np.int64))
# Before: IndexError
# After: (array([-1]), array([0.]), array([0.]))
```

Closes #378
