### PR TITLE
fix: use groupby.tail(1) instead of .last() in get_latest_version

### DIFF
--- a/pyrosm/data_filter.pyx
+++ b/pyrosm/data_filter.pyx
@@ -340,7 +340,10 @@ cdef filter_node_indices(node_arrays, osm_keys, data_filter, filter_type, bint k
 cpdef get_latest_version(df):
     # The order of versions is always the same
     # (newest version is the last)
-    return df.groupby("id").last().reset_index()
+    # Use tail(1) instead of .last() to select whole rows — .last() picks
+    # the last non-null value per column independently, which can resurrect
+    # deleted tags from older versions when a newer version sets them to None.
+    return df.groupby("id").tail(1).reset_index(drop=True)
 
 
 cdef inline bint _is_empty_tag_value(object v):


### PR DESCRIPTION
## Summary

Fixes hybrid rows in history reads where `groupby("id").last()` mixes columns across versions.

### Problem

`get_latest_version()` in `data_filter.pyx` uses `df.groupby("id").last()` to select the latest version of each element. But `GroupBy.last()` picks the **last non-null value per column independently** — so a newer version that removes a tag (sets it to `None`) inherits the old value from a previous version:

```python
df = pd.DataFrame({"id": [1, 1], "version": [1, 2], "name": ["old", None]})
df.groupby("id").last().reset_index()
# version 2, but name is "old" — resurrected from version 1
```

### Fix

Replace `.last()` with `.tail(1)` which selects **whole rows**:

```python
df.groupby("id").tail(1).reset_index(drop=True)
# version 2, name is None — the actual latest state
```

This prevents deleted tags from being silently resurrected when reading `.osh.pbf` files at a specific timestamp.

Closes #379
